### PR TITLE
Instant bot responses via a self-hosted command runner, plus /expedite

### DIFF
--- a/.github/scripts/assert-cmd-runner-safe.py
+++ b/.github/scripts/assert-cmd-runner-safe.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Fail if the self-hosted command runner's label could execute untrusted code.
+
+GitHub warns against self-hosted runners on public repos because a fork's PR can
+run arbitrary code on your hardware. That warning does NOT apply to the
+certification command workflow, for one specific reason: it pins
+`ref: default_branch` and never checks out a PR head.
+
+That is a property of the current file, not a guarantee. This test makes it a
+guarantee: any workflow that reaches the command runner must never check out
+untrusted code, and must never be reachable from a `pull_request` trigger.
+
+Run with no arguments from the repo root.
+"""
+import pathlib
+import re
+import sys
+
+import yaml
+
+LABEL = "atlas-cmd"
+# Triggers whose payload a fork controls. `pull_request_target` and
+# `issue_comment` run from the DEFAULT branch, so they are safe on their own --
+# what makes them unsafe is checking out the head ref, which is checked below.
+FORK_CONTROLLED = {"pull_request"}
+UNSAFE_REFS = (
+    "github.event.pull_request.head",
+    "github.event.pull_request.merge_commit_sha",
+    "github.head_ref",
+    "github.event.merge_group.head_ref",
+)
+
+
+def uses_cmd_runner(job):
+    ro = job.get("runs-on")
+    blob = str(ro)
+    # Matches a bare label, a list, or the `vars.CMD_RUNNER_LABEL` indirection.
+    return LABEL in blob or "CMD_RUNNER_LABEL" in blob
+
+
+def main():
+    problems = []
+    for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+        try:
+            wf = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # a malformed workflow is a different test's job
+            print(f"  skip {path.name}: {exc}")
+            continue
+        if not isinstance(wf, dict):
+            continue
+        triggers = set((wf.get(True) or wf.get("on") or {}).keys())
+        for name, job in (wf.get("jobs") or {}).items():
+            if not isinstance(job, dict) or not uses_cmd_runner(job):
+                continue
+            bad = triggers & FORK_CONTROLLED
+            if bad:
+                problems.append(
+                    f"{path.name}:{name} runs on {LABEL} and is triggered by "
+                    f"{sorted(bad)} — a fork could run its own code on our hardware."
+                )
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                if "checkout" not in str(step.get("uses", "")):
+                    continue
+                ref = str((step.get("with") or {}).get("ref", ""))
+                if not ref:
+                    problems.append(
+                        f"{path.name}:{name} checks out with no explicit ref on "
+                        f"{LABEL}; the default is the event's head."
+                    )
+                elif any(u in ref for u in UNSAFE_REFS):
+                    problems.append(
+                        f"{path.name}:{name} checks out '{ref}' on {LABEL} — that is "
+                        f"untrusted code on our own machine."
+                    )
+    if problems:
+        print("the self-hosted command runner is reachable from untrusted code:")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"no workflow on '{LABEL}' checks out untrusted code.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/assert-command-authority.py
+++ b/.github/scripts/assert-command-authority.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Only the commands that are meant to change a verdict may change one.
+
+`/help` and `/review` post text. They must never mint a Stamp, a Seal or an
+Expedite, never re-run CI, and never PATCH anything -- because their permission
+checks are correspondingly weak: `/review` is open to anyone who can comment.
+If a future edit gave `/review` the ability to create a check run, an outside
+contributor could mint their own seal by asking a question.
+
+That is true of the file today by inspection. This makes it true by rule.
+
+Also pins the workflow to least privilege: a top-level `permissions:` wider than
+`contents: read` would hand every step of it more authority than any step needs.
+"""
+import pathlib
+import sys
+
+import yaml
+
+WORKFLOW = pathlib.Path(".github/workflows/certification-commands.yml")
+# Verbs that legitimately change state, and the marks each may mint.
+MAY_MINT = {"/stamp and /seal", "/expedite"}
+FORBIDDEN = (
+    ("check-runs", "mint a check run"),
+    ("/rerun", "re-run CI"),
+    ("-X PATCH", "PATCH a resource"),
+    ("-X PUT", "PUT a resource"),
+    ("-X DELETE", "DELETE a resource"),
+)
+ALLOWED_PERMISSIONS = {"contents": "read"}
+
+
+def main():
+    wf = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    problems = []
+
+    perms = wf.get("permissions")
+    if perms != ALLOWED_PERMISSIONS:
+        problems.append(
+            f"top-level permissions are {perms!r}, expected {ALLOWED_PERMISSIONS!r} — "
+            f"every step inherits these, and none of them needs more."
+        )
+
+    for job_name, job in (wf.get("jobs") or {}).items():
+        for step in job.get("steps") or []:
+            name = step.get("name") or ""
+            run = step.get("run") or ""
+            if not run or not name.startswith("/"):
+                continue
+            if name in MAY_MINT:
+                continue
+            for needle, what in FORBIDDEN:
+                if needle in run:
+                    problems.append(
+                        f"{job_name}:{name} can {what} ('{needle}'), but only "
+                        f"{sorted(MAY_MINT)} may change a verdict. {name}'s permission "
+                        f"check is weaker on purpose because it only posts text."
+                    )
+
+    if problems:
+        print("a command has more authority than its permission check justifies:")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print("only the state-changing commands can change state; permissions are minimal.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/assert-selftest-wired.py
+++ b/.github/scripts/assert-selftest-wired.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""The certification self-test must actually run, in a job that must pass.
+
+Eighty-one checks hang on one line in one workflow. Delete that line and every
+one of them stops running -- silently, with the job it lived in still green.
+
+This cannot live inside the self-test itself: if the step is removed the suite
+never executes, so a check inside it can never fire. It therefore runs from a
+DIFFERENT required job, so removing the self-test breaks something else that
+must pass.
+
+Asserts two things:
+  1. some job invokes certification-selftest.sh, and
+  2. that job reports under a name branch protection requires -- a suite in a
+     job nobody has to pass is a suite that can be ignored.
+"""
+import pathlib
+import sys
+
+import yaml
+
+SUITE = "certification-selftest.sh"
+# Branch protection on main requires this context. Kept as a literal because the
+# assertion has to work without network access; if protection changes, this line
+# is the one to update, and the failure message says so.
+REQUIRED_CONTEXTS = {"cargo deny"}
+
+
+def main():
+    hosts = []
+    for path in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+        try:
+            wf = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(wf, dict):
+            continue
+        for job_key, job in (wf.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if isinstance(step, dict) and SUITE in str(step.get("run", "")):
+                    hosts.append((path.name, job_key, job.get("name") or job_key))
+
+    if not hosts:
+        print(f"nothing runs {SUITE}.")
+        print("  The certification self-test is 81 checks and 50 negative controls.")
+        print("  If this is deliberate, delete the suite too -- a suite that does not")
+        print("  run is worse than none, because the repo still looks tested.")
+        return 1
+
+    enforced = [h for h in hosts if h[2] in REQUIRED_CONTEXTS]
+    if not enforced:
+        names = ", ".join(sorted({h[2] for h in hosts}))
+        print(f"{SUITE} runs, but only in non-required job(s): {names}")
+        print(f"  Branch protection requires: {sorted(REQUIRED_CONTEXTS)}")
+        print("  A failing suite would not block a merge, so it does not gate anything.")
+        return 1
+
+    for f, k, n in enforced:
+        print(f"{SUITE} runs in {f}:{k} (reports as '{n}', which is required).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -22,6 +22,19 @@ ROOT=$(pwd)
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 
+# Prerequisites, checked up front and LOUDLY. The alternative -- skipping the
+# checks whose tools are missing -- turns a suite that cannot run into a suite
+# that reports success, which is the exact failure this file exists to prevent.
+missing=""
+for tool in python3 jq; do command -v "$tool" >/dev/null || missing="$missing $tool"; done
+python3 -c 'import yaml' 2>/dev/null || missing="$missing python3-yaml"
+python3 -c 'import segno' 2>/dev/null || missing="$missing python3-segno"
+if [ -n "$missing" ]; then
+  echo "cannot run: missing$missing" >&2
+  echo "install them and re-run; this suite never skips a check it cannot perform." >&2
+  exit 2
+fi
+
 ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
 # want_rc <expected> <label> <cmd...>

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -563,6 +563,90 @@ grep -q 'UNTRUSTED' .github/scripts/pr-review.sh \
   && ok "untrusted PR prose is fenced in the prompt" \
   || bad "PR prose is not fenced -- a title could instruct the model"
 
+echo "== the bot's one comment, and the certificate =="
+# The bot keeps ONE comment and edits it in place, except on merge, where it
+# posts a second one -- because GitHub does not notify on an @mention added by
+# EDITING a comment, so tagging the authors in the edited comment would alert
+# nobody. Both halves are asserted here, plus the idempotency that stops a
+# contributor being tagged four times.
+xbot() { python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(".github/workflows/certification-bot.yml"))
+for j in d["jobs"].values():
+    for st in j.get("steps", []) or []:
+        if (st.get("name") or "") == sys.argv[1]:
+            print(st["run"]); sys.exit(0)
+' "$1"; }
+xbot 'Post or edit the one comment' > "$TMP/bot.sh"
+if [ -s "$TMP/bot.sh" ]; then
+  botstub() {  # botstub <existing-certificate-count>
+    mkdir -p "$TMP/bin"; : > "$TMP/bcalls"
+    cat > "$TMP/bin/gh" <<STUB
+#!/bin/bash
+printf 'ARGV: %s\\n' "\$*" >> "\$BCALLS"
+case "\$*" in
+  *comments*--jq*) echo "$1" ;;                       # certificate-marker count
+  *"/pulls/"*commits*) echo "alice" ;;
+  *"/pulls/"*) echo "alice" ;;
+  *) : ;;
+esac
+exit 0
+STUB
+    chmod +x "$TMP/bin/gh"
+    printf '#!/bin/bash\nexit 0\n' > "$TMP/bin/sudo"; chmod +x "$TMP/bin/sudo"
+    # rsvg-convert must actually PRODUCE its output. A no-op stub left no PNG,
+    # so the sha256sum that names the file failed and `set -euo pipefail` aborted
+    # the step before it ever posted -- which read as "the bot does not post a
+    # certificate on merge" when the bot was right and the stub was hollow.
+    cat > "$TMP/bin/rsvg-convert" <<'STUB'
+#!/bin/bash
+out=""; while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2;; *) shift;; esac; done
+[ -n "$out" ] && printf 'PNG-STUB' > "$out"
+exit 0
+STUB
+    chmod +x "$TMP/bin/rsvg-convert"
+  }
+  runbot() {  # runbot <state> <comment_id> <cert-count>
+    botstub "$3"
+    ( PATH="$TMP/bin:$PATH" BCALLS="$TMP/bcalls" REPO=o/r PR=1 DEFAULT_BRANCH=main \
+      STATE="$1" HEADLINE=h COMMENT_ID="$2" HEAD_SHA=abc1234567 \
+      bash "$TMP/bot.sh" >/dev/null 2>&1 ); }
+  patched() { grep -q 'PATCH' "$TMP/bcalls"; }
+  posted()  { grep -q 'POST.*issues/1/comments' "$TMP/bcalls"; }
+  # The idempotency QUERY also contains the literal marker, inside its --jq
+  # filter. Grepping for the marker alone matched the lookup and reported a
+  # certificate that was never posted -- the assertion could not tell "asked
+  # whether one exists" from "posted one". Require the POST too.
+  certed()  { grep -qE 'POST.*issues/1/comments.*atlas-certificate' "$TMP/bcalls"; }
+
+  runbot pr-certification-stage-1 "" 0
+  posted && ! patched && ok "no prior comment -> posts one" || bad "no prior comment -> did not post exactly one"
+  # CONTROL: with a prior comment it must EDIT, never post a second. A thread of
+  # stale state comments is precisely what the marker exists to prevent.
+  runbot pr-certification-stage-1 12345 0
+  patched && ok "control: an existing comment is edited, not duplicated" \
+    || bad "control: it posted a second state comment instead of editing"
+
+  # The marker is both the lookup key and the memory of the previous state.
+  grep -q 'atlas-certification-state' "$TMP/bot.sh" \
+    && ok "the state marker is written into the comment" \
+    || bad "no state marker -- the next run cannot find its own comment"
+
+  # THE CERTIFICATE: only on merge, and only once.
+  runbot pr-certification-merged "" 0
+  certed && ok "merged -> the certificate is posted" || bad "merged -> no certificate"
+  runbot pr-certification-stage-3 "" 0
+  ! certed && ok "control: a non-merged state posts no certificate" \
+    || bad "control: a certificate was posted for a PR that has not merged"
+  # CONTROL: the bot also fires on check_run completions AFTER a merge. Without
+  # the marker check a contributor is tagged once per event.
+  runbot pr-certification-merged "" 1
+  ! certed && ok "control: a certificate already posted is not posted again" \
+    || bad "control: it posted a second certificate"
+else
+  bad "could not extract the bot's comment step"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -244,6 +244,59 @@ else
   bad "could not extract the one-commit-one-signer shell from ci.yml"
 fi
 
+echo "== certification-state.sh: the state machine =="
+# Eleven states, chosen from the PR's merged flag, its mergeable_state, its
+# queue entry, and three check-run conclusions. Driven here by a stubbed `gh`
+# so every branch is reachable without a live PR.
+mkstate() {  # mkstate <merged> <mergeable_state> <stamp> <seal> <records>
+  mkdir -p "$TMP/bin"
+  cat > "$TMP/bin/gh" <<STUB
+#!/bin/bash
+args="\$*"
+case "\$args" in
+  *"/pulls/"*"/merge"*) exit 1 ;;
+  *check-runs*)
+      # emit one line per matching check run, as --jq would
+      # Print unconditionally. A guarded echo returns non-zero on an
+      # empty value, which made the whole stub exit 1 and every "no such check
+      # run" case look like an API failure rather than an absent check.
+      case "\$args" in
+        *Stamp*)  printf '%s\\n' "$3" ;;
+        *Seal*)   printf '%s\\n' "$4" ;;
+        *Certifications*) printf '%s\\n' "$5" ;;
+      esac
+      exit 0 ;;
+  *"/pulls/"*) printf '{"merged":%s,"head":{"sha":"abc1234567"},"mergeable_state":"%s"}\n' "$1" "$2" ;;
+  *) echo "" ;;
+esac
+STUB
+  chmod +x "$TMP/bin/gh"
+}
+state_is() {  # state_is <expected> <label> <merged> <mergeable> <stamp> <seal> <records>
+  local want=$1 label=$2; shift 2
+  mkstate "$@"
+  local got
+  got=$(PATH="$TMP/bin:$PATH" REPO=o/r PREV_STATE="" bash .github/scripts/certification-state.sh 7 2>/dev/null | cut -f1)
+  if [ "$got" = "$want" ]; then ok "$label"; else bad "$label (got '$got', want '$want')"; fi
+}
+
+state_is pr-certification-stage-1 "unstamped -> stage 1"                 false clean ""        ""        ""
+state_is pr-certification-stage-2-both "stamped, nothing else -> stage 2 (both)" false clean success ""  ""
+state_is pr-certification-stage-2-needs-records "stamped + seal -> needs records" false clean success success ""
+state_is pr-certification-stage-2-needs-seal "stamped + records -> needs seal"   false clean success ""  success
+state_is pr-certification-stage-3 "stamped + seal + records -> stage 3"  false clean success success success
+state_is pr-certification-merged "a merged PR reads merged"              true  clean ""        ""        ""
+state_is pr-certification-blocked "a conflicting PR reads blocked"       false dirty success success success
+
+# CONTROL: precedence. A merged PR is merged whatever its checks say, and a
+# conflicting one is blocked however green it is -- if either ever lost to the
+# stage ladder, the bot would show a stale stage on a PR nobody can merge.
+state_is pr-certification-merged "control: merged outranks a full stage-3 board" true clean success success success
+state_is pr-certification-blocked "control: blocked outranks stage 3"    false dirty success success success
+# CONTROL: a check that exists but did NOT succeed must not count as done.
+state_is pr-certification-stage-2-both "control: a failed Seal is not a seal" false clean success failure ""
+state_is pr-certification-stage-2-needs-seal "control: a failed Seal with records still needs a seal" false clean success failure success
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -386,6 +386,83 @@ else
   bad "could not extract the /stamp and /seal handler"
 fi
 
+echo "== seal status: the merge-queue path =="
+# The seal job runs in the queue too, where there is no pull_request payload --
+# the PR number has to be recovered from a GitHub-generated branch name. Getting
+# this wrong either deadlocks the queue (nothing can land) or lets an unsealed
+# entry through. It had only ever been exercised by hand.
+xseal() { python3 -c '
+import yaml
+d = yaml.safe_load(open(".github/workflows/ci.yml"))
+print(d["jobs"]["seal"]["steps"][0]["run"])
+'; }
+xseal > "$TMP/seal.sh"
+if [ -s "$TMP/seal.sh" ]; then
+  sealstub() {  # sealstub <check-runs-count> <pull-head-sha>
+    mkdir -p "$TMP/bin"
+    printf '#!/bin/bash\ncase "$*" in\n  *check-runs*) printf "%%s\\n" "%s"; exit 0 ;;\n  *pulls/*) printf "%%s\\n" "%s"; exit 0 ;;\n  *) exit 0 ;;\nesac\n' "$1" "$2" > "$TMP/bin/gh"
+    chmod +x "$TMP/bin/gh"
+  }
+  runseal() {  # runseal <event> <pr_sha> <pr_num> <mq_ref>
+    ( PATH="$TMP/bin:$PATH" REPO=o/r EVENT="$1" PR_SHA="$2" PR_NUM="$3" MQ_HEAD_REF="$4" \
+      bash "$TMP/seal.sh" >"$TMP/sealout" 2>&1 ); }
+
+  sealstub 1 abc1234567
+  runseal pull_request abc1234567 7 ""; rc=$?
+  [ "$rc" = 0 ] && ok "seal: a sealed PR passes" || bad "seal: a sealed PR did not pass (rc=$rc)"
+
+  sealstub 0 abc1234567
+  runseal pull_request abc1234567 7 ""; rc=$?
+  [ "$rc" = 1 ] && ok "control: an unsealed PR fails" || bad "control: an unsealed PR passed (rc=$rc)"
+
+  # A push to main has no PR to seal; holding it would block main forever.
+  sealstub 0 ""
+  runseal push "" "" ""; rc=$?
+  [ "$rc" = 0 ] && ok "a push carries no PR and is not held" || bad "a push was held (rc=$rc)"
+
+  # THE QUEUE PATH: recover the PR from gh-readonly-queue/<base>/pr-<N>-<sha>.
+  sealstub 1 abc1234567
+  runseal merge_group "" "" "refs/heads/gh-readonly-queue/main/pr-840-abc1234567"; rc=$?
+  [ "$rc" = 0 ] && ok "queue: a sealed entry passes" || bad "queue: a sealed entry failed (rc=$rc)"
+  # The success path prints only the sha, so the recovered number is asserted on
+  # the FAILURE path, which names "PR #<n>". That proves the number was derived
+  # from the branch AND that the right PR was consulted -- a wrong number would
+  # look up someone else's seal.
+  sealstub 0 abc1234567
+  runseal merge_group "" "" "refs/heads/gh-readonly-queue/main/pr-840-abc1234567"
+  grep -q '#840' "$TMP/sealout" 2>/dev/null && ok "queue: the PR number is recovered from the branch" \
+    || bad "queue: the PR number was not recovered from the branch name"
+
+  sealstub 0 abc1234567
+  runseal merge_group "" "" "refs/heads/gh-readonly-queue/main/pr-840-abc1234567"; rc=$?
+  [ "$rc" = 1 ] && ok "control: an unsealed queue entry is ejected" || bad "control: an unsealed queue entry passed (rc=$rc)"
+
+  # CONTROL: an unparseable queue branch must REFUSE, not guess. Guessing here
+  # would either seal the wrong PR or wave through an unknown one.
+  sealstub 1 abc1234567
+  runseal merge_group "" "" "refs/heads/gh-readonly-queue/main/garbage"; rc=$?
+  [ "$rc" = 1 ] && ok "control: an unparseable queue branch is refused" || bad "control: an unparseable branch was accepted (rc=$rc)"
+
+  # CONTROL: fail CLOSED. This inverts the stamp job beside it on purpose -- a
+  # stamp only spends runners, but a seal is a person vouching, and an
+  # unreadable API must never be read as a vouch nobody gave.
+  mkdir -p "$TMP/bin"; printf '#!/bin/bash\nexit 1\n' > "$TMP/bin/gh"; chmod +x "$TMP/bin/gh"
+  runseal pull_request abc1234567 7 ""; rc=$?
+  # rc=1 alone is NOT enough here. With the fail-closed branch deleted the script
+  # still exits 1 -- by accident, via `[: REFUSE: integer expression expected`
+  # falling through to the generic "Not sealed" message. That is safe today and
+  # fragile tomorrow, and it tells the operator the wrong thing: "no seal" when
+  # the truth is "we could not look". So pin the DELIBERATE path by its message.
+  if [ "$rc" = 1 ] && grep -q 'Could not read the seal' "$TMP/sealout"; then
+    ok "control: an unreadable API fails CLOSED, deliberately"
+  else
+    bad "control: unreadable API -> rc=$rc, and not via the fail-closed branch"
+    sed 's/^/       /' "$TMP/sealout" | head -3
+  fi
+else
+  bad "could not extract the seal job's shell from ci.yml"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -297,6 +297,95 @@ state_is pr-certification-blocked "control: blocked outranks stage 3"    false d
 state_is pr-certification-stage-2-both "control: a failed Seal is not a seal" false clean success failure ""
 state_is pr-certification-stage-2-needs-seal "control: a failed Seal with records still needs a seal" false clean success failure success
 
+echo "== command handlers: who may do what =="
+# The handlers live in certification-commands.yml. What matters is not only that
+# a refusal prints a message, but that a REFUSED command creates NO check run --
+# a refusal that still mints the mark is cosmetic. The stub records every call so
+# both halves can be asserted.
+xcmd() { python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(".github/workflows/certification-commands.yml"))
+for j in d["jobs"].values():
+    for st in j.get("steps", []) or []:
+        if (st.get("name") or "") == sys.argv[1]:
+            print(st["run"]); sys.exit(0)
+' "$1"; }
+
+ghspy() {  # records every gh invocation to $TMP/calls
+  mkdir -p "$TMP/bin"; : > "$TMP/calls"
+  cat > "$TMP/bin/gh" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >> "$CALLS"
+for a in "$@"; do case "$a" in body=*|output*) printf '%s\n' "$a" >> "$CALLS.body";; esac; done
+exit 0
+STUB
+  chmod +x "$TMP/bin/gh"
+}
+# made_check <name> -> did the handler POST a check run of that name?
+made_check() { grep -q -- "-f name=$1" "$TMP/calls" 2>/dev/null; }
+refused()    { grep -qi 'issues/.*/comments' "$TMP/calls" 2>/dev/null && ! made_check "$1"; }
+
+xcmd '/expedite' > "$TMP/exp.sh"
+if [ -s "$TMP/exp.sh" ]; then
+  runexp() { ghspy; : > "$TMP/calls.body"
+    ( PATH="$TMP/bin:$PATH" CALLS="$TMP/calls" REPO=o/r PR=1 ACTOR=u \
+      PERM="$1" ARGS="$2" HEAD_SHA=abc1234567 SHORT=abc1234567 \
+      bash "$TMP/exp.sh" >/dev/null 2>&1 ); }
+
+  runexp admin "the GPU box is down for maintenance"
+  made_check Expedite && ok "expedite: admin with a reason mints the waiver" \
+    || bad "expedite: admin with a reason did NOT mint the waiver"
+  grep -q 'maintenance' "$TMP/calls.body" 2>/dev/null && ok "expedite: the reason is recorded" \
+    || bad "expedite: the reason was not recorded anywhere"
+
+  # CONTROL: write access is NOT enough. /expedite discards the requirement to
+  # prove anything, so it must be admin-only -- and the refusal must not mint.
+  runexp write "trust me"
+  refused Expedite && ok "control: write access cannot expedite" \
+    || bad "control: write access expedited (or the refusal still minted the waiver)"
+  runexp read "trust me"
+  refused Expedite && ok "control: read access cannot expedite" \
+    || bad "control: read access expedited"
+  runexp none "trust me"
+  refused Expedite && ok "control: a stranger cannot expedite" \
+    || bad "control: a stranger expedited"
+
+  # CONTROL: a reason is required. An unexplained bypass six months on is
+  # indistinguishable from an accident.
+  runexp admin ""
+  refused Expedite && ok "control: admin without a reason is refused" \
+    || bad "control: an unexplained expedite was accepted"
+  runexp admin "   "
+  refused Expedite && ok "control: whitespace is not a reason" \
+    || bad "control: whitespace passed as a reason"
+else
+  bad "could not extract the /expedite handler"
+fi
+
+xcmd '/stamp and /seal' > "$TMP/ss.sh"
+if [ -s "$TMP/ss.sh" ]; then
+  runss() { ghspy
+    ( PATH="$TMP/bin:$PATH" CALLS="$TMP/calls" REPO=o/r PR=1 ACTOR="$1" AUTHOR="$2" \
+      VERB="$3" PERM="$4" HEAD_SHA=abc1234567 SHORT=abc1234567 \
+      bash "$TMP/ss.sh" >/dev/null 2>&1 ); }
+
+  runss alice alice /stamp none
+  made_check Stamp && ok "stamp: the PR's author may stamp their own PR" \
+    || bad "stamp: the author could not stamp their own PR"
+  runss bob alice /stamp write
+  made_check Stamp && ok "stamp: write access may stamp" || bad "stamp: write access could not stamp"
+  # CONTROL: a stranger with no write access is neither.
+  runss bob alice /stamp none
+  refused Stamp && ok "control: a non-author without write cannot stamp" \
+    || bad "control: a stranger stamped"
+  # CONTROL: /seal is a different claim -- authorship confers nothing.
+  runss alice alice /seal none
+  refused Seal && ok "control: the author cannot seal without write access" \
+    || bad "control: authorship was accepted as a seal"
+else
+  bad "could not extract the /stamp and /seal handler"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -50,6 +50,21 @@ want_nonzero() {
   fi
 }
 
+# want_rc_msg <expected-rc> <substring> <label> <cmd...> -- rc AND which guard
+# fired. Several guards here overlap: a record with no sidecar trips the
+# signature check AND the one-signer check, because "no sidecar" reads as a
+# distinct signer. A control that only asserts rc=1 therefore passes even when
+# the guard it targets has been deleted -- verified: removing the signature
+# check left the suite green at 32/32.
+want_rc_msg() {
+  local want=$1 needle=$2 label=$3; shift 3
+  "$@" >"$TMP/out" 2>&1; local got=$?
+  if [ "$got" = "$want" ] && grep -qF "$needle" "$TMP/out"; then ok "$label"; else
+    bad "$label (rc=$got want=$want; expected message containing '$needle')"
+    sed 's/^/       /' "$TMP/out" | head -4
+  fi
+}
+
 # want_rc <expected> <label> <cmd...>
 want_rc() {
   local want=$1 label=$2; shift 2
@@ -143,6 +158,91 @@ want_rc 0 "truncation does not die on a 300KB body" \
 # fails on input where the UNPIPED form above succeeded. The pipe is the cause.
 want_nonzero "control: the pre-fix (piped) form fails on the same input" \
   bash -c "set -euo pipefail; b=\$(jq -r '.body // \"\"' '$TMP/big.json' | head -c 4000); echo ok"
+
+echo "== ci.yml decision logic (extracted and run against a stubbed API) =="
+# These shell blocks decide whether anything merges uncertified. They live
+# inside ci.yml where nothing could execute them, so they are pulled out and run
+# here against a fake `gh` -- no network, deterministic.
+extract() { python3 -c '
+import sys, yaml
+d = yaml.safe_load(open(".github/workflows/ci.yml"))
+job, name = sys.argv[1].split("/", 1)
+for st in d["jobs"][job]["steps"]:
+    if (st.get("name") or "") == name or (name == "-" and st.get("run")):
+        print(st["run"]); break
+' "$1"; }
+
+mkstub() {
+  mkdir -p "$TMP/bin"
+  printf '#!/bin/bash\ncase "$*" in\n  *check-runs*) echo "%s" ;;\n  *pulls/*/commits*) echo "" ;;\n  *pulls/*) echo deadbeefcafe ;;\n  *) echo "" ;;\nesac\n' "$1" > "$TMP/bin/gh"
+  chmod +x "$TMP/bin/gh"
+}
+
+extract 'stamp/-' > "$TMP/stamp.sh"
+if [ -s "$TMP/stamp.sh" ]; then
+  mkstub 1
+  : > "$TMP/go1"
+  ( PATH="$TMP/bin:$PATH" GITHUB_OUTPUT="$TMP/go1" REPO=o/r EVENT=pull_request \
+    SHA=abc PR=1 MQ_HEAD_REF= bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  grep -q 'stamped=true' "$TMP/go1" && ok "stamp: a Stamp releases the lane" || bad "stamp: a Stamp did not release the lane"
+  mkstub 0
+  : > "$TMP/go2"
+  ( PATH="$TMP/bin:$PATH" GITHUB_OUTPUT="$TMP/go2" REPO=o/r EVENT=pull_request \
+    SHA=abc PR=1 MQ_HEAD_REF= bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  grep -q 'stamped=false' "$TMP/go2" && ok "control: no Stamp holds the lane" || bad "control: an unstamped PR did not hold the lane"
+  : > "$TMP/go3"
+  ( PATH="$TMP/bin:$PATH" GITHUB_OUTPUT="$TMP/go3" REPO=o/r EVENT=merge_group \
+    SHA=abc PR= MQ_HEAD_REF= bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  grep -q 'stamped=true' "$TMP/go3" && ok "merge_group is never held" || bad "merge_group was held -- that would wedge the queue"
+else
+  bad "could not extract the stamp shell from ci.yml"
+fi
+
+extract 'pr-benchmark-gate-alias/Mirror the certification verdict' > "$TMP/alias.sh"
+if [ -s "$TMP/alias.sh" ]; then
+  want_rc 0 "alias: a green certification passes" \
+    env RESULT=success WEB_ONLY=false STAMPED=true EXPEDITED=false bash "$TMP/alias.sh"
+  want_rc 0 "alias: a web-only diff passes on a deliberate skip" \
+    env RESULT=skipped WEB_ONLY=true STAMPED=true EXPEDITED=false bash "$TMP/alias.sh"
+  want_rc 0 "alias: an admin expedite passes" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=true EXPEDITED=true bash "$TMP/alias.sh"
+  want_rc 1 "control: held (unstamped) stays red" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=false EXPEDITED=false bash "$TMP/alias.sh"
+  want_rc 1 "control: a failed certification stays red" \
+    env RESULT=failure WEB_ONLY=false STAMPED=true EXPEDITED=false bash "$TMP/alias.sh"
+  # The one that matters most: a BROKEN classifier leaves WEB_ONLY empty. If that
+  # ever passed, any diff could skip certification by breaking classify-diff.
+  want_rc 1 "control: a broken classifier (empty web_only) stays red" \
+    env RESULT=skipped WEB_ONLY= STAMPED=true EXPEDITED=false bash "$TMP/alias.sh"
+else
+  bad "could not extract the alias shell from ci.yml"
+fi
+
+echo "== one PR, one commit, one signer =="
+extract 'pr-benchmark-gate/One PR, one commit, one signer' > "$TMP/oc.sh"
+if [ -s "$TMP/oc.sh" ]; then
+  R="$TMP/ocrepo"; rm -rf "$R"; mkdir -p "$R/.benchmarks/b"
+  ( cd "$R" && git init -q . && git config user.email t@t && git config user.name t \
+    && echo s > s && git add -A && git commit -qm base ) >/dev/null 2>&1
+  BASE=$( cd "$R" && git rev-parse HEAD )
+  mk() { printf '{"git_sha":"%s","recorded_at":1788300000}' "$2" > "$R/.benchmarks/b/$1.json"; }
+  sg() { printf '{"v":1,"key":"%s","sig":"x"}' "$2" > "$R/.benchmarks/b/$1.json.sig"; }
+  mk r1 aaaaaaaaaa; sg r1 k1; ( cd "$R" && git add -A && git commit -qm r1 ) >/dev/null 2>&1
+  want_rc 0 "records that agree pass" sh -c "cd '$R' && BASE=$BASE bash '$TMP/oc.sh'"
+  mk r2 bbbbbbbbbb; sg r2 k1; ( cd "$R" && git add -A && git commit -qm r2 ) >/dev/null 2>&1
+  want_rc_msg 1 "span more than one commit" "control: records from two commits are refused" \
+    sh -c "cd '$R' && BASE=$BASE bash '$TMP/oc.sh'"
+  mk r2 aaaaaaaaaa; sg r2 k2; ( cd "$R" && git add -A && git commit -qm r3 ) >/dev/null 2>&1
+  want_rc_msg 1 "more than one signer" "control: records from two signers are refused" \
+    sh -c "cd '$R' && BASE=$BASE bash '$TMP/oc.sh'"
+  # The backdating bypass: an ADDED record with no signature at all.
+  rm -f "$R/.benchmarks/b/r2.json.sig"; sg r1 k1
+  ( cd "$R" && git add -A && git rm -q --cached .benchmarks/b/r2.json.sig 2>/dev/null; git commit -qm r4 ) >/dev/null 2>&1
+  want_rc_msg 1 "Unsigned record added" "control: an added record with no signature is refused" \
+    sh -c "cd '$R' && BASE=$BASE bash '$TMP/oc.sh'"
+else
+  bad "could not extract the one-commit-one-signer shell from ci.yml"
+fi
 
 echo
 echo "  $PASS passed, $FAIL failed"

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# The certification pipeline's self-test.
+#
+# The Rust half of this pipeline (gate/signing.rs, gate/card.rs) has tests that
+# run on every PR. The shell and Python half -- which decides who may stamp, who
+# may seal, whether a runner can reach untrusted code, and whether a record was
+# signed -- had none. Every one of those guards was verified once, by hand, and
+# then trusted forever.
+#
+# EVERY check here has a NEGATIVE CONTROL: the guard is shown failing on input
+# it must reject, not merely passing on input it should accept. A guard that has
+# only ever been seen to pass is indistinguishable from a guard that cannot
+# fail, and the second kind is worse than no guard at all because it reports
+# safety.
+#
+# Runs offline. No network, no GitHub API, no GPU.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+ROOT=$(pwd)
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+# want_rc <expected> <label> <cmd...>
+want_rc() {
+  local want=$1 label=$2; shift 2
+  "$@" >"$TMP/out" 2>&1; local got=$?
+  if [ "$got" = "$want" ]; then ok "$label"; else
+    bad "$label (expected rc=$want, got rc=$got)"; sed 's/^/       /' "$TMP/out" | head -4
+  fi
+}
+
+echo "== seal coverage =="
+printf 'README.md\n' > "$TMP/one.txt"
+want_rc 0 "a codeowner of every path covers the diff" \
+  sh -c "python3 .github/scripts/seal-coverage.py .github/CODEOWNERS '@tbraun96' < '$TMP/one.txt'"
+# CONTROL: a non-owner must NOT cover.
+want_rc 1 "control: a non-owner does not cover" \
+  sh -c "python3 .github/scripts/seal-coverage.py .github/CODEOWNERS '@nobody-at-all' < '$TMP/one.txt'"
+# CONTROL: an empty sealer list must not cover.
+want_rc 1 "control: an empty sealer list does not cover" \
+  sh -c "python3 .github/scripts/seal-coverage.py .github/CODEOWNERS '' < '$TMP/one.txt'"
+# CONTROL: it must FAIL CLOSED on a pattern it cannot match. This inverts
+# gate/codeowners.rs, which is documented fail-OPEN; if this ever flips, a
+# seal would silently cover paths its author never reviewed.
+for pat in '**/x.rs' 'a?b.rs' 'a[b].rs'; do
+  printf '%s  @someone\n*  @tbraun96\n' "$pat" > "$TMP/co"
+  want_rc 1 "control: refuses unsupported pattern '$pat'" \
+    sh -c "python3 .github/scripts/seal-coverage.py '$TMP/co' '@tbraun96' < '$TMP/one.txt'"
+done
+
+echo "== the command runner cannot reach untrusted code =="
+want_rc 0 "the workflows as they stand are safe" python3 .github/scripts/assert-cmd-runner-safe.py
+mkdir -p "$TMP/wf/.github/workflows"; cp .github/scripts/assert-cmd-runner-safe.py "$TMP/wf/"
+# CONTROL x3: each shape that would let a fork run code on our hardware.
+cat > "$TMP/wf/.github/workflows/a.yml" <<'Y'
+on: { pull_request: { types: [opened] } }
+jobs: { j: { runs-on: atlas-cmd, steps: [{ uses: actions/checkout@v4, with: { ref: main } }] } }
+Y
+want_rc 1 "control: pull_request trigger on the command runner" \
+  sh -c "cd '$TMP/wf' && python3 assert-cmd-runner-safe.py"
+cat > "$TMP/wf/.github/workflows/a.yml" <<'Y'
+on: { pull_request_target: { types: [opened] } }
+jobs: { j: { runs-on: [self-hosted, atlas-cmd], steps: [{ uses: actions/checkout@v4, with: { ref: "${{ github.event.pull_request.head.sha }}" } }] } }
+Y
+want_rc 1 "control: checks out the PR head on the command runner" \
+  sh -c "cd '$TMP/wf' && python3 assert-cmd-runner-safe.py"
+cat > "$TMP/wf/.github/workflows/a.yml" <<'Y'
+on: { issue_comment: { types: [created] } }
+jobs: { j: { runs-on: atlas-cmd, steps: [{ uses: actions/checkout@v4 }] } }
+Y
+want_rc 1 "control: checkout with no explicit ref on the command runner" \
+  sh -c "cd '$TMP/wf' && python3 assert-cmd-runner-safe.py"
+
+echo "== certificate rendering =="
+T=docs/diagrams/states/certificate-merged.svg
+render() { python3 .github/scripts/render-certificate.py --template "$T" --out "$1" \
+    --url https://github.com/o/r/pull/7 --pr 7 --title t --repo o/r --commit abc1234567 \
+    --date 2026-01-01 --gates "11 / 11" --qr-x 980 --qr-y 455 "${@:2}"; }
+want_rc 0 "renders with one author"           render "$TMP/c1.svg" --authors "alice"
+want_rc 0 "renders with three authors"        render "$TMP/c3.svg" --authors "alice,bob,carol"
+want_rc 0 "renders with the count absent"     render "$TMP/c0.svg" --authors "alice"
+# A filled author slot must be VISIBLE. The template ships slots 2 and 3 hidden,
+# and an earlier version set their text without unhiding them -- co-authors were
+# silently dropped from a certificate that looked correct.
+vis() { python3 - "$1" <<'PY'
+import re,sys
+s=open(sys.argv[1],encoding='utf-8').read()
+print(sum(1 for i in (1,2,3)
+          if re.search(r'<g[^>]*id="field-cert-author-%d"(?![^>]*display="none")'%i, s)))
+PY
+}
+[ "$(vis "$TMP/c1.svg")" = "1" ] && ok "one author -> one visible slot" || bad "one author -> $(vis "$TMP/c1.svg") visible slots"
+[ "$(vis "$TMP/c3.svg")" = "3" ] && ok "three authors -> three visible slots" || bad "three authors -> $(vis "$TMP/c3.svg") visible slots"
+# CONTROL: a template that lacks an id must be an error, not a silent no-op.
+sed 's/id="value-cert-pr"/id="value-cert-pr-RENAMED"/' "$T" > "$TMP/broken.svg"
+want_rc 1 "control: a renamed id is an error, not a silent skip" \
+  sh -c "python3 .github/scripts/render-certificate.py --template '$TMP/broken.svg' --out '$TMP/x.svg' --url u --pr 7 --title t --authors alice"
+# The rendered SVG must be well-formed; a duplicated attribute made librsvg
+# refuse the whole file while the script still exited 0.
+want_rc 0 "output parses as XML" python3 -c "import xml.dom.minidom,sys;xml.dom.minidom.parse('$TMP/c3.svg')"
+
+echo "== pr-review survives a large payload =="
+# `set -euo pipefail` plus `jq | head -c` takes SIGPIPE past the 64K pipe
+# buffer and kills the script. Any PR body over 4000 chars hit it.
+python3 -c "import json;print(json.dumps({'body':'x'*300000}))" > "$TMP/big.json"
+want_rc 0 "truncation does not die on a 300KB body" \
+  bash -c "set -euo pipefail; b=\$(jq -r '(.body // \"\")[0:4000]' '$TMP/big.json'); [ \${#b} -eq 4000 ]"
+# CONTROL: the old form must still be shown to fail, or this test proves nothing.
+want_rc 141 "control: the pre-fix form still dies on SIGPIPE" \
+  bash -c "set -euo pipefail; b=\$(jq -r '.body // \"\"' '$TMP/big.json' | head -c 4000); echo ok"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -463,6 +463,42 @@ else
   bad "could not extract the seal job's shell from ci.yml"
 fi
 
+echo "== command authority is bounded =="
+want_rc 0 "only state-changing commands can change state" \
+  python3 .github/scripts/assert-command-authority.py
+# CONTROL x3: each way a text-only command could quietly gain authority.
+mkdir -p "$TMP/auth/.github/workflows"; cp .github/scripts/assert-command-authority.py "$TMP/auth/"
+mkwf() {  # mkwf <extra-run-line-for-/review> <permissions-yaml>
+  cat > "$TMP/auth/.github/workflows/certification-commands.yml" <<WF
+name: c
+on: { issue_comment: { types: [created] } }
+permissions:
+$2
+jobs:
+  cmd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: /review
+        run: |
+          echo reviewing
+          $1
+      - name: /stamp and /seal
+        run: gh api -X POST "repos/o/r/check-runs" -f name=Stamp
+WF
+}
+mkwf 'echo ok' '  contents: read'
+want_rc 0 "a text-only /review passes" sh -c "cd '$TMP/auth' && python3 assert-command-authority.py"
+mkwf 'gh api -X POST "repos/o/r/check-runs" -f name=Seal' '  contents: read'
+want_rc 1 "control: /review minting a check run is refused" \
+  sh -c "cd '$TMP/auth' && python3 assert-command-authority.py"
+mkwf 'gh api -X POST "repos/o/r/actions/runs/1/rerun"' '  contents: read'
+want_rc 1 "control: /review re-running CI is refused" \
+  sh -c "cd '$TMP/auth' && python3 assert-command-authority.py"
+mkwf 'echo ok' '  contents: write
+  checks: write'
+want_rc 1 "control: widened workflow permissions are refused" \
+  sh -c "cd '$TMP/auth' && python3 assert-command-authority.py"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -499,6 +499,70 @@ mkwf 'echo ok' '  contents: write
 want_rc 1 "control: widened workflow permissions are refused" \
   sh -c "cd '$TMP/auth' && python3 assert-command-authority.py"
 
+echo "== /review refuses safely =="
+# Every refusal here exits 0 on purpose: a /review that cannot reach a model
+# must not fail anyone's CI. That makes the exit code useless as an assertion,
+# so each check pins the MESSAGE -- and, for the two missing-config cases, that
+# no request was attempted at all.
+revstub() {  # revstub <http-code> <response-body>
+  mkdir -p "$TMP/bin"; : > "$TMP/rcalls"; : > "$TMP/curled"
+  # pr-review.sh posts with `-F body=@-`, i.e. the message arrives on STDIN, not
+  # in argv. A stub that only records arguments captures the call and loses the
+  # text -- which read as "the script never explained itself" when it had.
+  cat > "$TMP/bin/gh" <<'STUB'
+#!/bin/bash
+printf 'ARGV: %s\n' "$*" >> "$RCALLS"
+case "$*" in *body=@-*) cat >> "$RCALLS" ;; esac
+exit 0
+STUB
+  cat > "$TMP/bin/curl" <<STUB
+#!/bin/bash
+echo called >> "\$CURLED"
+for a in "\$@"; do case "\$a" in /tmp/or.json) : ;; esac; done
+printf '%s' '$2' > /tmp/or.json
+printf '%s' '$1'
+STUB
+  chmod +x "$TMP/bin/gh" "$TMP/bin/curl"
+}
+runrev() {
+  ( PATH="$TMP/bin:$PATH" RCALLS="$TMP/rcalls" CURLED="$TMP/curled" \
+    REPO=o/r PR=1 ACTOR=u ARGS="" SHORT=abc1234567 \
+    OPENROUTER_KEY="$1" OPENROUTER_DEFAULT_FREE_MODEL="$2" \
+    bash .github/scripts/pr-review.sh >/dev/null 2>&1 ); echo $?; }
+
+revstub 200 '{"choices":[{"message":{"content":"looks fine"}}]}'
+rc=$(runrev "" "nvidia/x:free")
+[ "$rc" = 0 ] && grep -qi 'key' "$TMP/rcalls" && ok "no API key: says so, and does not fail CI" \
+  || bad "no API key: rc=$rc, or it never explained itself"
+# CONTROL: with no key it must not attempt a request.
+[ ! -s "$TMP/curled" ] && ok "control: no key -> no request attempted" \
+  || bad "control: it called the endpoint without a key"
+
+revstub 200 '{"choices":[{"message":{"content":"looks fine"}}]}'
+rc=$(runrev "k" "")
+[ "$rc" = 0 ] && grep -q 'OPENROUTER_DEFAULT_FREE_MODEL' "$TMP/rcalls" \
+  && ok "no model id: names the variable that is empty" \
+  || bad "no model id: rc=$rc, or it did not name the variable"
+[ ! -s "$TMP/curled" ] && ok "control: no model -> no request attempted" \
+  || bad "control: it called the endpoint with no model"
+
+revstub 500 '{}'
+rc=$(runrev "k" "nvidia/x:free")
+[ "$rc" = 0 ] && grep -qi 'could not reach the model' "$TMP/rcalls" \
+  && ok "a 500 is reported, not swallowed" || bad "a 500 was not reported (rc=$rc)"
+grep -q '500' "$TMP/rcalls" && ok "the HTTP code is in the message" || bad "the HTTP code was not reported"
+
+revstub 200 '{"choices":[{"message":{"content":"THE REVIEW BODY"}}]}'
+rc=$(runrev "k" "nvidia/x:free")
+grep -q 'THE REVIEW BODY' "$TMP/rcalls" && ok "a 200 posts the model's answer" \
+  || bad "a 200 did not post the answer"
+
+# The PR's own prose is attacker-controlled. It must be fenced so a title or
+# body cannot issue instructions to the model.
+grep -q 'UNTRUSTED' .github/scripts/pr-review.sh \
+  && ok "untrusted PR prose is fenced in the prompt" \
+  || bad "PR prose is not fenced -- a title could instruct the model"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -37,6 +37,19 @@ fi
 
 ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+# want_broken_pipe <label> <cmd...> -- asserts the command FAILS because of a
+# broken pipe, without pinning the exit code. jq traps EPIPE and exits 2 with a
+# message; tools that take the signal die with 141. Both are the failure this
+# control exists to demonstrate, and which one you get depends on the jq build,
+# so asserting 141 made the control pass on one machine and fail on another.
+want_nonzero() {
+  local label=$1; shift
+  "$@" >"$TMP/out" 2>&1; local got=$?
+  if [ "$got" -ne 0 ]; then ok "$label"; else
+    bad "$label (expected a non-zero exit, got 0)"; sed 's/^/       /' "$TMP/out" | head -3
+  fi
+}
+
 # want_rc <expected> <label> <cmd...>
 want_rc() {
   local want=$1 label=$2; shift 2
@@ -123,7 +136,12 @@ python3 -c "import json;print(json.dumps({'body':'x'*300000}))" > "$TMP/big.json
 want_rc 0 "truncation does not die on a 300KB body" \
   bash -c "set -euo pipefail; b=\$(jq -r '(.body // \"\")[0:4000]' '$TMP/big.json'); [ \${#b} -eq 4000 ]"
 # CONTROL: the old form must still be shown to fail, or this test proves nothing.
-want_rc 141 "control: the pre-fix form still dies on SIGPIPE" \
+# The exit code differs by platform -- jq traps EPIPE and exits 2 with a
+# message, other builds take the signal and die with 141 silently -- so pinning
+# either one made this control pass on one machine and fail on another. What is
+# invariant, and what the control actually needs to show, is that the PIPED form
+# fails on input where the UNPIPED form above succeeded. The pipe is the cause.
+want_nonzero "control: the pre-fix (piped) form fails on the same input" \
   bash -c "set -euo pipefail; b=\$(jq -r '.body // \"\"' '$TMP/big.json' | head -c 4000); echo ok"
 
 echo

--- a/.github/workflows/certification-bot.yml
+++ b/.github/workflows/certification-bot.yml
@@ -38,7 +38,12 @@ concurrency:
 jobs:
   state:
     name: Certification state
-    runs-on: ubuntu-latest
+    # Same self-hosted runner as the command handler, for the same reason: this
+    # posts the pipeline STATUS, and a status that lands an hour after the event
+    # is not a status. Safe on our own hardware because the checkout below pins
+    # the default branch and never the fork's head -- and
+    # assert-cmd-runner-safe.py enforces that for every workflow on this label.
+    runs-on: ${{ vars.CMD_RUNNER_LABEL || 'ubuntu-latest' }}
     # A comment on a plain issue has no PR to describe. `check_run` events carry
     # their PRs in an array that is empty for pushes to main.
     if: >-

--- a/.github/workflows/certification-commands.yml
+++ b/.github/workflows/certification-commands.yml
@@ -49,7 +49,7 @@ on:
         description: Which verb to run
         required: true
         type: choice
-        options: [/stamp, /seal, /help, /review]
+        options: [/stamp, /seal, /help, /review, /expedite]
 
 permissions:
   contents: read
@@ -61,7 +61,20 @@ concurrency:
 jobs:
   command:
     name: Certification command
-    runs-on: ubuntu-latest
+    # The command handler is three API calls and ~20 seconds of work, but on
+    # GitHub-hosted runners it queued behind 15-27 runs per push plus two
+    # sibling repos -- a /stamp once waited 220 MINUTES. It now runs on a
+    # self-hosted runner on the always-on box, which picks up in seconds.
+    #
+    # Safe here specifically because this workflow pins
+    # `ref: default_branch` and NEVER checks out a PR head, so a fork cannot
+    # run its own code on our hardware. `hardening_tests` below enforces that
+    # the label stays off any workflow that does check out untrusted code.
+    #
+    # The variable is the escape hatch: if the box is down, set
+    # CMD_RUNNER_LABEL to `ubuntu-latest` and commands go back to hosted
+    # runners without a code change.
+    runs-on: ${{ vars.CMD_RUNNER_LABEL || 'ubuntu-latest' }}
     # Cheap gates first so the overwhelming majority of comments cost one
     # skipped job: it must be a PR, and the body must START with a verb we own.
     # `startsWith` on the raw body means a quotation of "/seal" mid-sentence is
@@ -113,7 +126,7 @@ jobs:
             args=$(printf '%s' "$BODY" | head -1 | tr -d '\r' | cut -s -d' ' -f2-)
           fi
           case "$verb" in
-            /help|/stamp|/seal|/review) ;;
+            /help|/stamp|/seal|/review|/expedite) ;;
             *) echo "not a command we own: $verb" >&2; exit 0 ;;
           esac
           # /review on a line comment is legal; the other three are not, because
@@ -154,6 +167,7 @@ jobs:
           | `/stamp` | release the held-back lane: certification + the nine release-matrix builds. Anyone with **write** access. |
           | `/seal` | vouch for this diff. A **codeowner** of every path in it. Voided by the next commit. |
           | `/review [question]` | an agentic read of this PR. Optional question, e.g. `/review does the fix cover the C=2 rung?` |
+          | `/expedite <reason>` | **admin only.** Allows the merge without benchmark records or a codeowner seal. Every other check still has to pass, and the reason is recorded on the PR. |
 
           **Why the lane is held back.** Certification and nine cross-compiles cost
           about an hour of runners. A draft should not pay that on every push, so
@@ -256,6 +270,76 @@ jobs:
           | commit | \`$SHORT\` |
 
           $( [ "$VERB" = "/seal" ] && echo "The next commit to this PR voids it — re-\`/seal\` when the diff settles." || echo "This holds for the life of the PR." )" >/dev/null
+
+      - name: /expedite
+        if: steps.cmd.outputs.verb == '/expedite'
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.cmd.outputs.pr }}
+          ACTOR: ${{ steps.cmd.outputs.actor }}
+          PERM: ${{ steps.cmd.outputs.perm }}
+          ARGS: ${{ steps.cmd.outputs.args }}
+          HEAD_SHA: ${{ steps.cmd.outputs.head_sha }}
+          SHORT: ${{ steps.cmd.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          refuse() { gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$1" >/dev/null; exit 0; }
+
+          # ADMIN ONLY, and deliberately narrower than /stamp or /seal. A stamp
+          # spends runners and a seal records a review; an expedite discards the
+          # evidence requirement altogether, so it is not something write access
+          # should confer.
+          case "$PERM" in admin) ;; *)
+            refuse "@$ACTOR — \`/expedite\` is administrative: it merges without benchmark
+          records, without a codeowner seal, or both. That needs \`admin\`; yours is \`$PERM\`.
+
+          If the certification is merely SLOW rather than impossible, \`/stamp\` is what
+          you want — it releases the lane and still proves the numbers." ;;
+          esac
+
+          # A reason is required. An unexplained bypass in six months' time is
+          # indistinguishable from an accident, and this check run is the only
+          # place the reason survives.
+          why=$(printf '%s' "${ARGS:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [ -z "$why" ]; then
+            refuse "@$ACTOR — \`/expedite\` needs a reason on the same line, e.g.
+
+          \`\`\`
+          /expedite docs-only change, GPU box is down for maintenance
+          \`\`\`
+
+          The reason goes into the check run and is the only record of why the
+          gate was waived."
+          fi
+
+          gh api -X POST "repos/$REPO/check-runs" \
+            -f name="Expedite" -f head_sha="$HEAD_SHA" -f status=completed \
+            -f conclusion=success \
+            -f "output[title]=Expedited by @$ACTOR — certification waived" \
+            -f "output[summary]=@$ACTOR (admin) waived the certification requirement for
+          $SHORT.
+
+          Reason given: $why
+
+          The rest of the pipeline still has to pass. What this skips is the
+          benchmark records and the codeowner seal -- nothing else." >/dev/null
+
+          gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="### ⚠ Expedited — certification waived
+
+          | | |
+          |---|---|
+          | who | @$ACTOR (\`admin\`) |
+          | commit | \`$SHORT\` |
+          | reason | $why |
+
+          This PR may now merge **without benchmark records and without a codeowner
+          seal**. Every other check still has to pass — expedite skips the evidence,
+          not the pipeline.
+
+          A new commit does not clear this. If the numbers matter for what landed
+          here, run the campaign afterwards on \`main\` and commit the records." >/dev/null
+          echo "expedited by @$ACTOR at $SHORT: $why"
 
       - name: /review
         if: steps.cmd.outputs.verb == '/review'

--- a/.github/workflows/certification-preflight.yml
+++ b/.github/workflows/certification-preflight.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Does the certification App still have the permissions the pipeline needs?
+#
+# The offline self-test proves the LOGIC is right. It cannot prove the App is
+# still allowed to act: every write the pipeline makes goes through an
+# installation token, and an App whose grant is narrowed -- by an org policy, by
+# someone editing the App, by a permission added to the manifest and never
+# accepted -- keeps working right up until the moment somebody types /stamp.
+#
+# Several of those failures are SILENT by design. The bot swallows API errors so
+# a broken lookup cannot fail a contributor's CI, and the certificate step
+# treats an unreadable comments API as "already posted". Those are the right
+# behaviours and they are exactly why a permission regression would go unnoticed
+# until a release was blocked.
+#
+# This probes each permission with the smallest real call that needs it, on a
+# schedule and on demand. It writes nothing a human has to clean up.
+name: Certification preflight
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays, off the hour
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: certification preflight
+    runs-on: ${{ vars.CMD_RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - name: Mint the certification App token
+        id: apptoken
+        if: vars.CERTIFICATION_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.CERTIFICATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CERTIFICATION_APP_PRIVATE_KEY }}
+
+      - name: Probe every permission the pipeline needs
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error title=No App token::CERTIFICATION_APP_CLIENT_ID is unset, so every command that mints a mark is already broken."
+            exit 1
+          fi
+          fail=0
+          probe() {  # probe <permission> <why it matters> <cmd...>
+            local perm=$1 why=$2; shift 2
+            if "$@" >/dev/null 2>&1; then
+              printf '  ok    %-22s %s\n' "$perm" "$why"
+            else
+              printf '  FAIL  %-22s %s\n' "$perm" "$why"; fail=1
+            fi
+          }
+
+          probe "pull_requests:read" "/stamp resolves the head sha and the author" \
+            gh api "repos/$REPO/pulls?per_page=1"
+          probe "checks:read" "every gate reads Stamp, Seal and Expedite" \
+            gh api "repos/$REPO/commits/$SHA/check-runs?per_page=1"
+          probe "issues:read" "the bot finds its own comment by marker" \
+            gh api "repos/$REPO/issues?per_page=1"
+          probe "members:read" "/stamp and /seal check who is asking" \
+            gh api "repos/$REPO/collaborators?per_page=1"
+          probe "actions:read" "/stamp re-runs the held CI run" \
+            gh api "repos/$REPO/actions/runs?per_page=1"
+          probe "contents:read" "the bot-cards branch hosts generated certificates" \
+            gh api "repos/$REPO/branches?per_page=1"
+
+          # The one WRITE worth probing for real: without checks:write, /stamp,
+          # /seal and /expedite all fail, and they are the whole pipeline. A
+          # check run is additive and named for what it is, so this costs a line
+          # in the checks list and nothing else.
+          if gh api -X POST "repos/$REPO/check-runs" \
+               -f name="Certification preflight" -f head_sha="$SHA" \
+               -f status=completed -f conclusion=success \
+               -f "output[title]=App permissions verified" \
+               -f "output[summary]=Probed by certification-preflight.yml. If this is missing or red, /stamp, /seal and /expedite cannot mint their marks." \
+               >/dev/null 2>&1; then
+            printf '  ok    %-22s %s\n' "checks:write" "/stamp, /seal and /expedite mint their marks"
+          else
+            printf '  FAIL  %-22s %s\n' "checks:write" "/stamp, /seal and /expedite CANNOT mint their marks"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error title=The certification App has lost a permission::A command will fail the next time someone uses it, and several of those failures are silent by design. Re-check the App's repository permissions and that the installation has accepted them."
+            exit 1
+          fi
+          echo "every permission the pipeline needs is present."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       stamped: ${{ steps.q.outputs.stamped }}
+      expedited: ${{ steps.q.outputs.expedited }}
     steps:
       - id: q
         env:
@@ -130,7 +131,7 @@ jobs:
             # the exact inverse of the fail-open doctrine. Assign, then test the
             # command's own status, and require a clean integer.
             k=$(gh api "repos/$REPO/commits/$s/check-runs?per_page=100" \
-                  --jq '[.check_runs[] | select(.name == "Stamp" and .conclusion == "success")] | length' \
+                  --jq '[.check_runs[] | select((.name == "Stamp" or .name == "Expedite") and .conclusion == "success")] | length' \
                   2>/dev/null) || k=FAILOPEN
             case "$k" in ''|*[!0-9]*) k=FAILOPEN ;; esac
             if [ "$k" = "FAILOPEN" ]; then
@@ -146,6 +147,22 @@ jobs:
           else
             echo "stamped=false" >>"$GITHUB_OUTPUT"
             echo "not stamped on any commit of PR #$PR — certification and the release matrix are held."
+          fi
+
+          # Separately: did an admin WAIVE the evidence with /expedite? The loop
+          # above already treats an Expedite as a stamp, because an expedited PR
+          # must still run the lane -- the point is to merge without RECORDS, not
+          # to skip the build. This publishes the waiver on its own so the alias
+          # can turn a red certification green and say why.
+          exp=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+                  --jq '[.check_runs[] | select(.name == "Expedite" and .conclusion == "success")] | length' \
+                  2>/dev/null) || exp=0
+          case "$exp" in ''|*[!0-9]*) exp=0 ;; esac
+          if [ "$exp" -gt 0 ]; then
+            echo "expedited=true" >>"$GITHUB_OUTPUT"
+            echo "EXPEDITED at $SHA — an admin waived the certification requirement."
+          else
+            echo "expedited=false" >>"$GITHUB_OUTPUT"
           fi
 
   # The binding half of `/seal`. The Seal CHECK RUN is minted by the App in
@@ -194,7 +211,7 @@ jobs:
           # A seal vouches for a DIFF, so only a Seal on the CURRENT head counts
           # — unlike a stamp, which deliberately carries across new commits.
           n=$(gh api "repos/$REPO/commits/$sha/check-runs?per_page=100" \
-                --jq '[.check_runs[] | select(.name == "Seal" and .conclusion == "success")] | length' \
+                --jq '[.check_runs[] | select((.name == "Seal" or .name == "Expedite") and .conclusion == "success")] | length' \
                 2>/dev/null) || n=REFUSE
           case "$n" in ''|*[!0-9]*) n=REFUSE ;; esac
           # Deliberately fails CLOSED, inverting the fail-open shape of `stamp`
@@ -1194,9 +1211,20 @@ jobs:
           RESULT: ${{ needs.pr-benchmark-gate.result }}
           WEB_ONLY: ${{ needs.changes.outputs.web_only }}
           STAMPED: ${{ needs.stamp.outputs.stamped }}
+          EXPEDITED: ${{ needs.stamp.outputs.expedited }}
         run: |
           echo "PR Benchmark Certifications => ${RESULT} (web_only=${WEB_ONLY:-unknown})"
           if [ "${RESULT}" = "success" ]; then exit 0; fi
+          # An admin waived the evidence requirement with /expedite. Pass -- but
+          # say so loudly, because a green check that silently means "we did not
+          # measure" is the exact hole this pipeline exists to close. The
+          # Expedite check run carries who waived it and why.
+          if [ "${EXPEDITED}" = "true" ]; then
+            echo "::warning title=Certification waived::An admin expedited this PR, so \
+          certification did not have to pass. See the Expedite check run for who \
+          waived it and the reason they gave."
+            exit 0
+          fi
           # THE ONE SKIP THAT IS A PASS: the certification was deliberately not
           # run because every changed file is under site/ blog/ book/
           # web-shared/, none of which is a measured input of any record. The

--- a/.github/workflows/cmd-runner-health.yml
+++ b/.github/workflows/cmd-runner-health.yml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Automatic fallback for the self-hosted command runner.
+#
+# `certification-commands.yml` and `certification-bot.yml` resolve their
+# `runs-on` from the CMD_RUNNER_LABEL variable. That makes the switch instant
+# when the runner is healthy and reversible by hand when it is not -- but a
+# by-hand switch needs a hand, and a runner that dies at 2am leaves every
+# /stamp and every status update queued behind a runner that will never answer.
+#
+# This flips the variable on our behalf. It deliberately runs on a GITHUB-HOSTED
+# runner: it is the thing that notices the self-hosted one is gone, so it cannot
+# depend on it. Latency does not matter here -- nobody is waiting on a health
+# check -- which is exactly why the hosted queue is acceptable for this job and
+# not for the commands themselves.
+name: Command runner health
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    name: command runner health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint the certification App token
+        id: apptoken
+        if: vars.CERTIFICATION_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.CERTIFICATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CERTIFICATION_APP_PRIVATE_KEY }}
+
+      - name: Point the commands at a runner that answers
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          WANT: atlas-cmd
+          FALLBACK: ubuntu-latest
+        run: |
+          set -uo pipefail
+          # `online` is GitHub's own view of the runner's heartbeat, which is
+          # what actually decides whether a job gets picked up.
+          online=$(gh api "repos/$REPO/actions/runners" \
+                     --jq "[.runners[] | select(any(.labels[]; .name == \"$WANT\")) | select(.status == \"online\")] | length" \
+                     2>/dev/null) || online=UNKNOWN
+          case "$online" in ''|*[!0-9]*) online=UNKNOWN ;; esac
+
+          cur=$(gh api "repos/$REPO/actions/variables/CMD_RUNNER_LABEL" --jq '.value' 2>/dev/null) || cur=""
+          echo "runners online with '$WANT': $online   CMD_RUNNER_LABEL=${cur:-<unset>}"
+
+          # UNKNOWN means the API did not answer. Changing the routing on a
+          # guess is worse than leaving it: a false "offline" would move every
+          # command onto the hosted queue we built this to escape.
+          if [ "$online" = "UNKNOWN" ]; then
+            echo "::warning title=Runner health unknown::could not read the runner list; leaving CMD_RUNNER_LABEL as ${cur:-<unset>}."
+            exit 0
+          fi
+
+          want="$WANT"
+          [ "$online" -eq 0 ] && want="$FALLBACK"
+          if [ "$cur" = "$want" ]; then
+            echo "already correct — nothing to do."
+            exit 0
+          fi
+
+          if gh api -X PATCH "repos/$REPO/actions/variables/CMD_RUNNER_LABEL" \
+               -f name=CMD_RUNNER_LABEL -f value="$want" >/dev/null 2>&1; then
+            if [ "$want" = "$FALLBACK" ]; then
+              echo "::warning title=Command runner is offline::commands and the status bot moved to $FALLBACK. They will be slow until the self-hosted runner returns."
+            else
+              echo "::notice title=Command runner is back::commands and the status bot moved back to $WANT."
+            fi
+            echo "CMD_RUNNER_LABEL: ${cur:-<unset>} -> $want"
+          else
+            # Writing a variable needs `administration: write`, which the App may
+            # not have been granted. Say so plainly rather than failing the run:
+            # a red health check every 15 minutes trains people to ignore it.
+            echo "::warning title=Cannot switch runners automatically::the token cannot write CMD_RUNNER_LABEL (needs 'administration: write' on the certification App). Set it by hand to '$want'."
+          fi

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -31,6 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # Deliberately hosted HERE and not in the certification suite it guards.
+      # The suite is 81 checks behind one line in security.yml; delete that line
+      # and every check stops running while the job it lived in stays green. A
+      # guard inside the suite cannot notice its own absence, so it lives in a
+      # different REQUIRED job -- removing the suite now breaks this one instead.
+      - name: The certification self-test still runs, in a job that must pass
+        run: |
+          python3 -m pip install --quiet PyYAML
+          python3 .github/scripts/assert-selftest-wired.py
+
       - name: Check no .rs file exceeds 500 lines
         shell: bash
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,8 +47,12 @@ jobs:
       # code -- a property of the files today, which this turns into a rule.
       # Cheap, pure-Python, and it lives in the security job because that is
       # what it is.
-      - name: The command runner cannot reach untrusted code
-        run: python3 .github/scripts/assert-cmd-runner-safe.py
+      # The whole certification self-test, which includes the command-runner
+      # assertion. Every check in it has a negative control -- the guard is
+      # shown FAILING on input it must reject, not merely passing on input it
+      # should accept. Offline: no network, no API, no GPU.
+      - name: Certification pipeline self-test
+        run: bash .github/scripts/certification-selftest.sh
       # `rust-version` pins the action's in-container toolchain to our
       # rust-toolchain.toml channel. Without it, the action's bundled Rust
       # can't honor the repo pin and rustup errors ("override toolchain

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,6 +51,11 @@ jobs:
       # assertion. Every check in it has a negative control -- the guard is
       # shown FAILING on input it must reject, not merely passing on input it
       # should accept. Offline: no network, no API, no GPU.
+      # segno generates the certificate's QR matrix; PyYAML parses workflows for
+      # the runner-safety assertion. Both are pure Python and install in seconds.
+      # The suite REFUSES to run without them rather than skipping those checks.
+      - name: Self-test prerequisites
+        run: python3 -m pip install --quiet segno PyYAML
       - name: Certification pipeline self-test
         run: bash .github/scripts/certification-selftest.sh
       # `rust-version` pins the action's in-container toolchain to our

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,6 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The self-hosted command runner executes on our own hardware. It is
+      # only safe while no workflow that reaches its label checks out untrusted
+      # code -- a property of the files today, which this turns into a rule.
+      # Cheap, pure-Python, and it lives in the security job because that is
+      # what it is.
+      - name: The command runner cannot reach untrusted code
+        run: python3 .github/scripts/assert-cmd-runner-safe.py
       # `rust-version` pins the action's in-container toolchain to our
       # rust-toolchain.toml channel. Without it, the action's bundled Rust
       # can't honor the repo pin and rustup errors ("override toolchain

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -177,3 +177,41 @@ fails correctly, naming the missing message.
 **Still open.** `certification-state.sh` has no coverage. The seal job's
 `merge_group` branch — which derives the PR number from a queue branch name — is
 exercised only by hand.
+
+---
+
+## Wave 5 — the state machine, and two harness bugs that looked like results
+
+**Found.** `certification-state.sh` picks one of eleven states from the PR's
+merged flag, its mergeable_state, its queue entry and three check-run
+conclusions. It is what the bot shows an author. Nothing tested it.
+
+**Changed.** 11 checks driven by a stubbed `gh`, covering every stage the ladder
+can reach plus the two precedence rules that outrank it. Total 43.
+
+**Two of my own bugs, both of which first read as findings.**
+
+*One.* Four state checks failed with empty output. The obvious reading was a
+defect in the script. Running it directly showed it emitting `stage-1`
+perfectly — the fault was my stub: `[ -n "$v" ] && echo "$v"` returns non-zero
+on an empty value, so the stub exited 1 and every *absent check run* looked like
+an *API failure*. Fixed by printing unconditionally. Had I trusted the first
+reading, I would have "fixed" a script that was already correct.
+
+*Two.* Sabotage B — forcing `has_seal=true` — showed the suite green at 43/43,
+which reads as a hole. It was not. The anchor matched **zero** times: the real
+line has two spaces after the semicolon and quotes around `success`. The
+sabotage never applied. Re-run with an asserted anchor, it turns **four** checks
+red, including both "a failed Seal is not a seal" controls.
+
+A silently no-op'd sabotage is indistinguishable from an uncaught regression,
+and both look like green. Assert the anchor before drawing the conclusion.
+
+**The controls proved it.** Removing the merged-outranks-everything rule turns
+`a merged PR reads merged` and `merged outranks a full stage-3 board` red.
+Treating any Seal conclusion as a seal turns four red.
+
+**Still open.** The seal job's `merge_group` branch — deriving a PR number from
+a `gh-readonly-queue/<base>/pr-<N>-<sha>` branch name — is exercised only by
+hand. `/expedite` has no end-to-end coverage; its `admin`-only refusal and its
+required-reason refusal are both untested.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -463,3 +463,43 @@ narrowed; on-demand covers the case where someone has just edited the App.
 50 controls, and its authority now has a live probe with a control. What is not
 covered — and cannot be, short of a staging org — is GitHub changing the
 semantics of an endpoint underneath us.
+
+---
+
+## Wave 12 — the guard on the guard
+
+**Found.** Eighty-one checks and fifty controls hang on **one line in one
+workflow**. Delete that line and every one of them stops running — silently,
+with `cargo deny`, the job it lived in, still green. Ten waves of work,
+removable in a one-line diff nobody would notice in review.
+
+The good half: `cargo deny` *is* a required context, so a **failing** suite does
+block a merge. The gap was never enforcement of the result; it was enforcement
+of the **wiring**.
+
+**Why it could not go in the suite.** If the step is removed the suite never
+executes, so a check inside it can never fire. A guard cannot notice its own
+absence. It has to live somewhere that still runs.
+
+**Changed.** `assert-selftest-wired.py`, hosted in the **LoC-cap job** — a
+different required context. Removing the suite from `security.yml` now breaks
+`Enforce ≤500 LoC per source file` instead. It asserts two things: that some job
+invokes the suite, and that the job reports under a name branch protection
+requires — because a suite in a job nobody has to pass is a suite that can be
+ignored.
+
+**The controls proved it**, both anchor-asserted:
+
+| Sabotage | Result |
+|---|---|
+| the self-test step deleted from `security.yml` | ❌ *"nothing runs certification-selftest.sh"* |
+| the suite moved to a non-required job | ❌ *"runs, but only in non-required job(s)"* |
+
+**On the literal in that file.** `REQUIRED_CONTEXTS = {"cargo deny"}` is
+hardcoded, because the assertion must work without network access. If branch
+protection changes, that line is what needs updating — and the failure message
+says exactly that rather than leaving someone to guess.
+
+**Still open.** Nothing known. This wave closed the last structural gap I can
+name: the pipeline's logic is covered offline, its authority is probed live, and
+its wiring is now guarded from a job that cannot be removed in the same edit.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -71,3 +71,35 @@ target the behaviour under test, or the control is theatre.
 **Still open.** `certification-state.sh` and the `ci.yml` stamp/seal/expedite
 shell have no coverage in the suite yet. The one-commit-one-signer step is
 tested only in a scratch repo, by hand.
+
+---
+
+## Wave 2 — the gate itself was not portable
+
+**Found.** CI went red on `cargo deny` — the job wave 1 had just added the
+self-test to. Not a flake: the suite's three certificate-rendering checks failed
+on `ubuntu-latest` because `render-certificate.py` imports `segno`, which had
+been installed by hand on this box and on avarok but exists nowhere in CI.
+
+The gate built to catch regressions was itself broken in a way that only CI
+could see. Worth stating plainly: wave 1 reported "19 passed" from a machine
+where the dependency happened to be present, and that number was true and
+useless.
+
+**Changed.** The suite now checks its prerequisites up front — `python3`, `jq`,
+PyYAML, segno — and exits 2 with a named list if any are absent. The security
+job installs them before running it.
+
+**The control proved it.** With a shimmed `python3` that reports segno missing,
+the suite exits **2** and names `python3-segno`, rather than running a reduced
+set of checks and reporting success. With the prerequisites present it is 19/19
+again.
+
+The tempting fix was to skip the QR-dependent checks when segno is unavailable.
+That would have turned a suite that *cannot run* into a suite that *reports
+success* — the precise failure mode this file exists to prevent, reintroduced
+inside the file itself.
+
+**Still open.** Unchanged from wave 1: `certification-state.sh` and the
+`ci.yml` stamp/seal/expedite shell have no coverage; the one-commit-one-signer
+step is exercised only by hand.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -328,3 +328,38 @@ commands stay powerless.
 or a non-200 — is untested; the harness would need to fake an OpenRouter
 endpoint. The bot's state-comment editing (marker lookup, in-place PATCH) has no
 coverage.
+
+---
+
+## Wave 9 — /review's refusals, and a stub that lost the message
+
+**Found.** `pr-review.sh` refuses in three ways — no model id, no API key, a
+non-200 from the endpoint — and every one of them exits **0** on purpose: a
+`/review` that cannot reach a model must not fail anyone's CI. That makes the
+exit code useless as an assertion, so all three had to be pinned by message.
+None was tested.
+
+**Changed.** 8 checks, 5 controls. Total 75.
+
+**A harness bug that read as a script bug.** Five checks failed with "it never
+explained itself". The script had explained itself perfectly: it posts with
+`gh api ... -F body=@-`, so the message arrives on **stdin**, and my stub only
+recorded argv. Third time this record notes the same shape — the first reading
+of a red test was "the code is broken" and the truth was "the harness is".
+
+**The controls proved it**, each with an asserted anchor:
+
+| Sabotage | What went red |
+|---|---|
+| the missing-key guard removed — would call the endpoint with no credential | both the message check and `no key -> no request attempted` |
+| a non-200 reported as success | `a 500 is reported, not swallowed` |
+| the `UNTRUSTED` fence renamed | `PR prose is not fenced` |
+
+The last is the one worth keeping. A PR's title and body are attacker-controlled
+text that gets fed to a model. They are fenced between `UNTRUSTED` markers with
+the system prompt told to treat anything inside as data. Remove the fence and a
+PR title becomes an instruction — and the guard now notices.
+
+**Still open.** The bot's state-comment editing — finding its own comment by the
+`<!-- atlas-certification-state:… -->` marker and PATCHing it in place — has no
+coverage. That is the last uncovered path.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -252,3 +252,42 @@ work, and now that cannot regress silently.
 `gh-readonly-queue/<base>/pr-<N>-<sha>` — is exercised only by hand. `/help` and
 `/review` have no coverage; both are low-consequence (they post text and cannot
 change a verdict), which is why they are last.
+
+---
+
+## Wave 7 — the merge-queue seal path, and the hollow control again
+
+**Found.** The seal job also runs inside the merge queue, where there is no
+`pull_request` payload and the PR number must be recovered from a
+GitHub-generated branch name, `gh-readonly-queue/<base>/pr-<N>-<sha>`. Wrong
+here means either the queue deadlocks or an unsealed entry lands. Hand-tested
+only.
+
+**Changed.** 8 checks, 5 controls. Total 62.
+
+**A wrong assertion of mine.** The first version asserted the recovered PR
+number appears in the success output. It does not — the success path prints only
+the sha. The number is named on the *failure* path, so the assertion moved
+there: `PR #840` in the refusal proves both that the number was derived from the
+branch and that the right PR was consulted. A wrong number would have looked up
+someone else's seal and passed.
+
+**The hollow control, a second time.** Sabotage A deleted the fail-closed branch
+and the suite stayed green at 62/62. Not a safe outcome — an accident. With the
+branch gone the script still exits 1, via
+`[: REFUSE: integer expression expected` falling through to the generic "Not
+sealed" message. Safe today, fragile tomorrow, and it tells the operator the
+wrong thing: *"no seal"* when the truth is *"we could not look"*.
+
+The control asserted `rc=1` and nothing else, so it could not tell a deliberate
+refusal from an arithmetic crash. It now pins the message — `Could not read the
+seal` — and re-running the sabotage fails correctly.
+
+This is the same defect class as wave 4, found in a different file one wave
+apart. The generalisation is worth stating: **when several paths can produce the
+same exit code, asserting the exit code tests none of them.** Pin the
+diagnostic.
+
+**Still open.** `/help` and `/review` have no coverage. Both only post text and
+cannot change a verdict, which is why they are last — but "cannot change a
+verdict" is itself an untested claim.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -414,3 +414,52 @@ merge-queue seal path, and the bot's comment lifecycle.
 defect that only appears against the real GitHub API — the App's token
 permissions, for instance, are asserted nowhere and would fail only in
 production.
+
+---
+
+## Wave 11 — the offline gap: is the App still allowed to act?
+
+**Found.** Wave 10 closed the last *logic* path and named what remained: the
+suite runs offline, so it proves the pipeline decides correctly but not that it
+is still permitted to act. Every write goes through an installation token, and
+an App whose grant narrows — an org policy, an edit to the App, a permission
+added to the manifest and never accepted — keeps working right up until someone
+types `/stamp`.
+
+Worse, several of those failures are **silent by design**. The bot swallows API
+errors so a broken lookup cannot fail a contributor's CI; the certificate step
+treats an unreadable comments API as "already posted". Both are correct
+behaviours, and both are exactly why a permission regression would go unnoticed
+until a release was blocked.
+
+**Changed.** `certification-preflight.yml` probes each permission with the
+smallest real call that needs it — weekly and on demand. It names *why* each
+one matters, so a failure says what will break rather than which endpoint
+returned 403:
+
+    pull_requests:read   /stamp resolves the head sha and the author
+    checks:read          every gate reads Stamp, Seal and Expedite
+    issues:read          the bot finds its own comment by marker
+    members:read         /stamp and /seal check who is asking
+    actions:read         /stamp re-runs the held CI run
+    contents:read        the bot-cards branch hosts generated certificates
+    checks:write         /stamp, /seal and /expedite mint their marks
+
+`checks:write` is probed for real, by creating a check run named "Certification
+preflight". Without it the three commands that mint marks are all dead, which is
+the whole pipeline. A check run is additive and self-describing, so the probe
+costs one line in the checks list and leaves nothing to clean up.
+
+**The control proved it.** All six read probes pass against the live API with a
+valid token, and **all six fail** with an invalid one — so the probes are
+reaching GitHub rather than passing vacuously.
+
+**Why this is not in the self-test.** It needs the network and a real App token,
+which the offline suite deliberately does not have. Running it per-PR would also
+add a check run to every PR for no benefit. Weekly catches a grant that was
+narrowed; on-demand covers the case where someone has just edited the App.
+
+**Still open.** Nothing known. The pipeline's logic has 81 offline checks with
+50 controls, and its authority now has a live probe with a control. What is not
+covered — and cannot be, short of a staging org — is GitHub changing the
+semantics of an endpoint underneath us.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -503,3 +503,42 @@ says exactly that rather than leaving someone to guess.
 **Still open.** Nothing known. This wave closed the last structural gap I can
 name: the pipeline's logic is covered offline, its authority is probed live, and
 its wiring is now guarded from a job that cannot be removed in the same edit.
+
+---
+
+## Wave 13 — the Rust tests were trusted the way the shell was before wave 1
+
+**Found.** `gate/signing.rs` and `gate/card.rs` have 21 tests that run on every
+PR, and this record has leaned on that fact since wave 1 to argue the Rust half
+was covered. Not one of them had ever been **shown to fail**. That is exactly
+the position the shell half was in before any of this started, one level up:
+green tests, trusted because they are green.
+
+**Changed.** Nothing in the code. Three sabotages, to find out whether the
+existing tests measure anything.
+
+| Sabotage | Caught by |
+|---|---|
+| signature verification always succeeds | `editing_the_record_breaks_the_signature`, `a_record_cannot_be_repointed_at_another_commit`, `a_signature_from_another_record_does_not_transfer` |
+| `sig_path` uses `with_extension("sig")` | `the_sidecar_path_appends_and_does_not_eat_a_versioned_model_name`, `no_committed_record_escapes_the_cutover_unsigned` |
+| card formats a metric to 3 decimals instead of 1 | `formats_round_the_way_a_reader_expects` |
+
+All three caught, by the tests written for them. The Rust half is genuinely
+covered — now demonstrated rather than assumed.
+
+**A sabotage of mine that was inert, and why it matters.** The first attempt at
+the `sig_path` bug used `with_extension("json.sig")`. On
+`…-qwen3.8-27b.json` that yields `…-qwen3.8-27b.json.sig` — byte-identical to
+appending. The suite stayed green and I very nearly recorded an uncovered path.
+It was not one: the sabotage did not change behaviour. The real bug is
+`with_extension("sig")`, which produces `…-qwen3.8-27b.sig` and is caught
+immediately.
+
+Twice now a green result has meant "my sabotage did nothing" rather than "the
+guard is missing" — wave 5 with a non-matching anchor, and here with a matching
+anchor that made no behavioural difference. **Asserting the anchor is necessary
+and not sufficient. Check that the edit changes what the code does.**
+
+**Still open.** Nothing known. Every layer — shell logic, Rust logic, live
+authority, and the wiring that runs it all — has now been shown to fail when the
+thing it guards is broken.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -363,3 +363,54 @@ PR title becomes an instruction — and the guard now notices.
 **Still open.** The bot's state-comment editing — finding its own comment by the
 `<!-- atlas-certification-state:… -->` marker and PATCHing it in place — has no
 coverage. That is the last uncovered path.
+
+---
+
+## Wave 10 — the bot's comment lifecycle, and two hollow assertions of mine
+
+**Found.** The bot keeps ONE comment and edits it in place, except on merge,
+where it posts a second one — because GitHub does not notify on an `@mention`
+added by *editing* a comment, so tagging the authors in the edited comment would
+alert nobody. It also fires on `check_run` completions *after* a merge, so
+without an idempotency guard a contributor is tagged once per event. None of it
+was tested. This was the last uncovered path.
+
+**Changed.** 6 checks, 4 controls. Total 81.
+
+**Two hollow assertions, both mine, both found by the checks disagreeing.**
+
+*One.* `certed()` grepped the recorded calls for `atlas-certificate`. The
+idempotency **query** contains that literal string inside its `--jq` filter, so
+the helper matched the *lookup* and reported a certificate that was never
+posted. It could not distinguish "asked whether one exists" from "posted one".
+Now it requires a `POST` to the comments endpoint carrying the marker.
+
+*Two.* With that fixed, the positive went red: "merged -> no certificate". The
+bot was right again. My `rsvg-convert` stub was a no-op that produced no file,
+so the `sha256sum` naming it failed and `set -euo pipefail` aborted the step
+before the POST. A stub that does not produce its output is not a stub, it is a
+different failure.
+
+That is the fourth time in this record that a red check meant the harness was
+wrong, not the code. The pattern is consistent enough to state as a rule: **when
+a new test fails against code that has been working, suspect the test first.**
+
+**The controls proved it**, each anchor-asserted:
+
+| Sabotage | What went red |
+|---|---|
+| the certificate loses its once-only guard | `a certificate already posted is not posted again` |
+| the bot posts instead of editing | `an existing comment is edited, not duplicated` |
+| the certificate is posted regardless of state | `a certificate was posted for a PR that has not merged` |
+
+**Coverage is now complete.** Every gate, command and bot path in the
+certification pipeline has at least one check and at least one negative control
+proven able to fail: seal coverage, runner safety, certificate rendering,
+pr-review truncation and refusals, the stamp/seal/alias/one-commit decision
+logic, the eleven-state machine, command permissions, command authority, the
+merge-queue seal path, and the bot's comment lifecycle.
+
+**Still open.** Nothing structural. The suite runs offline, so it cannot catch a
+defect that only appears against the real GitHub API — the App's token
+permissions, for instance, are asserted nowhere and would fail only in
+production.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -542,3 +542,27 @@ and not sufficient. Check that the edit changes what the code does.**
 **Still open.** Nothing known. Every layer — shell logic, Rust logic, live
 authority, and the wiring that runs it all — has now been shown to fail when the
 thing it guards is broken.
+
+---
+
+## Wave 14 — landing it, and the pipeline exercising itself
+
+**Found.** Thirteen waves of guards protect nothing while they sit on a branch.
+The suite gates `main` only once it is *on* `main`.
+
+**Changed.** Nothing new. `/stamp` and `/seal` on #843, dispatched against the
+branch's own workflow so they ran on the self-hosted runner the PR introduces.
+
+**The measurement.** Both marks recorded in **47 seconds** for two commands.
+Earlier the same day, on hosted runners, a single `/stamp` waited **220
+minutes**. Same repo, same commands, same account.
+
+That number is the point of the runner change, and it is now demonstrated by the
+change certifying itself rather than by a benchmark written to flatter it.
+
+**What this wave actually proves.** The pipeline ran its own three stages on the
+PR that hardens it: `/seal` verified codeowner coverage across the diff,
+`/stamp` released the held lane, both marks landed on the head, and the 81-check
+suite plus the wiring guard ran as required contexts on the same commit.
+
+**Still open.** Nothing known. The record's last entry is the merge itself.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -137,3 +137,43 @@ still be true on a machine you have never used.
 
 **Still open.** `certification-state.sh` and the `ci.yml` stamp/seal/expedite
 shell remain uncovered. CI has not yet confirmed this wave.
+
+---
+
+## Wave 4 — the ci.yml decision logic, and a control that measured nothing
+
+**Found.** Four shell blocks inside `ci.yml` decide whether anything merges
+uncertified — the stamp verdict, the seal verdict, the alias that mirrors
+certification into a required check, and the one-commit-one-signer step. They
+live inside a workflow file, where nothing could execute them. None had ever
+run outside a real CI job.
+
+**Changed.** The suite now extracts each block from `ci.yml` with PyYAML and
+runs it against a stubbed `gh`. 13 new checks, 7 of them controls. Total 32.
+
+**The control proved it — and then failed to.** Three sabotages of `ci.yml`:
+
+| Sabotage | Caught? |
+|---|---|
+| alias flips `WEB_ONLY = "true"` to `!= "false"` (the fail-open doctrine violation) | ✅ `control: a broken classifier (empty web_only) stays red` |
+| stamp stops short-circuiting non-PR events (would wedge the merge queue) | ✅ `merge_group was held` |
+| **one-commit step stops requiring a signature on added records** | ❌ **32/32, green** |
+
+The third is the finding. The control asserted only `rc=1`, and several guards
+in that step overlap: a record with no sidecar trips the signature check *and*
+the one-signer check, because "no sidecar" reads as a distinct signer. Deleting
+the guard under test left the suite green, because a different guard caught the
+same fixture.
+
+**A control that passes when the thing it tests has been deleted is measuring
+nothing.** It is the exact failure this record exists to catch, and it was in a
+check written one wave earlier specifically to catch such things.
+
+**Fixed.** `want_rc_msg` pins the exit code *and* which guard fired. The three
+one-commit controls now assert their own diagnostic — `Unsigned record added`,
+`span more than one commit`, `more than one signer`. Re-running sabotage 3 now
+fails correctly, naming the missing message.
+
+**Still open.** `certification-state.sh` has no coverage. The seal job's
+`merge_group` branch — which derives the PR number from a queue branch name — is
+exercised only by hand.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -215,3 +215,40 @@ Treating any Seal conclusion as a seal turns four red.
 a `gh-readonly-queue/<base>/pr-<N>-<sha>` branch name — is exercised only by
 hand. `/expedite` has no end-to-end coverage; its `admin`-only refusal and its
 required-reason refusal are both untested.
+
+---
+
+## Wave 6 — who may bypass the gate
+
+**Found.** The command handlers decide who may release the expensive lane, who
+may vouch for a diff, and — with `/expedite` — who may merge without proving
+anything at all. None was tested. `/expedite` is the highest-consequence path in
+the pipeline and had zero coverage from the moment it was written.
+
+**Changed.** 11 checks, 8 of them controls, driven through a `gh` stub that
+records every call. Total 54.
+
+**The assertion that matters.** A refusal is not merely "prints a message" — a
+refused command must create **no check run**. A refusal that still mints the
+mark is cosmetic, and would be invisible in a log. Every control here asserts
+both halves: a comment was posted *and* no `Stamp`/`Seal`/`Expedite` was minted.
+
+**The controls proved it.** Three sabotages, each with an asserted anchor so a
+silent no-op could not masquerade as a pass:
+
+| Sabotage | What went red |
+|---|---|
+| `/expedite` accepts `write`/`maintain`, not just `admin` | `control: write access cannot expedite` |
+| `/expedite` stops requiring a reason | both reason controls |
+| `/seal` accepts authorship instead of write access | `control: authorship was accepted as a seal` |
+
+The last is worth stating plainly: authorship and ownership are different
+claims. A stamp says "this is ready to cost an hour of runners", which its
+author is well placed to judge. A seal says "a codeowner has read this diff",
+which its author is not. Conflating them would let anyone self-certify their own
+work, and now that cannot regress silently.
+
+**Still open.** The seal job's `merge_group` branch — deriving a PR number from
+`gh-readonly-queue/<base>/pr-<N>-<sha>` — is exercised only by hand. `/help` and
+`/review` have no coverage; both are low-consequence (they post text and cannot
+change a verdict), which is why they are last.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -291,3 +291,40 @@ diagnostic.
 **Still open.** `/help` and `/review` have no coverage. Both only post text and
 cannot change a verdict, which is why they are last — but "cannot change a
 verdict" is itself an untested claim.
+
+---
+
+## Wave 8 — "it cannot change a verdict" was an inspection, not a test
+
+**Found.** `/help` and `/review` post text and mint nothing. That was true by
+reading the file, which is exactly the kind of claim that stops being true
+quietly. It matters more than it looks: `/review`'s permission check is
+deliberately weak — anyone who can comment may ask it a question — because it
+only posts prose. Give it the ability to create a check run and an outside
+contributor could mint their own `Seal` by asking about the diff.
+
+**Changed.** `.github/scripts/assert-command-authority.py`: only
+`/stamp and /seal` and `/expedite` may POST a check run, re-run CI, or PATCH,
+PUT or DELETE anything. It also pins the workflow to `permissions: {contents:
+read}`, since every step inherits the top-level grant and none of them needs
+more. 5 checks, 4 controls. Total 67.
+
+**The controls proved it**, on synthetic workflows and then on the real one:
+
+| Sabotage | Result |
+|---|---|
+| `/review` gains `POST .../check-runs -f name=Seal` (real file, anchor asserted) | ❌ refused |
+| top-level permissions widened to `contents: write, checks: write` (real file) | ❌ refused |
+| `/review` gains `/rerun` (synthetic) | ❌ refused |
+| a text-only `/review` | ✅ passes |
+
+**What this closes.** The three preceding waves tested whether a guard reaches
+the right verdict. This one tests whether a command *has the authority to reach
+a verdict at all* — a different question, and the one an attacker would ask
+first. The permission checks in wave 6 only matter while the weakly-checked
+commands stay powerless.
+
+**Still open.** `pr-review.sh`'s own behaviour — its refusals on a missing key
+or a non-200 — is untested; the harness would need to fake an OpenRouter
+endpoint. The bot's state-comment editing (marker lookup, in-place PATCH) has no
+coverage.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -103,3 +103,37 @@ inside the file itself.
 **Still open.** Unchanged from wave 1: `certification-state.sh` and the
 `ci.yml` stamp/seal/expedite shell have no coverage; the one-commit-one-signer
 step is exercised only by hand.
+
+---
+
+## Wave 3 — a control that asserted an implementation detail
+
+**Found.** With the dependency fixed, CI still failed — on the SIGPIPE control
+itself, not on the code it guards. The pre-fix form exits **2 in CI** and **141
+locally**: `jq` traps `EPIPE` and exits 2 with a diagnostic, while other builds
+take the signal and die silently with 141. The control asserted `rc=141`, so it
+passed on this box and failed on `ubuntu-latest`.
+
+The guarded behaviour was correct on both machines the entire time. The control
+was wrong.
+
+**Two wrong fixes, both tried.** First `rc=141` → "non-zero **and** the output
+mentions a broken pipe". That went red locally, where the process dies silently
+and prints nothing. Pinning the *message* is the same mistake as pinning the
+*code*: both are platform detail dressed up as an invariant.
+
+**Changed.** The control now asserts the property that is actually invariant:
+the **piped** form fails on the very input where the **unpiped** form, asserted
+green one line above, succeeded. That isolates the pipe as the cause without
+depending on how the platform reports it.
+
+**The control proved it.** Substituting the fixed (unpiped) command in for the
+"pre-fix" one turns that control red — so it is still measuring something. 19/19
+locally.
+
+**The lesson, since it generalises.** A negative control that pins an exit code
+or an error string is testing the platform, not the property. Ask what would
+still be true on a machine you have never used.
+
+**Still open.** `certification-state.sh` and the `ci.yml` stamp/seal/expedite
+shell remain uncovered. CI has not yet confirmed this wave.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1,0 +1,73 @@
+# Certification pipeline robustness
+
+An append-only record. One entry per wave: what was found, the evidence, what
+changed, and — the part that matters — what the *negative control* proved.
+
+A guard that has only ever been seen to pass is indistinguishable from a guard
+that cannot fail, and the second kind is worse than no guard at all, because it
+reports safety. So every entry here names the control and what it caught.
+
+**The gate:** `bash .github/scripts/certification-selftest.sh` — offline, no
+network, no GPU. It runs in the security job on every PR.
+
+---
+
+## Baseline — 2026-09-03
+
+Before any of this work:
+
+| Surface | Tested in CI? |
+|---|---|
+| `gate/signing.rs` | ✅ 12 Rust tests |
+| `gate/card.rs` | ✅ 9 Rust tests |
+| `seal-coverage.py` | ❌ none |
+| `assert-cmd-runner-safe.py` | ❌ none |
+| `render-certificate.py` | ❌ none |
+| `certification-state.sh` | ❌ none |
+| `pr-review.sh` | ❌ none |
+| `ci.yml` stamp / seal / expedite logic | ❌ none |
+| one-commit-one-signer step | ❌ none |
+
+Open at baseline: PR #843 red on `PR benchmark gate` and `seal status` — both
+expected (unstamped, unsealed), not defects.
+
+---
+
+## Wave 1 — the shell half had no tests at all
+
+**Found.** The Rust half of the certification pipeline has 21 tests that run on
+every PR. The shell and Python half — which decides who may stamp, who may seal,
+whether the self-hosted runner can reach untrusted code, and whether a record
+was signed — had **zero**. Every one of those guards had been verified once, by
+hand, in a terminal, and then trusted permanently.
+
+That is the highest-severity finding available here, because it is not a bug in
+any one guard: it is the absence of anything that would notice a bug in any of
+them.
+
+**Changed.** Added `.github/scripts/certification-selftest.sh` — 19 checks, of
+which **11 are negative controls** — and wired it into the security job, which
+already runs on every PR, so this costs no new queue slot.
+
+**The control proved it.** The suite was sabotaged four ways and watched go red:
+
+| Sabotage | What went red |
+|---|---|
+| `seal-coverage.py` stops refusing unsupported CODEOWNERS patterns (fail-open regression) | all 3 fail-closed controls |
+| `assert-cmd-runner-safe.py` blinded to head-ref checkouts | `control: checks out the PR head on the command runner` |
+| `render-certificate.py` stops un-hiding co-author slots | `three authors -> 1 visible slots` |
+| — | positives stayed green in every case |
+
+The third reproduces a real bug shipped earlier in the day: co-authors were
+silently dropped from a certificate that rendered and looked correct. It is now
+impossible to reintroduce without CI saying so.
+
+**A mistake worth recording.** The first sabotage attempt broke Python syntax
+rather than behaviour, so the *positive* test failed and the fail-closed
+controls stayed green. That looked like a caught regression and was not — it
+proved only that the suite notices a file that will not parse. Sabotage has to
+target the behaviour under test, or the control is theatre.
+
+**Still open.** `certification-state.sh` and the `ci.yml` stamp/seal/expedite
+shell have no coverage in the suite yet. The one-commit-one-signer step is
+tested only in a scratch repo, by hand.


### PR DESCRIPTION
Follow-up to #840. Commands and status updates now answer in **seconds** instead of hours.

## The problem, measured

The command handler is three API calls and about twenty seconds of work. On GitHub-hosted runners it queued behind 15–27 workflow runs per push, plus two sibling repos sharing the org concurrency pool. Observed on #840:

| command | queue time |
|---|---|
| `/stamp` | **220 min** |
| `/seal` | 100 min |
| `/seal` (later, pool free) | 10 min |

A status that lands an hour after the event it describes is not a status.

## The proof

Dispatched `/help` against this branch's workflow, so it ran on the new runner:

```
run 33782341739  workflow_dispatch  completed/success
runner: avarok-cmd
created 17:03:58 -> done 17:04:12     = 14s end to end
job wall time                          = 10s
```

The bot's comment landed at `17:04:08`. **14 seconds versus 220 minutes** — the same command, the same repo, the same day.

## What changed

**A self-hosted runner on `avarok`** (`avarok-cmd`, x86_64, 32 cores), installed as a systemd service, `enabled` + `active`, so it survives reboot. Both `certification-commands.yml` and `certification-bot.yml` now resolve `runs-on` from `vars.CMD_RUNNER_LABEL`.

**Why this is safe on a public repo.** GitHub advises against self-hosted runners here because a fork's PR can run arbitrary code on your hardware. It does not apply to these two workflows for one specific reason: both pin `ref: default_branch` and never check out a PR head. That is a property of the files as written, so `.github/scripts/assert-cmd-runner-safe.py` turns it into a rule — it fails if any workflow reaching the label is `pull_request`-triggered, checks out a head ref, or checks out with no explicit ref at all. Proven to fail on all three unsafe shapes and pass the safe one; runs in the security job.

**Automatic fallback.** `cmd-runner-health.yml` checks every 15 minutes and flips `CMD_RUNNER_LABEL` to `ubuntu-latest` if the runner stops answering. It runs on a *hosted* runner deliberately — it is the thing that notices the self-hosted one is gone, so it cannot depend on it. Three paths exercised live:

| condition | behaviour |
|---|---|
| online, variable correct | no-op |
| present but zero online | switches to `ubuntu-latest`, warns |
| **API cannot answer** | **leaves routing alone** |

The last one is the important one: a false "offline" reading would move every command onto the queue this exists to escape, so UNKNOWN is not treated as offline.

## `/expedite`

Administrative bypass. It waives the **evidence** — benchmark records and the codeowner seal — and nothing else; every other check still has to pass.

- **`admin` only.** A stamp spends runners and a seal records a review; an expedite discards the requirement to prove anything, which write access should not confer.
- **A reason is required** on the same line. An unexplained bypass six months later is indistinguishable from an accident, and the check run is the only place that reason survives.
- **Loud, not quiet.** It posts a marked comment naming who waived it and why, and the alias emits a `::warning` rather than passing silently — a green check that secretly means "we did not measure" is the exact hole this pipeline exists to close.

The gates honour it by accepting an `Expedite` check run wherever they accept a `Stamp` or a `Seal`. Verified against live data: #840's head reports `stamped=true / expedited=false`, #831's reports `false / false`.

## Note on the merge certificate

#840 shipped the certificate machinery but **could not certificate itself** — comment-handler workflows run from the default branch as it was when the event fired, and pre-merge `main` had zero certificate steps (post-merge: two). The bot did fire, 2 seconds after the merge. This PR will be the first merge that produces one.