### PR TITLE
atlas-core: partition Laguna parser contracts

### DIFF
--- a/crates/atlas-core/src/config/parsers/laguna.rs
+++ b/crates/atlas-core/src/config/parsers/laguna.rs
@@ -211,11 +211,17 @@ mod tests {
 
     #[test]
     fn rejects_missing_per_layer_heads() {
-        let invalid = CONFIG.replace(
-            "\"num_attention_heads_per_layer\": [48, 72]",
-            "\"num_attention_heads_per_layer\": []",
+        let mut invalid: serde_json::Value =
+            serde_json::from_str(CONFIG).expect("parse Laguna fixture");
+        invalid
+            .as_object_mut()
+            .expect("Laguna fixture is an object")
+            .remove("num_attention_heads_per_layer");
+        let error = crate::config::parse_config(&invalid.to_string())
+            .expect_err("must reject missing heads");
+        assert_eq!(
+            error.to_string(),
+            "laguna num_attention_heads_per_layer must not be empty"
         );
-        let error = crate::config::parse_config(&invalid).expect_err("must reject missing heads");
-        assert!(error.to_string().contains("must not be empty"));
     }
 }

--- a/crates/atlas-core/src/config/parsers/laguna.rs
+++ b/crates/atlas-core/src/config/parsers/laguna.rs
@@ -52,7 +52,6 @@ pub(crate) fn parse_laguna(raw: &Value) -> Result<ModelConfig> {
         config.num_experts_per_tok > 0,
         "laguna num_experts_per_tok must be non-zero"
     );
-
     let max_heads = config
         .num_attention_heads_per_layer
         .iter()
@@ -162,25 +161,51 @@ mod tests {
         }
     }"#;
 
+    fn parse_fixture() -> crate::config::ModelConfig {
+        crate::config::parse_config(CONFIG).expect("parse laguna")
+    }
+
     #[test]
-    fn parses_heterogeneous_attention_and_moe() {
-        let config = crate::config::parse_config(CONFIG).expect("parse laguna");
+    fn parses_heterogeneous_attention_layout() {
+        let config = parse_fixture();
         assert_eq!(config.model_type, "laguna");
         assert_eq!(config.num_attention_heads, 72);
         assert_eq!(config.num_attention_heads_per_layer, [48, 72]);
+        assert_eq!(config.num_key_value_heads, 8);
+        assert_eq!(config.head_dim, 128);
         assert_eq!(
             config.layer_types,
             [LayerType::FullAttention, LayerType::SlidingAttention]
         );
-        assert_eq!(config.num_attention_layers(), 2);
-        assert_eq!(config.num_ssm_layers(), 0);
+        assert_eq!(config.sliding_window, 512);
+        assert_eq!(config.qk_norm_type, "per_head");
+    }
+
+    #[test]
+    fn parses_laguna_moe_contract() {
+        let config = parse_fixture();
         assert_eq!(config.mlp_only_layers, [0]);
-        assert_eq!(config.rotary_dim(), 64);
-        assert_eq!(config.yarn_factor, 32.0);
-        assert_eq!(config.yarn_attention_factor, 1.3465736);
+        assert_eq!(config.num_experts, 256);
+        assert_eq!(config.num_experts_per_tok, 10);
+        assert_eq!(config.moe_intermediate_size, 1024);
+        assert_eq!(config.shared_expert_intermediate_size, 1024);
+        assert!(config.norm_topk_prob);
         assert_eq!(config.scoring_func, "sigmoid");
         assert!(config.use_routing_bias);
         assert_eq!(config.routed_scaling_factor, 2.5);
+    }
+
+    #[test]
+    fn parses_laguna_rope_and_eos_contract() {
+        let config = parse_fixture();
+        assert_eq!(config.rope_theta, 500000.0);
+        assert_eq!(config.partial_rotary_factor, 0.5);
+        assert_eq!(config.rotary_dim(), 64);
+        assert_eq!(config.yarn_factor, 32.0);
+        assert_eq!(config.yarn_beta_slow, 1.0);
+        assert_eq!(config.yarn_beta_fast, 32.0);
+        assert_eq!(config.yarn_original_max_position_embeddings, 8192);
+        assert_eq!(config.yarn_attention_factor, 1.3465736);
         assert_eq!(config.eos_token_id, 2);
     }
 


### PR DESCRIPTION
## Summary

Two Laguna parser checks could pass while missing real defects. The heterogeneous smoke test combined attention layout, MoE routing, and RoPE in one check whose oracle ignored most of the runtime-facing values it parsed. The missing-heads rejection test never actually removed the key it claimed to remove.

## Problems found

`parses_heterogeneous_attention_and_moe` observed neither YaRN beta bound nor the parsed expert count. Reading `beta_fast` from the `beta_slow` key left it green even though Laguna's inverse-frequency builder uses both to place the YaRN correction ramp. Overwriting the parsed expert count from 256 to 1 also stayed green even though the loader iterates that count and passes it into `MoeLayer`.

`rejects_missing_per_layer_heads` edited the fixture to an explicit empty array, so the key stayed present. A missing-key-only fallback that copies the top-level head count across layers survived it: that mutant parses `[48, 48]` instead of the checkpoint's heterogeneous `[48, 72]` and makes the loader validate the second layer against the wrong projection widths.

## Repair

- Split the smoke check into three focused contracts: attention layout (per-layer heads, KV heads, head dim, layer types, sliding window, per-head QK norm), MoE (expert count, top-K, routed/shared widths, router normalization, sigmoid scoring, routing bias, scaling factor), and RoPE/EOS (theta, partial rotary factor, both beta bounds, original context length, attention factor).
- Rebuilt the missing-heads fixture as a JSON object with `num_attention_heads_per_layer` actually removed, and pinned the exact rejection reason.
- Removed the Laguna-local `num_attention_layers()`/`num_ssm_layers()` assertions; the generic method has its own sliding-attention regression tied to KV-pool and dtype-vector sizing, and this file directly owns Laguna's parsed `layer_types`.

## Failure proof (replayed on current main, 567b5ebe7)

- Reading `beta_fast` from `beta_slow`: `parses_laguna_rope_and_eos_contract` fails with `left: 1.0, right: 32.0`. Restored production passes.
- Missing-key fallback copying the top-level head count: `rejects_missing_per_layer_heads` fails with a successful parse carrying `num_attention_heads_per_layer: [48, 48]`. Restored production passes.

## Production consequence

Per-layer heads and head dimension determine Laguna projection shapes at load; expert geometry and routing fields configure loader loops and MoE kernels; full-attention RoPE fields feed `compute_yarn_inv_freq` and attention setup. These consumption ties are static traces of current source, not executed inference.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (130 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos`
- [x] `git diff --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (owned by Linux CI; this macOS host reaches Linux-only paths outside this diff)
- [ ] Tested against a real model / hardware (not applicable: test-only change, production untouched)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

Production is unchanged. This proves parsed-configuration contracts only: it does not build the YaRN frequency table, load weights, or run a Laguna model. The host table computation, uploaded bytes, and the separately hardcoded 10,000 sliding theta remain untested (tracked as GAP-LAG-0001 in the audit ledger). Both mutants above were re-executed against current main during this port, not carried forward from the original 2026-08-21 session.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
