### PR TITLE
atlas-core: strengthen DeepSeek V4 parser contracts

### DIFF
--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -371,22 +371,15 @@ mod mscale_contract_tests {
     // value is unchanged; asserted here as the sliding-theta contract.
     const SLIDING_ROPE_THETA_CONTRACT: f32 = 10000.0;
 
-    // Test 1 + Test 4: the DS4F config makes yarn_rope_mscale == 1.0 for EVERY
-    // runtime call site. All nine sites call `yarn_rope_mscale(ctx.config)` with
-    // this parsed config; the helper (spark-model) is unit-tested separately to
-    // return exactly 1.0 when the two mscale terms are equal. Here we prove the
-    // parser produces terms that force that: yarn_mscale == yarn_mscale_all_dim.
+    // The parser owns the DS4F field override. The spark-model helper tests own
+    // the resulting runtime ratio.
     #[test]
-    fn ds4f_forces_mscale_terms_equal_so_ratio_is_one() {
+    fn ds4f_parser_forces_both_mscale_terms_to_zero() {
         let c = parse_deepseek_v4(DS4F_CONFIG).expect("parse DS4F");
         assert_eq!(c.yarn_mscale, 0.0, "yarn_mscale must be forced to 0.0");
         assert_eq!(
             c.yarn_mscale_all_dim, 0.0,
             "yarn_mscale_all_dim must be forced to 0.0"
-        );
-        assert_eq!(
-            c.yarn_mscale, c.yarn_mscale_all_dim,
-            "equal terms => yarn_rope_mscale ratio == 1.0 (no 1.2772589 amplitude)"
         );
     }
 

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -383,11 +383,19 @@ mod mscale_contract_tests {
         );
     }
 
-    // Test 2: compress-path theta stays 160000.
+    // The compress path uses the checkpoint field, not the top-level theta or
+    // a memorized value from the published DS4F config.
     #[test]
-    fn ds4f_compress_theta_is_160000() {
+    fn ds4f_reads_checkpoint_compress_theta() {
         let c = parse_deepseek_v4(DS4F_CONFIG).expect("parse DS4F");
         assert_eq!(c.rope_theta, 160000.0, "compress rope_theta must be 160000");
+
+        let alternate = DS4F_CONFIG.replace(
+            "\"compress_rope_theta\": 160000",
+            "\"compress_rope_theta\": 234567",
+        );
+        let c = parse_deepseek_v4(&alternate).expect("parse alternate compress theta");
+        assert_eq!(c.rope_theta, 234567.0);
     }
 
     // Test 3: sliding-path theta contract is 10000 (compute.rs MAIN_ROPE_THETA,

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -393,11 +393,35 @@ mod mscale_contract_tests {
         assert_eq!(c.rope_theta, 234567.0);
     }
 
-    // Test 6: no unrelated YaRN defaults changed — factor/beta/original_max_pos
-    // still parse from the checkpoint exactly as before.
+    // These fields come from the checkpoint. The second partition keeps them
+    // distinct from the runtime fallback values.
     #[test]
-    fn ds4f_other_yarn_params_unchanged() {
+    fn ds4f_reads_checkpoint_yarn_scaling_parameters() {
         let c = parse_deepseek_v4(DS4F_CONFIG).expect("parse DS4F");
+        assert_eq!(c.yarn_factor, 16.0);
+        assert_eq!(c.yarn_beta_fast, 32.0);
+        assert_eq!(c.yarn_beta_slow, 1.0);
+        assert_eq!(c.yarn_original_max_position_embeddings, 65536);
+
+        let alternate = DS4F_CONFIG
+            .replace("\"factor\": 16", "\"factor\": 12.5")
+            .replace("\"beta_fast\": 32", "\"beta_fast\": 40")
+            .replace("\"beta_slow\": 1", "\"beta_slow\": 2")
+            .replace(
+                "\"original_max_position_embeddings\": 65536",
+                "\"original_max_position_embeddings\": 32768",
+            );
+        let c = parse_deepseek_v4(&alternate).expect("parse alternate YaRN parameters");
+        assert_eq!(c.yarn_factor, 12.5);
+        assert_eq!(c.yarn_beta_fast, 40.0);
+        assert_eq!(c.yarn_beta_slow, 2.0);
+        assert_eq!(c.yarn_original_max_position_embeddings, 32768);
+    }
+
+    #[test]
+    fn pre_release_rope_parameters_alias_is_supported() {
+        let pre_release = DS4F_CONFIG.replacen("\"rope_scaling\"", "\"rope_parameters\"", 1);
+        let c = parse_deepseek_v4(&pre_release).expect("parse pre-release YaRN parameters");
         assert_eq!(c.yarn_factor, 16.0);
         assert_eq!(c.yarn_beta_fast, 32.0);
         assert_eq!(c.yarn_beta_slow, 1.0);

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -441,18 +441,6 @@ mod mscale_contract_tests {
         assert_eq!(c.yarn_mscale_all_dim, 0.0);
     }
 
-    // Test 5 (config side): the force lives ONLY in this DS4F parser. A non-DS4F
-    // factory config keeps the shared factory default (yarn_mscale = 1.0),
-    // proving Qwen/other models are untouched by the DS4F override.
-    #[test]
-    fn non_ds4f_factory_default_mscale_untouched() {
-        let qwen = ModelConfig::qwen3_next_80b_nvfp4();
-        assert_eq!(
-            qwen.yarn_mscale, 1.0,
-            "shared factory default must remain 1.0 for non-DS4F models"
-        );
-    }
-
     #[test]
     fn incomplete_dspark_contract_is_rejected() {
         let incomplete = DS4F_CONFIG.replace(

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -366,11 +366,6 @@ mod mscale_contract_tests {
       "compress_ratios": [0,0,4,128,4,128,4,0,0,0]
     }"#;
 
-    // Mirrors compute.rs `const MAIN_ROPE_THETA: f32 = 10000.0` — the sliding
-    // (compressor-absent) rope theta. This diff does not touch compute.rs, so the
-    // value is unchanged; asserted here as the sliding-theta contract.
-    const SLIDING_ROPE_THETA_CONTRACT: f32 = 10000.0;
-
     // The parser owns the DS4F field override. The spark-model helper tests own
     // the resulting runtime ratio.
     #[test]
@@ -396,13 +391,6 @@ mod mscale_contract_tests {
         );
         let c = parse_deepseek_v4(&alternate).expect("parse alternate compress theta");
         assert_eq!(c.rope_theta, 234567.0);
-    }
-
-    // Test 3: sliding-path theta contract is 10000 (compute.rs MAIN_ROPE_THETA,
-    // untouched by this diff).
-    #[test]
-    fn sliding_theta_contract_is_10000() {
-        assert_eq!(SLIDING_ROPE_THETA_CONTRACT, 10000.0);
     }
 
     // Test 6: no unrelated YaRN defaults changed — factor/beta/original_max_pos

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -434,7 +434,7 @@ mod mscale_contract_tests {
     fn ds4f_explicit_checkpoint_mscale_is_overridden() {
         let with_mscale = DS4F_CONFIG.replace(
             "\"type\": \"yarn\"",
-            "\"type\": \"yarn\", \"mscale\": 1.0, \"mscale_all_dim\": 0.0",
+            "\"type\": \"yarn\", \"mscale\": 1.0, \"mscale_all_dim\": 0.5",
         );
         let c = parse_deepseek_v4(&with_mscale).expect("parse DS4F w/ explicit mscale");
         assert_eq!(c.yarn_mscale, 0.0);

--- a/crates/atlas-core/src/config/parsers/deepseek_v4.rs
+++ b/crates/atlas-core/src/config/parsers/deepseek_v4.rs
@@ -442,28 +442,36 @@ mod mscale_contract_tests {
     }
 
     #[test]
-    fn incomplete_dspark_contract_is_rejected() {
-        let incomplete = DS4F_CONFIG.replace(
-            "\"compress_rope_theta\": 160000,",
-            "\"compress_rope_theta\": 160000, \"dspark_block_size\": 5,",
+    fn each_dspark_field_is_required_when_contract_is_present() {
+        let mut complete: serde_json::Value =
+            serde_json::from_str(DS4F_CONFIG).expect("parse DS4F fixture");
+        let object = complete.as_object_mut().expect("DS4F fixture is an object");
+        object.insert("dspark_block_size".into(), serde_json::json!(5));
+        object.insert("dspark_noise_token_id".into(), serde_json::json!(128799));
+        object.insert(
+            "dspark_target_layer_ids".into(),
+            serde_json::json!([40, 41, 42]),
         );
-        let err = parse_deepseek_v4(&incomplete).expect_err("incomplete DSpark config");
-        assert!(
-            err.to_string().contains("dspark_noise_token_id"),
-            "unexpected error: {err:#}"
-        );
-    }
+        object.insert("dspark_markov_rank".into(), serde_json::json!(256));
 
-    #[test]
-    fn dspark_fields_without_block_size_are_rejected() {
-        let incomplete = DS4F_CONFIG.replace(
-            "\"compress_rope_theta\": 160000,",
-            "\"compress_rope_theta\": 160000, \"dspark_markov_rank\": 256,",
-        );
-        let err = parse_deepseek_v4(&incomplete).expect_err("incomplete DSpark config");
-        assert!(
-            err.to_string().contains("dspark_block_size"),
-            "unexpected error: {err:#}"
-        );
+        for missing in [
+            "dspark_block_size",
+            "dspark_noise_token_id",
+            "dspark_target_layer_ids",
+            "dspark_markov_rank",
+        ] {
+            let mut incomplete = complete.clone();
+            incomplete
+                .as_object_mut()
+                .expect("DS4F fixture is an object")
+                .remove(missing);
+            let err =
+                parse_deepseek_v4(&incomplete.to_string()).expect_err("incomplete DSpark config");
+            let expected = format!("DSpark config is missing `{missing}`");
+            assert!(
+                err.to_string().contains(&expected),
+                "missing {missing} produced unexpected error: {err:#}"
+            );
+        }
     }
 }

--- a/crates/spark-model/src/weight_loader/deepseek_v4/compute.rs
+++ b/crates/spark-model/src/weight_loader/deepseek_v4/compute.rs
@@ -6,6 +6,8 @@ use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
 use crate::weight_map::DenseWeight;
 
+const MAIN_ROPE_THETA: f32 = 10000.0;
+
 fn alloc_or_managed(gpu: &dyn GpuBackend, bytes: usize) -> Result<DevicePtr> {
     // Latched on the BACKEND, not in a static: after a model is unloaded the
     // memory pressure that caused the fallback is gone, and the next load
@@ -323,17 +325,38 @@ pub fn ensure_yarn_inv_freq(
 /// Atlas's dispatch overrides to compress_rope_theta=160000 for the shared yarn
 /// table — so the 10000 base is hardcoded here to match the reference). Cheap
 /// (~32 floats); computed per compressor-less layer, no shared cache needed.
-pub fn main_inv_freq(config: &ModelConfig, gpu: &dyn GpuBackend) -> Result<DevicePtr> {
-    const MAIN_ROPE_THETA: f32 = 10000.0; // reference rope_theta for sliding layers
-    let rope = config.qk_rope_head_dim;
+fn main_inv_freq_values(rope: usize) -> Vec<f32> {
     let n_pairs = rope / 2;
     let dim_f = rope as f32;
     let mut inv_freq = vec![0.0f32; n_pairs];
     for (j, f) in inv_freq.iter_mut().enumerate() {
         *f = 1.0 / MAIN_ROPE_THETA.powf((2 * j) as f32 / dim_f);
     }
+    inv_freq
+}
+
+pub fn main_inv_freq(config: &ModelConfig, gpu: &dyn GpuBackend) -> Result<DevicePtr> {
+    let inv_freq = main_inv_freq_values(config.qk_rope_head_dim);
     let bytes: Vec<u8> = inv_freq.iter().flat_map(|v| v.to_le_bytes()).collect();
     let ptr = alloc_or_managed(gpu, bytes.len())?;
     gpu.copy_h2d(&bytes, ptr)?;
     Ok(ptr)
+}
+
+#[cfg(test)]
+mod main_inv_freq_tests {
+    use super::main_inv_freq_values;
+
+    #[test]
+    fn sliding_rope_table_uses_theta_10000() {
+        let values = main_inv_freq_values(64);
+        assert_eq!(values.len(), 32);
+        for (index, expected) in [(0, 1.0), (8, 0.1), (16, 0.01), (24, 0.001)] {
+            assert!(
+                (values[index] - expected).abs() < 1e-7,
+                "frequency {index} was {}, expected {expected}",
+                values[index]
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Seven held audit commits for the DeepSeek V4 config parser, ported onto current main with every mutant re-executed against today's production. Six are test-only oracle repairs; one extracts a host-side helper in `spark-model` so the sliding-RoPE table is tested where it is actually computed.

## Problems found (each proven with an executed old-green mutant)

- The mscale test asserted both zero fields and then a redundant equality between them; the equality has no surviving mutant of its own.
- The compress-theta test could not distinguish a real `compress_rope_theta` lookup from a hardcoded 160000: the only fixture matched the published value.
- The old sliding-RoPE test asserted a test-local constant equaled 10000; changing production `MAIN_ROPE_THETA` to 9999 left it green — it never compiled or called the production consumer.
- All four YaRN fixture values (factor 16, beta-fast 32, beta-slow 1, original max position 65,536) equaled the runtime fallback literals, so disabling all four checkpoint lookups stayed green.
- The explicit-mscale override test supplied `mscale_all_dim: 0.0`, matching both the disabled contract and the generic default, so restoring the nested lookup without the zero override stayed green.
- `non_ds4f_factory_default_mscale_untouched` never called `parse_deepseek_v4` and its Qwen factory field has no in-repository production consumer (re-verified by repo-wide field-read trace on current main: only `yarn_rope_mscale` reads these fields, from DS4F attention/loader paths). Deleted as misplaced.
- The two partial DSpark fixtures could not prove `dspark_target_layer_ids` was required; removing it from the required-field list left both green.

## Repair

Renamed and strengthened the parser tests with discriminating sentinel fixtures (compress theta 234,567; YaRN 12.5/40/2/32,768; explicit `mscale_all_dim: 0.5`), added the documented `rope_parameters` alias check, replaced the partial DSpark fixtures with one valid four-field contract minus each field independently requiring the exact `DSpark config is missing `<field>`` reason, and moved the sliding-RoPE oracle into `spark-model` as `main_inv_freq_values`, tested at rotary dim 64 against independent anchors (index 0 = 1.0, 8 = 0.1, 16 = 0.01, 24 = 0.001). `main_inv_freq` now uploads exactly that returned vector — a behavior-preserving extraction.

## Failure proof (replayed on current main, 567b5ebe7)

- Hardcoding the compress-theta assignment to 160000.0 fails the sentinel with `left: 160000.0, right: 234567.0`.
- Hardcoding `yarn_factor = 16.0` fails the alternate partition with `left: 16.0, right: 12.5`.
- Removing `dspark_target_layer_ids` from the required list fails with the missing-field reason replaced by the later empty-list error.
- Each was applied alone and production restored afterward (clean diff verified).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (126 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos` · `git diff --check`
- [ ] `cargo test -p spark-model --lib main_inv_freq` — does not compile on this macOS host (`spark-storage` uses Linux-only `posix_fallocate`/`posix_fadvise`/`O_DIRECT`); the new spark-model check is owned by Linux CI on this PR
- [ ] Tested against a real model / hardware (parser and host-table contracts only; no weights loaded, no kernel launched)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

Production behavior is unchanged (the `main_inv_freq` change is a pure extraction; the same loop computes the same floats). The tests stop at parsed configuration and the host-side frequency vector: no device table bytes are inspected, no RoPE kernel launched, no inference output compared. GAP-DS4F-0001 (runtime-table response to alternate YaRN parameters) and GAP-DS4F-0002 (no production read of `dspark_noise_token_id` beyond validation) remain open in the audit ledger.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
