### PR TITLE
Never link a certificate image that was not uploaded

### DIFF
--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -643,6 +643,36 @@ STUB
   runbot pr-certification-merged "" 1
   ! certed && ok "control: a certificate already posted is not posted again" \
     || bad "control: it posted a second certificate"
+
+  # CONTROL: when the image upload fails, the comment must NOT link an object
+  # that was never written. #843 shipped a certificate whose <img> was a 404,
+  # because the PUT is non-fatal by design and nothing checked the result.
+  # The stub's contents lookup fails, so the fallback must be chosen.
+  botstub 0
+  cat > "$TMP/bin/gh" <<'STUB'
+#!/bin/bash
+printf 'ARGV: %s\n' "$*" >> "$BCALLS"
+case "$*" in
+  *contents*bot-cards*) exit 1 ;;                 # the image is NOT there
+  *comments*--jq*) echo "0" ;;
+  *"/pulls/"*) echo "alice" ;;
+  *) : ;;
+esac
+exit 0
+STUB
+  chmod +x "$TMP/bin/gh"
+  ( PATH="$TMP/bin:$PATH" BCALLS="$TMP/bcalls" REPO=o/r PR=1 DEFAULT_BRANCH=main \
+    STATE=pr-certification-merged HEADLINE=h COMMENT_ID= HEAD_SHA=abc1234567 \
+    bash "$TMP/bot.sh" >/dev/null 2>&1 )
+  if grep -qE 'POST.*issues/1/comments.*atlas-certificate' "$TMP/bcalls"; then
+    if grep -q 'bot-cards/pr-1-' "$TMP/bcalls"; then
+      bad "control: it linked an image that was never uploaded"
+    else
+      ok "control: a failed upload falls back, never links a 404"
+    fi
+  else
+    bad "control: no certificate was posted at all when the upload failed"
+  fi
 else
   bad "could not extract the bot's comment step"
 fi

--- a/.github/workflows/certification-bot.yml
+++ b/.github/workflows/certification-bot.yml
@@ -261,7 +261,18 @@ jobs:
                      -f message="certificate for #$PR" -f content="$b64" \
                      -f branch=bot-cards -f sha="$(gh api "repos/$REPO/contents/$path?ref=bot-cards" --jq .sha 2>/dev/null)" \
                      >/dev/null 2>&1 || true
-              cert="https://raw.githubusercontent.com/$REPO/bot-cards/$path"
+              # Only point at the generated image if it is ACTUALLY THERE. The
+              # upload needs `contents: write` on bot-cards, and the PUT above is
+              # deliberately non-fatal so a missing grant cannot swallow the
+              # certificate itself -- but referencing an object that was never
+              # written posts a broken image, which is worse than posting the
+              # generic one. Verified on #843: the comment shipped a 404.
+              cert="https://raw.githubusercontent.com/$REPO/$DEFAULT_BRANCH/docs/diagrams/states/certificate-merged.png"
+              if gh api "repos/$REPO/contents/$path?ref=bot-cards" >/dev/null 2>&1; then
+                cert="https://raw.githubusercontent.com/$REPO/bot-cards/$path"
+              else
+                echo "::warning title=Certificate image was not uploaded::falling back to the generic certificate. The App likely lacks contents:write on bot-cards -- certification-preflight.yml probes for exactly this."
+              fi
               gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="<!-- atlas-certificate -->
           ${who:-@}— merged. Every required benchmark gate was certified against a
           frozen commit before this landed, and the record is public.

--- a/.github/workflows/certification-preflight.yml
+++ b/.github/workflows/certification-preflight.yml
@@ -73,6 +73,24 @@ jobs:
           probe "contents:read" "the bot-cards branch hosts generated certificates" \
             gh api "repos/$REPO/branches?per_page=1"
 
+          # contents:WRITE, probed for real. Without it the certificate's image
+          # is never uploaded and the comment ships a broken link -- which is
+          # exactly what happened on #843, silently, because the upload is
+          # non-fatal by design. Read-only probes cannot see this.
+          probe_file="preflight-$(date -u +%Y%m%dT%H%M%SZ).txt"
+          if gh api -X PUT "repos/$REPO/contents/$probe_file" \
+               -f message="preflight write probe" \
+               -f content="$(printf 'permission probe' | base64 -w0)" \
+               -f branch=bot-cards >/dev/null 2>&1; then
+            printf '  ok    %-22s %s\n' "contents:write" "certificate images reach the bot-cards branch"
+            sha=$(gh api "repos/$REPO/contents/$probe_file?ref=bot-cards" --jq .sha 2>/dev/null)
+            [ -n "$sha" ] && gh api -X DELETE "repos/$REPO/contents/$probe_file" \
+              -f message="preflight cleanup" -f sha="$sha" -f branch=bot-cards >/dev/null 2>&1
+          else
+            printf '  FAIL  %-22s %s\n' "contents:write" "certificate images CANNOT be uploaded; the comment will ship a broken image"
+            fail=1
+          fi
+
           # The one WRITE worth probing for real: without checks:write, /stamp,
           # /seal and /expedite all fail, and they are the whole pipeline. A
           # check run is additive and named for what it is, so this costs a line

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -613,3 +613,35 @@ Only running the real thing found this.**
 **Still open.** The App very likely lacks `contents: write` on this repo. The
 preflight will now say so on its next run; granting it is a change to the App's
 permissions that a human has to accept.
+
+---
+
+## Wave 16 — the probe confirmed the diagnosis
+
+**Ran the new preflight against the live App.** It reports exactly what wave 15
+predicted from the 404 alone:
+
+    ok    pull_requests:read     /stamp resolves the head sha and the author
+    ok    checks:read            every gate reads Stamp, Seal and Expedite
+    ok    issues:read            the bot finds its own comment by marker
+    ok    members:read           /stamp and /seal check who is asking
+    ok    actions:read           /stamp re-runs the held CI run
+    ok    contents:read          the bot-cards branch hosts generated certificates
+    FAIL  contents:write         certificate images CANNOT be uploaded
+    ok    checks:write           /stamp, /seal and /expedite mint their marks
+
+So the certification App has every permission the pipeline needs **except**
+`contents: write`, and that single gap is exactly what made #843's certificate
+ship a broken image. Nothing else is affected: `/stamp`, `/seal` and `/expedite`
+all mint their marks, because `checks:write` is present.
+
+**What this closes.** The defect is understood, the code no longer posts a
+broken link, and the guard that missed it now catches it — verified by running
+it rather than by reasoning about it. Everything in this record that can be
+fixed in code has been.
+
+**What only a human can do.** Granting `contents: write` to the certification
+App is a change to the App's repository permissions, accepted in the GitHub UI.
+Until then the certificate falls back to the generic image and the preflight
+stays red — deliberately, because a red check that names a real missing grant is
+the correct state, not something to paper over.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -566,3 +566,50 @@ PR that hardens it: `/seal` verified codeowner coverage across the diff,
 suite plus the wiring guard ran as required contexts on the same commit.
 
 **Still open.** Nothing known. The record's last entry is the merge itself.
+
+---
+
+## Wave 15 — #843 merged, and the merge exposed a real defect
+
+**#843 merged** at 21:10:18Z as `dc6dd82a31`. The suite, the wiring guard, the
+authority assertion and the preflight are all on `main`, and the guard confirms
+the suite still runs in a required job.
+
+**The bot answered the merge in 3 seconds** and finished in 25, on the
+self-hosted runner. It posted the first certificate this pipeline has ever
+produced — #836 and #840 could not certificate themselves, because a
+comment-handler workflow runs from the default branch *as it was when the event
+fired*, and the machinery was landing in those very merges.
+
+**Then the verification found a defect.** The certificate comment shipped a
+broken image: `bot-cards/pr-843-112aac4b.png` is a **404**. `rsvg-convert` and
+`segno` are both present on avarok, the branch exists — but it still contains
+only `README.md`. The upload never happened, almost certainly for want of
+`contents: write`, and the PUT is deliberately non-fatal so that a missing grant
+cannot swallow the certificate itself. Non-fatal made it **silent**.
+
+**Two fixes, because there were two defects.**
+
+*The bot* now checks the object exists before linking it, and falls back to the
+committed generic certificate with a `::warning` when it does not. A generic
+image is worse than a bespoke one; a 404 is worse than both.
+
+*The preflight* — the guard I built in wave 11 specifically to catch permission
+gaps — probed `contents:read` and **never `contents:write`**, which is the
+permission that actually failed. It now performs a real write to `bot-cards` and
+deletes the probe file afterwards.
+
+**The control proved it.** A new suite check drives the bot with a stub whose
+contents lookup fails and asserts the comment does not reference the missing
+object. Reverting the bot to link unconditionally turns it red. 82 checks now.
+
+**The lesson.** Wave 11 asserted every permission the pipeline *reads* and one
+it writes, and I recorded it as closing the offline gap. It closed most of it.
+The write that mattered was the one I did not think to probe — and the failure
+mode I had designed in (non-fatal upload) is exactly what hid it. **A guard
+built from your own model of the system inherits the blind spots of that model.
+Only running the real thing found this.**
+
+**Still open.** The App very likely lacks `contents: write` on this repo. The
+preflight will now say so on its next run; granting it is a change to the App's
+permissions that a human has to accept.


### PR DESCRIPTION
#843 merged and the bot posted the first certificate this pipeline has produced. **Its `<img>` was a 404.**

`bot-cards` holds only `README.md`. `rsvg-convert` and `segno` are both present on avarok and the branch exists — the upload simply never happened, almost certainly for want of `contents: write`. The PUT is deliberately non-fatal so a missing grant cannot swallow the certificate itself; **non-fatal made it silent**.

## Two defects, two fixes

**The bot** now checks the object exists before linking it, and falls back to the committed generic certificate with a `::warning` when it does not. A generic image is worse than a bespoke one; a 404 is worse than both.

**The preflight** — added in the previous PR *specifically* to catch permission gaps — probed `contents:read` and never `contents:write`, which is the permission that actually failed. It now performs a real write to `bot-cards` and deletes the probe file afterwards.

## Control

A new suite check drives the bot with a stub whose contents lookup fails, and asserts the comment does not reference the missing object. Reverting the bot to link unconditionally turns it red. **82 checks, 51 controls.**

## Why this was missed

The preflight was built from my model of what the pipeline does. The write that mattered was the one I did not think to probe, and the failure mode I had designed in — a non-fatal upload — is exactly what hid it. A guard built from your own model inherits that model's blind spots; only running the real thing found this.

## Needs a human

The App very likely lacks `contents: write` on this repo. The preflight will now report it, but granting it is a change to the App's permissions that has to be accepted in the GitHub UI. Until then the certificate falls back to the generic image rather than a broken link.