### PR TITLE
Two bounds asserted in prose: an OOB write (#799) and a scheduler panic (#842)

### DIFF
--- a/crates/spark-model/src/layers/vision_encoder/enc_impl/forward.rs
+++ b/crates/spark-model/src/layers/vision_encoder/enc_impl/forward.rs
@@ -12,6 +12,47 @@ use spark_runtime::gpu::GpuBackend;
 
 use super::super::VisionEncoder;
 
+/// Do the packed merged rows this batch will write fit `buf_out`?
+///
+/// #799: this bound existed as a `debug_assert!`, which is compiled out of the
+/// `--release` binaries we serve. A single video request then wrote 4.7x past
+/// the allocation, raising `CUDA_ERROR_ILLEGAL_ADDRESS` and poisoning the CUDA
+/// context — the process survived and answered 503 to every later request, for
+/// every tenant, until it was restarted.
+///
+/// The caller's own doc comment says the scheduler caps `Σp <= p_max` "so this
+/// is normally unreachable". Video defeats that cap: all temporal groups of one
+/// clip arrive as a SINGLE media item and are encoded as one batch, so the
+/// per-item cap never sees the sum. 19 groups of 30x34 patches merge to 4845
+/// rows against a 1024-row buffer.
+///
+/// A `Result` rather than an assert, and a free function rather than a method,
+/// for the same reason `check_pixel_len` next door is one: the refusal is the
+/// behaviour worth testing, and a bound that can only be exercised with a GPU
+/// attached is a bound nothing will exercise. Prose is not a bound; this is.
+fn check_packed_rows(mp_i: &[usize], mp_off: &[usize], p_max: usize) -> Result<()> {
+    anyhow::ensure!(
+        mp_i.len() == mp_off.len(),
+        "vision: {} merged row counts but {} offsets; the packed layout is inconsistent",
+        mp_i.len(),
+        mp_off.len()
+    );
+    let end = match (mp_off.last(), mp_i.last()) {
+        (Some(off), Some(n)) => off
+            .checked_add(*n)
+            .ok_or_else(|| anyhow::anyhow!("vision: merged row offset {off} + {n} overflows"))?,
+        _ => 0,
+    };
+    anyhow::ensure!(
+        end <= p_max,
+        "vision: this batch packs {end} merged rows into an output buffer of {p_max} rows. \
+         A video arrives as one media item whose temporal groups encode as a single batch, \
+         which defeats the scheduler's per-item cap. Send fewer frames, or allocate a \
+         larger vision scratch."
+    );
+    Ok(())
+}
+
 impl VisionEncoder {
     /// Single-image forward (back-compat shim). For N=1 this issues the SAME
     /// kernels with the SAME args in the SAME order as the old per-image path
@@ -246,10 +287,7 @@ impl VisionEncoder {
         gpu: &dyn GpuBackend,
         stream: u64,
     ) -> Result<Vec<(usize, usize, usize)>> {
-        debug_assert!(
-            mp_off.last().map(|o| o + mp_i.last().unwrap()).unwrap_or(0) <= self.p_max,
-            "oversized vision batch: Σmerged_p exceeds buf_out rows"
-        );
+        check_packed_rows(mp_i, mp_off, self.p_max)?;
         let pos_interp_on = std::env::var("ATLAS_VISION_POSINTERP")
             .map(|v| v != "0")
             .unwrap_or(true);
@@ -290,5 +328,67 @@ impl VisionEncoder {
             .iter()
             .map(|(_px, gh, gw)| (gh / sms, gw / sms, (gh * gw) / (sms * sms)))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_packed_rows;
+
+    /// The batch from issue #799, with its real numbers. A Qwen3.8-27B serve at
+    /// `--vision-max-pixels 262144` allocates 1024 patch rows; one video of 19
+    /// temporal groups at 30x34 patches merges 2x2 to 255 rows per group, so
+    /// the packed write ends at 4845 — 4.7x the allocation.
+    ///
+    /// Before this check that write happened, in release, and poisoned the CUDA
+    /// context: the server then answered 503 to every request, for every
+    /// tenant, until restarted. It must now be a refused request instead.
+    #[test]
+    fn refuses_the_video_batch_that_poisoned_the_cuda_context() {
+        let groups = 19;
+        let merged_per_group = (30 / 2) * (34 / 2); // 255
+        let mp_i = vec![merged_per_group; groups];
+        let mp_off: Vec<usize> = (0..groups).map(|g| g * merged_per_group).collect();
+        assert_eq!(mp_off.last().unwrap() + mp_i.last().unwrap(), 4845);
+
+        let err = check_packed_rows(&mp_i, &mp_off, 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("4845"),
+            "must name the rows it would have written: {err}"
+        );
+        assert!(err.contains("1024"), "must name the capacity: {err}");
+    }
+
+    /// The ordinary path the scheduler's cap produces must still pass, or the
+    /// fix trades an outage for a refusal of every image request.
+    #[test]
+    fn admits_a_batch_that_fits() {
+        assert!(check_packed_rows(&[100, 200], &[0, 100], 1024).is_ok());
+        // Exactly full is not over-full.
+        assert!(check_packed_rows(&[24], &[1000], 1024).is_ok());
+        // One row past is.
+        assert!(check_packed_rows(&[25], &[1000], 1024).is_err());
+    }
+
+    /// An empty batch writes nothing. The previous expression reached
+    /// `mp_i.last().unwrap()` whenever `mp_off` was non-empty, so a length
+    /// mismatch was a panic rather than an error.
+    #[test]
+    fn handles_empty_and_mismatched_layouts_without_panicking() {
+        assert!(check_packed_rows(&[], &[], 1024).is_ok());
+        let err = check_packed_rows(&[], &[0], 1024).unwrap_err().to_string();
+        assert!(err.contains("inconsistent"), "{err}");
+    }
+
+    /// `usize` addition on attacker-influenced geometry must not wrap into a
+    /// passing comparison.
+    #[test]
+    fn an_overflowing_offset_is_an_error_not_a_wrap() {
+        let err = check_packed_rows(&[2], &[usize::MAX - 1], 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("overflows"), "{err}");
     }
 }

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -403,12 +403,25 @@ fn apply_rollback(a: &mut ActiveSeq, keep_len: usize, dropped: usize) {
     // 5. Rewind the grammar FSM by the same token count so the
     //    constrained-decoding matcher stays in sync with the truncated
     //    token stream. Every dropped token is a post-`</think>` content
-    //    token (the watchdogs that call this fire after thinking has
-    //    closed) and was therefore fed to `grammar_state.accept_token`,
-    //    so `rollback(dropped)` is exact. Reuses the existing
-    //    spec-decode grammar-rewind path (`GrammarState::rollback`).
+    //    token, so it was fed to `grammar_state.accept_token`.
+    //
+    //    That did NOT make `rollback(dropped)` exact, and #842 is what it
+    //    cost: `accept_token` returns true for stop/EOS and in the TERMINATED
+    //    state without advancing the matcher, so a `json_schema` matcher that
+    //    has already closed its object records no steps for the tokens that
+    //    follow. One report dropped 96 tokens against 1 recorded step; the
+    //    assert inside the matcher then panicked the scheduler thread and the
+    //    server accepted requests forever without generating.
     if let Some(ref mut gs) = a.grammar_state {
-        gs.rollback(dropped);
+        match grammar_rewind(dropped, gs.num_history_steps()) {
+            Some(n) => gs.rollback(n),
+            None => tracing::warn!(
+                "grammar rollback skipped: {dropped} tokens dropped but the matcher \
+                 recorded only {} steps. Constrained output may drift for this \
+                 sequence; it is not a reason to kill the scheduler (#842).",
+                gs.num_history_steps()
+            ),
+        }
     }
 
     // 6. Reset the watchdog accumulators so the just-cleared window does
@@ -448,6 +461,32 @@ pub trait RomHead: Send + Sync {
 // A trained ROM head belongs to the MODEL that was trained with it, so the
 // seam is `SchedCtx::rom_head` rather than a process global — correct by
 // construction before the artifact loader lands, rather than after.
+
+/// How far to rewind the grammar matcher for `dropped` sequence tokens.
+///
+/// `None` means "do not rewind at all": the caller's count cannot be reconciled
+/// with the matcher's history, so any rewind would be a guess.
+///
+/// The three speculative-decode callers of `GrammarState::rollback` all pass a
+/// delta of `num_history_steps()` measured across the span they are undoing —
+/// see `spec_step.rs` and `verify_pipeline_helper.rs`. The watchdog path passed
+/// a raw count of sequence tokens instead, and `accept_token` returns true
+/// without advancing the matcher for stop/EOS tokens and in the terminated
+/// state. A `json_schema` matcher terminates as soon as its object closes, so
+/// every token after that is a token the matcher never recorded.
+///
+/// Rewinding `min(dropped, steps)` was rejected: with a terminated matcher the
+/// recorded steps belong to tokens that are being KEPT, so a partial rewind
+/// would corrupt the state that a panic at least left visible. Refusing is the
+/// honest answer, and it is the correct one in the reported case — those 96
+/// tokens genuinely advanced the matcher zero times.
+///
+/// This removes the outage. It does not make the accounting exact; that needs
+/// the anchor the speculative paths have, captured where the droppable window
+/// begins.
+fn grammar_rewind(dropped: usize, history_steps: usize) -> Option<usize> {
+    (dropped <= history_steps).then_some(dropped)
+}
 
 #[cfg(test)]
 #[path = "rollback_tests.rs"]

--- a/crates/spark-server/src/scheduler/rollback_tests.rs
+++ b/crates/spark-server/src/scheduler/rollback_tests.rs
@@ -257,3 +257,48 @@ fn rom_head_absent_by_default() {
             .is_none()
     );
 }
+
+/// #842: the watchdog path rewound the grammar matcher by a count of SEQUENCE
+/// tokens, while the matcher only records a step for tokens that actually
+/// advanced it. `accept_token` returns true for stop/EOS and in the terminated
+/// state without advancing, so a `json_schema` matcher that has closed its
+/// object records nothing for the tokens that follow.
+///
+/// The reported panic was `cannot roll back 96 tokens: only 1 steps recorded`,
+/// raised by an `assert!` inside the matcher — on the scheduler thread. The
+/// server then accepted requests forever and generated nothing, looking healthy
+/// from `/v1/models`, until it was killed.
+#[test]
+fn the_reported_mismatch_refuses_to_rewind_instead_of_panicking() {
+    // Both reported occurrences, with their real numbers.
+    assert_eq!(super::grammar_rewind(96, 1), None);
+    assert_eq!(super::grammar_rewind(88, 1), None);
+}
+
+/// The ordinary case must still rewind, or the fix trades a crash for grammar
+/// state that silently stops tracking the token stream.
+#[test]
+fn an_accountable_span_still_rewinds_exactly() {
+    assert_eq!(super::grammar_rewind(4, 4), Some(4));
+    assert_eq!(super::grammar_rewind(4, 9), Some(4));
+    assert_eq!(super::grammar_rewind(0, 0), Some(0));
+}
+
+/// One step short is still short. The boundary is where an off-by-one would
+/// reintroduce the panic, since the matcher asserts `n <= history`.
+#[test]
+fn the_boundary_is_inclusive_on_the_safe_side() {
+    assert_eq!(super::grammar_rewind(5, 5), Some(5));
+    assert_eq!(super::grammar_rewind(6, 5), None);
+}
+
+/// A partial rewind was considered and rejected. With a terminated matcher the
+/// recorded steps belong to tokens that are being KEPT, so `min(dropped, steps)`
+/// would rewind past the truncation point and corrupt state that the panic at
+/// least left visible. This pins the decision so a later "helpful" clamp has to
+/// argue with it.
+#[test]
+fn it_does_not_silently_clamp_to_the_available_history() {
+    assert_ne!(super::grammar_rewind(96, 1), Some(1));
+    assert_eq!(super::grammar_rewind(96, 1), None);
+}


### PR DESCRIPTION
Closes nothing on its own — both issues stay open for their second halves, described below.

Two production outages, found in the open issues, with the **same shape**: a bound that existed only as a comment or as an assertion the release build strips.

## #799 — a video request wrote 4.7× past `buf_out` and poisoned the CUDA context

One video request raised `CUDA_ERROR_ILLEGAL_ADDRESS` and poisoned the context. The process **stayed alive** and answered `503` to every later request, for every tenant, until restarted.

The bound existed — as a `debug_assert!`, compiled out of the `--release` binaries we serve. So production had no bound, only a comment claiming one:

> The scheduler caps Σp ≤ p_max so this is normally unreachable — a correctness guard only.

Video defeats that cap: all temporal groups of a clip arrive as **one** media item and encode as one batch, so the per-item cap never sees the sum. 19 groups of 30×34 patches merge to 4845 rows against a 1024-row buffer.

`check_packed_rows` is now a pure free function returning `Result`, mirroring `check_pixel_len` in the sibling file — whose doc comment had *already* observed that `forward_oversized_fallback` "bounds Σ*merged* p and not per-image `p`", and which ends with the line this earns: **prose is not a bound; this is.**

Two more hazards closed on the way: the old expression reached `mp_i.last().unwrap()` whenever `mp_off` was non-empty (a panic, not an error), and the sum now uses `checked_add` so an overflowing offset cannot wrap into a passing comparison.

**Control — and it only means anything in release.** Four tests run under `--release`. Restoring `debug_assert!` makes two of them **fail in release and pass in debug**, which is precisely the blindness that caused the outage and precisely what a debug-only test can never catch.

```
release, ensure!:        4 passed; 0 failed
release, debug_assert!:  2 passed; 2 FAILED
```

## #842 — a `json_schema` request killed the scheduler thread, silently

Three times in one day. The API kept accepting requests and logging sessions, generated nothing ever again, and `/v1/models` still answered — so the server looked healthy while being dead.

```
cannot roll back 96 tokens: only 1 steps recorded
```

**Diagnosed by the codebase disagreeing with itself.** Four callers rewind the grammar matcher. Three pass a *delta* of `num_history_steps()` across the span they undo (`spec_step.rs:462→470`, `verify_pipeline_helper.rs:343→391` and `503→548`). The fourth — the watchdog path — passed a raw count of **sequence** tokens. The crate already documents why that is wrong, on `num_history_steps` itself, as BUG#3: `accept_token` returns `true` for stop/EOS and in the **terminated** state without advancing the matcher. A `json_schema` matcher terminates the moment its object closes, so every token after that records nothing.

The comment above the call asserted the precondition that had stopped holding:

> every dropped token ... was therefore fed to `grammar_state.accept_token`, so `rollback(dropped)` is exact.

`grammar_rewind` is pure over two integers — testable with no model, scheduler or GPU. **`min(dropped, steps)` was considered and rejected**, and that reasoning is pinned in a test so a later "helpful" clamp has to argue with it: with a terminated matcher the recorded steps belong to tokens being **kept**, so a partial rewind corrupts state the panic at least left visible.

**Control is the tempting wrong fix.** Changing refuse to clamp:

```
refuse:  21 passed; 0 failed
clamp:   18 passed; 3 FAILED
```

The fourth test stays green under both — clamping and refusing genuinely agree when `dropped ≤ steps`. A control that reddened all four would have been measuring less, not more.

## Scope, stated plainly

Both are the **outage** half only.

- #799 fix (2) — chunking the encode so long videos *work* — is not done. Video is now a clean per-request error instead of a multi-tenant outage: strictly better, still not "video works".
- #842's accounting is still not exact; that needs the anchor the speculative paths have, captured where the droppable window begins. Constrained output may drift on an affected sequence, which is logged.

Both issues stay open for those halves.

## This PR owes a campaign

It touches `crates/`, so all 11 gates re-opened. Split out of #856 for exactly that reason — the docs and CI work there is certified-clean and shouldn't wait on 5 GPU-hours. The record entries for these two waves are in #856; the code is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc