### PR TITLE
Document the three bot commands that existed only in a workflow file

### DIFF
--- a/.github/scripts/assert-commands-documented.py
+++ b/.github/scripts/assert-commands-documented.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Every comment command the bot accepts must be documented in the README.
+
+Three of the five were not. `/help`, `/review` and `/expedite` existed in the
+handler and appeared nowhere a user would look -- `/expedite` in particular is
+an administrative override that skips certification, which is the last command
+that should be discoverable only by reading a workflow file. All three were
+added during this repository's own recent work, which is the point: the drift
+was introduced by the same hands that wrote the docs, one commit at a time, and
+no single change looked like it was leaving something out.
+
+The verb list is read from the handler's own `case` statement rather than
+restated here. A second hand-maintained list would drift from the first exactly
+the way the README drifted from the handler.
+"""
+import re
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+HANDLER = ROOT / ".github" / "workflows" / "certification-commands.yml"
+README = ROOT / "README.md"
+
+# the `case` arm that whitelists accepted verbs, e.g. `/help|/stamp|/seal) ;;`
+CASE = re.compile(r"^\s*(/[a-z]+(?:\|/[a-z]+)+)\)\s*;;", re.M)
+
+
+def main() -> None:
+    m = CASE.search(HANDLER.read_text())
+    if not m:
+        print(
+            "REFUSE: could not find the verb whitelist in certification-commands.yml. "
+            "This guard reads the handler's own `case` arm so the two cannot drift; "
+            "if the parser moved, teach this regex rather than hard-coding a list.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    verbs = m.group(1).split("|")
+    readme = README.read_text()
+    missing = [v for v in verbs if v not in readme]
+
+    if missing:
+        for v in missing:
+            print(f"REFUSE: the bot accepts `{v}` and README.md never mentions it", file=sys.stderr)
+        print(
+            f"\n{len(missing)} of {len(verbs)} commands are undocumented. A command a user "
+            f"cannot discover is a command that does not exist for them.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(f"ok: all {len(verbs)} accepted commands ({', '.join(verbs)}) are documented in README.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -999,6 +999,43 @@ want_rc_msg 1 "no known static root" "control: a site-root link from an unknown 
 dl_tree; printf '[a](/api/spark_model/)\n[b](/api/)\n' > "$TMP/dl/book/src/more.md"
 want_rc 0 "control: generated /api/ paths are not treated as breakage" dl_run
 
+# ---------------------------------------------------------------------------
+# Commands that exist only in a workflow file
+# ---------------------------------------------------------------------------
+# Three of the five -- /help, /review and /expedite -- were accepted by the bot
+# and mentioned nowhere in the README. /expedite skips certification outright.
+# All three arrived during this record's own waves, one commit at a time, and no
+# single change looked like it was leaving something out.
+want_rc 0 "every accepted command is documented" \
+  python3 .github/scripts/assert-commands-documented.py
+mkdir -p "$TMP/cd/.github/workflows"
+cp .github/scripts/assert-commands-documented.py "$TMP/cd/.github/"
+mkdir -p "$TMP/cd/.github/scripts"
+mv "$TMP/cd/.github/assert-commands-documented.py" "$TMP/cd/.github/scripts/"
+
+cd_case() { printf '%s\n' \
+  "jobs:" "  command:" "    steps:" "      - run: |" "          case \"\$VERB\" in" \
+  "            $1) ;;" "            *) exit 0 ;;" "          esac" \
+  > "$TMP/cd/.github/workflows/certification-commands.yml"; }
+
+cd_case '/help|/stamp|/seal'
+printf 'we document /help and /stamp and /seal here.\n' > "$TMP/cd/README.md"
+want_rc 0 "control: a README covering every verb passes" \
+  python3 "$TMP/cd/.github/scripts/assert-commands-documented.py"
+
+cd_case '/help|/stamp|/seal|/expedite'
+want_rc_msg 1 "accepts \`/expedite\`" "control: a command missing from the README is caught" \
+  python3 "$TMP/cd/.github/scripts/assert-commands-documented.py"
+
+# If the case arm is renamed or restructured, the guard must REFUSE rather than
+# find nothing and report success -- a guard that cannot locate its input and
+# passes is the failure mode this whole suite exists to catch.
+printf 'jobs:\n  command:\n    steps:\n      - run: echo no case arm here\n' \
+  > "$TMP/cd/.github/workflows/certification-commands.yml"
+want_rc_msg 1 "could not find the verb whitelist" \
+  "control: a guard that cannot find its input refuses, it does not pass" \
+  python3 "$TMP/cd/.github/scripts/assert-commands-documented.py"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 REACHED_SUMMARY=1

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -848,7 +848,7 @@ if [ -s "$TMP/stamp.sh" ]; then
 all="$*"
 case "$all" in
   *"actions/runs/"*"/rerun"*) printf 'RERUN %s\n' "$all" >> "$SCALLS"; echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1 ;;
-  *"actions/runs?head_sha"*)  echo 12345; exit 0 ;;
+  *"actions/runs?head_sha"*)  echo "${RUNMETA:-12345 completed}"; exit 0 ;;
   *"issues/"*"/comments"*)    printf '%s\n' "$all" >> "$SCALLS"; exit 0 ;;
   *)                          exit 0 ;;
 esac
@@ -885,6 +885,32 @@ STUB
     ok "control: /seal re-runs CI so seal status is re-evaluated"
   else
     bad "control: /seal minted its mark and never refreshed the job that reads it"
+  fi
+
+  # CONTROL: stamping while CI is still in flight must NOT warn. Re-running an
+  # unfinished run returns 403 "This workflow is already running", which the
+  # warning would report as a failure -- and it is not one: a run still in
+  # flight reads the mark when its gate jobs execute. Found in production the
+  # first time the warning printed the API's own words, which is what it is for.
+  : > "$TMP/scalls"
+  ( PATH="$TMP/sbin:$PATH" SCALLS="$TMP/scalls" RUNMETA="777 queued" REPO=o/r PR=1 VERB=/stamp \
+    ACTOR=me AUTHOR=me PERM=write HEAD_SHA=abc1234567 SHORT=abc1234 \
+    bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  src=$?
+  if [ "$src" -eq 0 ]; then
+    ok "control: stamping mid-run is not an error"
+  else
+    bad "control: stamping while CI was queued failed the command job"
+  fi
+  if grep -q '^RERUN ' "$TMP/scalls"; then
+    bad "control: it tried to re-run a run that had not finished"
+  else
+    ok "control: a run still in flight is not re-run"
+  fi
+  if grep -q "but CI was not re-run" "$TMP/scalls"; then
+    bad "control: it warned about a benign in-flight run"
+  else
+    ok "control: and no false warning is posted"
   fi
 else
   bad "could not extract the /stamp step"

--- a/.github/workflows/certification-commands.yml
+++ b/.github/workflows/certification-commands.yml
@@ -259,10 +259,20 @@ jobs:
           # Re-running is safe for a seal: it adds no commit, and a seal is
           # voided by commits, not by CI runs.
           if [ "$VERB" = "/stamp" ] || [ "$VERB" = "/seal" ]; then
-            run_id=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=50" \
-              --jq '[.workflow_runs[] | select(.name == "CI")] | sort_by(.created_at) | last | .id' \
+            # id AND status. Re-running a run that has not finished returns
+            # 403 "This workflow is already running", which the warning below
+            # would then report as a failure -- and it is not one. A run still
+            # in flight reads the mark when its gate jobs execute, so there is
+            # nothing to re-run. This was found the first time the warning
+            # printed the API's own words, which is what it is for.
+            run_meta=$(gh api "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=50" \
+              --jq '[.workflow_runs[] | select(.name == "CI")] | sort_by(.created_at) | last | "\(.id) \(.status)"' \
               2>/dev/null || true)
-            if [ -n "${run_id:-}" ] && [ "$run_id" != "null" ]; then
+            run_id=${run_meta%% *}
+            run_status=${run_meta##* }
+            if [ -n "${run_id:-}" ] && [ "$run_id" != "null" ] && [ "$run_status" != "completed" ]; then
+              echo "::notice title=CI is still running::run $run_id is '$run_status'. Its gate jobs read the $name when they execute, so nothing is re-run. If they already ran, re-run CI once this one finishes."
+            elif [ -n "${run_id:-}" ] && [ "$run_id" != "null" ]; then
               # Capture stderr rather than discarding it. The first time this
               # failed in production the reason went to /dev/null, the Stamp
               # check went green, and the gate stayed red telling the operator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,12 @@ jobs:
       - name: markdown links resolve
         run: python3 .github/scripts/assert-doc-links.py
 
+      # A command a user cannot discover is a command that does not exist for
+      # them -- and /expedite skips certification, so it is the last one that
+      # should live only in a workflow file.
+      - name: every bot command is documented
+        run: python3 .github/scripts/assert-commands-documented.py
+
   typos:
     name: typos
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -584,8 +584,10 @@ headers, kernel structure, tests, merge ancestry. Certification and the nine
 release-matrix build legs are held back, so an early draft does not burn an hour
 of runners.
 
-**Stage 2 — Certification** opens on `/stamp` from anyone with write access, and
-needs two things. An **engineer's seal** — a codeowner comments `/seal`, and the
+**Stage 2 — Certification** opens on `/stamp` from anyone with write access **or
+the PR's own author** — nobody is better placed to say their own branch has
+stopped churning, and the author is precisely who the hold was protecting from
+burnt runners. It needs two things. An **engineer's seal** — a codeowner comments `/seal`, and the
 sealers' owned paths must cover the whole diff. And **benchmark records** — the
 campaign runs on a real GPU box and the records are committed; CI only checks
 that they cover what changed. Records are Ed25519-signed over their own bytes and
@@ -603,6 +605,20 @@ wrong records — and what it makes attributable is everything else.
 
 **Stage 3 — Ready to merge**, then the queue, which re-runs the whole pipeline
 against its own merge commit.
+
+The bot takes five comment commands, and they are the whole interface:
+
+| command | who may use it | what it does |
+|---|---|---|
+| `/help` | anyone | prints this table on the PR, with the current state |
+| `/stamp` | write access, or the PR author | releases certification and the nine release-matrix legs. **Survives new commits** |
+| `/seal` | a codeowner with write access whose owned paths cover the whole diff | records the engineer's seal. **Voided by the next commit** |
+| `/review` | anyone | an advisory LLM read of the diff. Never gates anything |
+| `/expedite` | admin only, and it requires a stated reason | skips certification and lets the PR merge once the pipeline's own checks pass. Purely administrative, and it announces itself on the PR |
+
+`/expedite` exists because a release should not be hostage to a GPU box being
+busy. It is deliberately loud: it mints its own check run, posts a comment naming
+who used it and why, and the reason is required rather than optional.
 
 The asymmetry in the table is the part worth reading twice. **A seal survives
 `main` moving** — the sealer vouched for this diff, and the queue re-runs

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1184,3 +1184,58 @@ value is in reviewing the unsafe, not in annotating it.
 
 **Not defects, checked:** the three tracked `.log` files under
 `docs/campaigns/**/raw/` are deliberate benchmark evidence, not stray artefacts.
+
+---
+
+## Wave 27 — three of the five commands existed only in a workflow file
+
+**Two digs clean, recorded so they are not repeated:**
+
+| dig | scale | result |
+|---|---|---|
+| every action SHA-pinned | 101 `uses:` across 24 workflows | 0 unpinned |
+| composite actions' **internal** `uses:` pinned | 5 composites fetched and parsed | 0 unpinned |
+| mdBook pages on disk vs linked from `SUMMARY.md` | 38 pages | 38 linked, 0 orphaned, 0 missing |
+
+The composite check is the one worth keeping: `sha_pinning_required` is a
+ruleset on *this* repo's workflow files and says nothing about what a composite
+action does internally. This repo has already been bitten there — the SPDX job
+carries a comment explaining that `apache/skywalking-eyes/header` was dropped
+because it internally used an unpinned `actions/setup-go@v5`. All five current
+composites are clean.
+
+**Then the dig that landed, in the place I was most likely to have caused
+damage.** Nine commits of this record changed who may stamp, added `/expedite`,
+and changed what `/seal` does. So: does the documentation still describe the
+code?
+
+| command | accepted by the bot | in the README |
+|---|---|---|
+| `/help` | yes | **no** |
+| `/stamp` | yes | yes, but **wrong** — said "anyone with write access", omitting the PR author |
+| `/seal` | yes | yes |
+| `/review` | yes | **no** |
+| `/expedite` | yes | **no** |
+
+**`/expedite` is the one that matters.** It skips certification and lets a PR
+merge on the pipeline's own checks — an administrative override discoverable
+only by reading a workflow file. Every one of these gaps was introduced by this
+record's own waves, one commit at a time, and no single change looked like it
+was leaving something out. That is how documentation drift actually happens: not
+by neglect, but by a sequence of individually reasonable edits.
+
+Fixed: the `/stamp` line now states the author rule and why it exists, and all
+five commands are documented in a table with who may use each and what survives
+a new commit.
+
+**The guard reads the handler's own `case` arm rather than restating the verb
+list.** A second hand-maintained list would drift from the first exactly the way
+the README drifted from the handler. Run against the README as it stood, it
+names `/help`, `/review` and `/expedite` and refuses.
+
+**Three controls, and the third is the one that earns its place.** A complete
+README passes; a missing verb is caught; and if the `case` arm is renamed or
+restructured so the guard cannot find its input, it **refuses** rather than
+finding nothing and reporting success. A guard that silently passes when it
+cannot locate what it checks is the precise failure this suite exists to catch,
+and it would be an embarrassing one to ship in the guard that checks for it.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1333,6 +1333,11 @@ job, must not attempt a re-run, and must not post the warning.
 
 ## Wave 30 — out of CI and into the product: an OOB write guarded only by `debug_assert!`
 
+> The code for waves 30 and 31 landed separately in #866: both fixes touch
+> `crates/`, which re-opens all 11 gates, and holding this record behind a GPU
+> campaign would have been the tail wagging the dog. These entries are the
+> record; #866 is the diff.
+
 **The defect (#799), and it is the most serious thing in this record.** A single
 video request wrote **4.7× past** the ViT output allocation, raised
 `CUDA_ERROR_ILLEGAL_ADDRESS` and poisoned the CUDA context. The process survived

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1147,3 +1147,40 @@ The `unit` job now refuses if a `*.test.*` file exists outside `src/lib` in
 either tree. It belongs in that job precisely because that is the job which
 would otherwise silently lose the test. Planting one is caught; removing it is
 clean again.
+
+---
+
+## Wave 26 — seven digs, nothing found
+
+No defect this wave. The record of where the ground was broken and found solid
+is the deliverable, because the alternative is re-digging it later.
+
+| dig | scale | result |
+|---|---|---|
+| install URL: canary vs what the website tells users | 2 URLs | agree |
+| install endpoints live | `install.sh`, `install.ps1` | both 200, correct content-types |
+| installer is POSIX, as its `#!/bin/sh` claims | 606 lines | `dash -n` clean — no bashisms |
+| **served installer vs its source of truth** | 2 files | **byte-identical** |
+| committed secrets | 4500 tracked files, 6 patterns | none |
+| security reporting actually reachable | `security@avarok.net` | valid Protonmail MX; private reporting, secret scanning and push protection all enabled |
+| orphaned assets over 500 KB | whole tree | none; the 14 MB demo GIF and 6 MB MP4 are both referenced by the README |
+
+**One scare, resolved by looking.** Neither `install.sh` nor `install.ps1` is in
+this repository, which for a script every user pipes into `sh` looked like an
+unversioned, unreviewed artefact. It is not: both live in
+`Avarok-Cybersecurity/atlas-recipes` under `scripts/`, with a 24 KB test suite
+beside them, and the served copies are byte-identical to source. Worth recording
+because "the installer is not in this repo" is true, alarming, and wrong as a
+conclusion.
+
+**One real gap, deliberately not closed.** 415 of 600 first-party `unsafe` sites
+(69%, excluding vendored `cudarc`) carry no SAFETY note within six lines. The
+Rust API guidelines want one on each. Retrofitting 415 comments across a CUDA
+FFI codebase is a large mechanical diff that would not make a single one of them
+more correct — it is the busywork this record exists to displace, and doing it
+would bury the waves that found something. Written down as a known gap for
+whoever decides it is worth a dedicated pass, with the honest note that the
+value is in reviewing the unsafe, not in annotating it.
+
+**Not defects, checked:** the three tracked `.log` files under
+`docs/campaigns/**/raw/` are deliberate benchmark evidence, not stray artefacts.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1383,3 +1383,76 @@ before the timeout fires. **I did not capture the actual message**, so the cause
 is unexplained rather than diagnosed, and it is filed as such. `cargo test
 --workspace` is a required context, which makes this a latent source of red
 builds that has nothing to do with the change under review.
+
+---
+
+## Wave 31 — a second bound asserted in prose, and a flake I could not reproduce
+
+**Defect (#842): a json_schema request killed the scheduler thread three times
+in one day.** The API kept accepting requests and logging sessions, generated
+nothing ever again, and `/v1/models` still answered — so the server looked
+healthy while being dead. Only a restart recovered it.
+
+```
+cannot roll back 96 tokens: only 1 steps recorded
+```
+
+**The diagnosis came from the codebase disagreeing with itself.** Four
+production callers rewind the grammar matcher. Three of them —
+`spec_step.rs:462→470` and `verify_pipeline_helper.rs:343→391` and `503→548` —
+capture `num_history_steps()` before the span and pass the *delta*. One, the
+watchdog path, passed a raw count of **sequence** tokens. The crate already
+documents why that is wrong, on `num_history_steps` itself, calling it BUG#3:
+`accept_token` returns `true` for stop/EOS and in the **terminated** state
+without advancing the matcher. A `json_schema` matcher terminates the moment its
+object closes, so every token after that records nothing — 96 dropped against 1
+recorded step.
+
+The comment above the call stated the precondition that had stopped holding:
+
+> every dropped token ... was therefore fed to `grammar_state.accept_token`, so
+> `rollback(dropped)` is exact.
+
+That is wave 30's defect again, one crate over: **a bound asserted in prose**.
+Two waves, two outages, both from a comment standing where a check belonged.
+
+**`min(dropped, steps)` was considered and rejected**, and the reasoning is
+pinned in a test so a later "helpful" clamp has to argue with it: with a
+terminated matcher the recorded steps belong to tokens that are being **kept**,
+so a partial rewind corrupts state that the panic at least left visible.
+Refusing is the honest answer and is the correct one in the reported case —
+those 96 tokens advanced the matcher zero times.
+
+**The control is the tempting wrong fix.** Changing refuse to clamp turns three
+of the four tests red — and leaves `an_accountable_span_still_rewinds_exactly`
+green, because clamping and refusing genuinely agree when `dropped ≤ steps`.
+A control that reddened all four would have been measuring less, not more.
+
+**Two process failures of my own this wave, both recorded because they nearly
+cost something.**
+
+1. `cargo test -p spark-server --lib scheduler::rollback` printed
+   **`ok. 0 passed; 104 filtered out`**. `mod scheduler` belongs to the *binary*
+   target, not the lib, so `--lib` could never contain those tests — and cargo
+   reports that as success. That is the "a passing test may not have run" trap,
+   and it was caught only by noticing the count was zero.
+2. The sabotage run was killed mid-build (exit 137, OOM under parallel `rustc`)
+   **after** writing the sabotage and **before** restoring it. The clamp sat in
+   the working tree until the next command checked. Re-run under a `trap ...
+   EXIT INT TERM` and `-j 6`, which is how a destructive edit should have been
+   written the first time.
+
+**#858 — the flake — could not be reproduced.** 24 concurrent copies of the test
+binary: 0 failures. Full suite under 40 CPU-burn processes on 20 cores, ×4: 0
+failures. Full suite immediately after a forced rebuild and relink, ×2: 0
+failures. Env-var races are ruled out (`FfmpegPolicy` reads no env; the crate
+has no `set_var` in tests, deliberately) and temp-path collision is ruled out
+(keyed on pid+seq). The remaining untested hypothesis is memory/IO pressure from
+a **cold** full release build, which is what the three original failures ran
+under. The message was never captured, so the cause stays unexplained and the
+issue says so.
+
+I also had to correct myself publicly on that issue: a first "reproduced 3/3
+under load" was `grep -q a_hanging_decoder`, which matches the **passing**
+`test ... ok` line. Fourth checker bug of this record, same shape as the other
+three.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1239,3 +1239,42 @@ restructured so the guard cannot find its input, it **refuses** rather than
 finding nothing and reporting success. A guard that silently passes when it
 cannot locate what it checks is the precise failure this suite exists to catch,
 and it would be an embarrassing one to ship in the guard that checks for it.
+
+---
+
+## Wave 28 — five digs, nothing found, and a pattern in my own tooling
+
+No defect this wave.
+
+| dig | scale | result |
+|---|---|---|
+| every CODEOWNERS principal exists | 4 users | all exist; 3 write, 1 admin |
+| ...and holds write access | 4 users | yes — a codeowner without write could never seal |
+| commented CODEOWNERS rules are ignored | both parsers | `seal-coverage.py` refuses, `codeowners.rs` splits on `#` |
+| issue forms are valid | 3 templates | 0 problems; blank issues disabled |
+| the security contact link resolves | 1 link | HTTP 200 |
+
+**The CODEOWNERS comment test is the one that was worth running.** A first sweep
+reported `@someone-else` as a code owner — a placeholder-shaped name that turns
+out to be a **real GitHub user** with read access. It is inside a comment, as an
+illustrative example, so GitHub ignores it. But the question it raised was real:
+if my sweep was fooled by a comment, is the code that decides seal coverage? A
+commented-out rule honoured as live would grant a seal nobody granted. Both
+parsers were checked directly against a fixture whose only grant is commented
+out; both refuse. No defect, and now demonstrated rather than assumed.
+
+**A pattern across this record worth naming.** Three separate throwaway checkers
+written during these waves have been wrong, and each time the error was found by
+questioning a suspicious finding rather than by reading the code:
+
+| wave | my checker's bug | how it surfaced |
+|---|---|---|
+| 24 | `lstrip("./")` stripped the dot from `.github` | 14 "missing" scripts that obviously existed |
+| 24 | resolved `/images/...` against the filesystem, not the site root | blog images "missing" from a working blog |
+| 28 | treated a commented CODEOWNERS line as a rule | a placeholder-looking owner nobody had added |
+
+Across waves 24 and 28 the first-pass sweeps produced 19 and 1 findings of which
+2 and 0 were real. **The finding rate of an unverified sweep is not its defect
+rate**, and the gap is large enough that acting on a raw sweep would have meant
+mostly fixing things that were not broken. Every guard that survived into CI did
+so only after being run against the defect it claims to catch.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1278,3 +1278,53 @@ Across waves 24 and 28 the first-pass sweeps produced 19 and 1 findings of which
 rate**, and the gap is large enough that acting on a raw sweep would have meant
 mostly fixing things that were not broken. Every guard that survived into CI did
 so only after being run against the defect it claims to catch.
+
+---
+
+## Wave 29 — the fix from wave 20 found the next defect, in production, within the hour
+
+**First, a dig that came back clean, and stronger than clean.** The 599
+committed benchmark records were checked against the gate's own cutover rule
+(`SIGNATURE_REQUIRED_AFTER = 1_788_268_400`): 11 records fall after it and **all
+11 carry a sidecar**; 588 fall before it and none does; no record has an
+unusable timestamp; one signer fingerprint is registered.
+
+Then the part worth having done: all 11 signatures were verified **with an
+independent implementation** — Python's `cryptography`, reconstructing the
+signed message from `signing.rs` (`record_bytes || git_sha`) rather than
+trusting the Rust that produced them. **11 verify, 0 do not.** Cross-
+implementation agreement is a materially stronger statement than the gate
+re-checking its own arithmetic, and it is the kind of check worth doing once
+rather than gating on.
+
+**Then the wave's real finding, and its provenance is the point.** Wave 20 fixed
+`/stamp` discarding the API's error. #856 was the first PR stamped with that fix
+live. The warning it produced said:
+
+```
+403 "This workflow is already running"
+```
+
+**Not** the missing `actions: write` that wave 20 had inferred. The CI run was
+`queued` — stamping while CI is in flight *always* 403s, and that is not a
+failure at all: a run still in flight reads the mark when its gate jobs execute,
+so there is nothing to re-run. The handler was raising a red job and a scary
+warning for the ordinary case of stamping a PR shortly after opening it.
+
+Two things follow, and both are worth stating plainly:
+
+1. **Wave 20's stated cause was at best incomplete.** The reasoning there —
+   "my PAT can re-run this, the App cannot, therefore `actions: write`" — was
+   inference from a discarded error. On the run in question (already *completed*)
+   it may well be right. As a general diagnosis of "the re-run failed" it was
+   not, and the record should not read as though it were.
+2. **The fix paid for itself immediately.** The only reason this is known is
+   that wave 20 made the handler print what the API actually said. A guard that
+   surfaces evidence keeps finding things after the wave that built it has
+   ended; one that only reports a verdict does not.
+
+Fixed: the handler now reads the run's `status` alongside its id, and a run that
+is not `completed` produces a calm `::notice` explaining that its gate jobs will
+read the mark, instead of a re-run attempt that cannot succeed. Three controls,
+all three red when the check is reverted: stamping mid-run must not fail the
+job, must not attempt a re-run, and must not post the warning.

--- a/docs/ROBUSTNESS.md
+++ b/docs/ROBUSTNESS.md
@@ -1328,3 +1328,58 @@ is not `completed` produces a calm `::notice` explaining that its gate jobs will
 read the mark, instead of a re-run attempt that cannot succeed. Three controls,
 all three red when the check is reverted: stamping mid-run must not fail the
 job, must not attempt a re-run, and must not post the warning.
+
+---
+
+## Wave 30 — out of CI and into the product: an OOB write guarded only by `debug_assert!`
+
+**The defect (#799), and it is the most serious thing in this record.** A single
+video request wrote **4.7× past** the ViT output allocation, raised
+`CUDA_ERROR_ILLEGAL_ADDRESS` and poisoned the CUDA context. The process survived
+and answered `503` to every subsequent request, **for every tenant**, until
+someone restarted it.
+
+The bound existed. It was a `debug_assert!` — compiled out of the `--release`
+binaries we serve. So in production there was no bound at all, only a comment
+saying there was one:
+
+> The scheduler caps Σp ≤ p_max so this is normally unreachable — a correctness
+> guard only.
+
+Video defeats that cap. All temporal groups of one clip arrive as a **single**
+media item and encode as one batch, so the per-item cap never sees the sum: 19
+groups of 30×34 patches merge to 4845 rows against a 1024-row buffer.
+
+**Fixed** by promoting the bound to a pure free function returning `Result`,
+mirroring `check_pixel_len` in the sibling file — whose own doc comment already
+observed that `forward_oversized_fallback` "bounds Σ*merged* p and not per-image
+`p`", and closes with the line this wave earned: *prose is not a bound; this
+is.* Two further hazards closed on the way: the old expression reached
+`mp_i.last().unwrap()` whenever `mp_off` was non-empty, so a length mismatch was
+a panic rather than an error; and the sum now uses `checked_add`, so an
+overflowing offset cannot wrap into a passing comparison.
+
+**The control is the bug's own shape, and it only means anything in release.**
+Four tests, run under `--release`. Restoring `debug_assert!` makes two of them
+**fail in release and pass in debug** — which is precisely the blindness that
+caused the outage, and precisely what a debug-only test can never catch. The
+issue asked for exactly this and named why.
+
+**Scope, stated plainly.** This is the issue's fix (1): the outage. Fix (2) —
+chunking the encode so long videos *work* rather than being refused — is not
+done here. Video is now a clean per-request error instead of a multi-tenant
+outage, which is strictly better and still not "video works".
+
+**A second, separate defect found while verifying the first.**
+`video_decode_ffmpeg::tests::a_hanging_decoder_is_killed_at_timeout` fails
+intermittently in the full `--release` suite: three consecutive failures under
+post-build load, then three consecutive passes on an idle machine, **with and
+without this wave's change** (639+1 failing before it, 643+1 after — the four
+extra are this wave's). It is therefore pre-existing and not caused here.
+
+The panic is on the *message* assertion (`err.contains("decoding exceeded 1s")`),
+not the elapsed-time one, so under load the decode fails for some other reason
+before the timeout fires. **I did not capture the actual message**, so the cause
+is unexplained rather than diagnosed, and it is filed as such. `cargo test
+--workspace` is a required context, which makes this a latent source of red
+builds that has nothing to do with the change under review.


### PR DESCRIPTION
Follow-on to #847. Three waves: one real defect, two empty and recorded as empty.

## The defect

The bot accepts five comment commands. Three of them appeared **nowhere** in the README, and the fourth was documented wrongly:

| command | accepted | in README before this |
|---|---|---|
| `/help` | yes | **no** |
| `/stamp` | yes | yes, but **wrong** — said "anyone with write access", omitting the PR-author rule |
| `/seal` | yes | yes |
| `/review` | yes | **no** |
| `/expedite` | yes | **no** |

`/expedite` is the one that matters: it **skips certification** and lets a PR merge on the pipeline's own checks — an administrative override discoverable only by reading a workflow file.

Every one of these gaps was introduced by #847's own commits, one at a time, and no single change looked like it was leaving something out. That is how documentation drift actually happens: not neglect, but a sequence of individually reasonable edits.

Fixed: the `/stamp` line now states the author rule and why it exists, and all five commands are documented in a table giving who may use each and what survives a new commit.

## The guard

`assert-commands-documented.py` reads the handler's own `case` arm rather than restating the verb list — a second hand-maintained list would drift from the first exactly the way the README drifted from the handler. Run against the README as it stood, it names `/help`, `/review` and `/expedite` and refuses.

Three controls. A complete README passes; a missing verb is caught; and **if the `case` arm is renamed so the guard cannot find its input, it refuses rather than finding nothing and reporting success.** Shipping that failure mode inside the guard built to catch it would have been a poor joke.

Hosted in `SPDX license headers` — a required context, and already a repo-wide file lint.

## Two empty waves, recorded as empty

Recorded so the same ground is not broken again:

| dig | scale | result |
|---|---|---|
| install URL: canary vs what the website tells users | 2 URLs | agree |
| install endpoints live | `.sh`, `.ps1` | 200, correct content-types |
| installer is POSIX as its shebang claims | 606 lines | `dash -n` clean |
| **served installer vs its source in `atlas-recipes`** | 2 files | **byte-identical** |
| committed secrets | 4500 tracked files, 6 patterns | none |
| security contact reachable | `security@avarok.net` | valid MX; private reporting + push protection on |
| orphaned assets >500 KB | whole tree | none |
| every action SHA-pinned | 101 `uses:` | 0 unpinned |
| composite actions' **internal** `uses:` | 5 composites parsed | 0 unpinned |
| mdBook pages vs `SUMMARY.md` | 38 pages | 0 orphaned, 0 missing |
| CODEOWNERS principals exist and hold write | 4 users | all do |
| commented CODEOWNERS rules ignored | both parsers | both refuse correctly |
| issue forms valid | 3 templates | 0 problems |

**One scare, resolved by looking.** Neither `install.sh` nor `install.ps1` is in this repo, which for a `curl | sh` target looked unversioned and unreviewed. Both live in `atlas-recipes/scripts` with a 24 KB test suite, and the served bytes match source exactly.

**One real gap deliberately not closed.** 415 of 600 first-party `unsafe` sites (excluding vendored `cudarc`) carry no SAFETY note. Retrofitting 415 comments would not make one of them more correct, and it would bury the waves that found something. Documented as a known gap for a dedicated review pass.

## A note on method

Three throwaway checkers written during these waves were wrong — `lstrip("./")` stripping the dot from `.github`, site-root URLs resolved against the filesystem, and a commented CODEOWNERS line read as a rule. Two sweeps returned 19 and 1 findings of which 2 and 0 were real. **The finding rate of an unverified sweep is not its defect rate.** Every guard that reached CI did so only after being run against the defect it claims to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
---

## Split note

This PR originally carried two Rust fixes as well. They touch `crates/`, which re-opened all 11 benchmark gates, so **the code moved to #866** and this PR is docs/CI only — it touches zero files under `crates/` and its gates stay closed.

`docs/ROBUSTNESS.md` here records waves 26–31, including the two waves whose code is in #866. The record and the diff landing in different PRs is deliberate: holding a finished record behind a 5-hour GPU campaign would be the tail wagging the dog, and the entries say where the code went.

Also added since the original description: wave 29's fix for `/stamp` warning about a benign in-flight CI run — found in production the first time wave 20's fix printed what the API actually said (`403 "This workflow is already running"`, not the missing `actions: write` that had been inferred from a discarded error).