### PR TITLE
atlas-core: fail-closed trainable-token parsing + LoRA contract repairs

### DIFF
--- a/crates/atlas-core/src/config/parsers/lora.rs
+++ b/crates/atlas-core/src/config/parsers/lora.rs
@@ -75,9 +75,9 @@ pub struct PeftAdapterConfig {
     /// which layers receive deltas; this is kept only for the startup log.
     pub layers_to_transform: Option<Vec<usize>>,
     /// Vocab-extension / trainable-token ids for the token overlay
-    /// (Feature 2). Flattened + deduped union of the config's
-    /// `trainable_token_indices` (list form, or `{"embed_tokens":[…],
-    /// "lm_head":[…]}` dict form). Empty ⇒ no `trainable_tokens` overlay.
+    /// (Feature 2). Unique ascending order from the config's
+    /// `trainable_token_indices` list, or the common order declared for
+    /// `embed_tokens` and `lm_head`. Empty ⇒ no `trainable_tokens` overlay.
     pub trainable_token_indices: Vec<u32>,
     /// Accepted `modules_to_save` leaves — the subset Atlas can apply as a
     /// token overlay (`embed_tokens` / `lm_head` full-row replacement).
@@ -149,7 +149,7 @@ struct RawPeftAdapterConfig {
     /// PEFT `trainable_token_indices` — vocab ids whose embed/lm_head rows the
     /// adapter fully replaces. Emitted as a bare list `[id, …]` OR a per-module
     /// dict `{"embed_tokens":[…], "lm_head":[…]}`. Parsed by
-    /// [`parse_trainable_tokens`] into a deduped `Vec<u32>`.
+    /// [`parse_trainable_tokens`] into one shared unique ascending `Vec<u32>`.
     #[serde(default)]
     trainable_token_indices: Option<serde_json::Value>,
     /// PEFT `target_parameters` — LoRA attached to fused `nn.Parameter`
@@ -286,14 +286,18 @@ fn partition_modules_to_save(mods: Option<&[String]>) -> Result<Vec<String>> {
     Ok(accepted)
 }
 
-/// Parse PEFT `trainable_token_indices` into a deduped ascending `Vec<u32>`.
+/// Parse PEFT `trainable_token_indices` into one unique ascending `Vec<u32>` shared by
+/// the embed and lm-head overlay paths.
 ///
 /// Accepts three on-disk forms: absent/null ⇒ empty; a bare list `[id, …]`;
-/// or a per-module dict `{"embed_tokens":[…], "lm_head":[…]}` whose value
-/// lists are unioned. Negative / non-integer entries are a named reject.
+/// or a per-module dict `{"embed_tokens":[…], "lm_head":[…]}` whose non-null
+/// lists must be identical. Negative, duplicate, unknown-module, and differing
+/// per-module entries are named rejects.
 fn parse_trainable_tokens(v: &Option<serde_json::Value>) -> Result<Vec<u32>> {
-    let mut ids: Vec<u32> = Vec::new();
-    let mut push_arr = |arr: &[serde_json::Value]| -> Result<()> {
+    fn parse_ids(arr: &[serde_json::Value]) -> Result<Vec<u32>> {
+        let mut ids = Vec::with_capacity(arr.len());
+        let mut seen = std::collections::HashSet::new();
+        let mut previous: Option<u32> = None;
         for e in arr {
             let n = e.as_u64().context(
                 "REJECT(trainable_token_indices): entries must be non-negative integers",
@@ -301,35 +305,60 @@ fn parse_trainable_tokens(v: &Option<serde_json::Value>) -> Result<Vec<u32>> {
             if n > u32::MAX as u64 {
                 bail!("REJECT(trainable_token_indices): id {n} exceeds u32 range");
             }
-            ids.push(n as u32);
+            let id = n as u32;
+            if !seen.insert(id) {
+                bail!("REJECT(trainable_token_indices): duplicate id {id}");
+            }
+            if let Some(prev) = previous
+                && id < prev
+            {
+                bail!(
+                    "REJECT(trainable_token_indices): ids must be ascending to preserve \
+                     trainable_tokens_delta row order; {id} follows {prev}"
+                );
+            }
+            previous = Some(id);
+            ids.push(id);
         }
-        Ok(())
-    };
+        Ok(ids)
+    }
+
     match v {
-        None | Some(serde_json::Value::Null) => {}
-        Some(serde_json::Value::Array(arr)) => push_arr(arr)?,
+        None | Some(serde_json::Value::Null) => Ok(Vec::new()),
+        Some(serde_json::Value::Array(arr)) => parse_ids(arr),
         Some(serde_json::Value::Object(map)) => {
-            for (_module, val) in map {
-                match val {
-                    serde_json::Value::Array(arr) => push_arr(arr)?,
-                    serde_json::Value::Null => {}
+            let mut shared: Option<Vec<u32>> = None;
+            for (module, val) in map {
+                if module != "embed_tokens" && module != "lm_head" {
+                    bail!(
+                        "REJECT(trainable_token_indices): unsupported module '{module}'; only \
+                         embed_tokens and lm_head are supported"
+                    );
+                }
+                let module_ids = match val {
+                    serde_json::Value::Array(arr) => parse_ids(arr)?,
+                    serde_json::Value::Null => continue,
                     other => bail!(
                         "REJECT(trainable_token_indices): dict value must be an array, got {other}"
                     ),
+                };
+                if let Some(ref expected) = shared
+                    && expected != &module_ids
+                {
+                    bail!(
+                        "REJECT(trainable_token_indices): per-module token lists differ; \
+                         Atlas requires one shared embed_tokens/lm_head order"
+                    );
                 }
+                shared = Some(module_ids);
             }
+            Ok(shared.unwrap_or_default())
         }
         Some(other) => bail!(
             "REJECT(trainable_token_indices): expected null, an array, or a per-module \
              object, got {other}"
         ),
     }
-    // Dedup while PRESERVING first-occurrence order: the `trainable_tokens_delta`
-    // tensor's rows align positionally to this id list, so a sort would break the
-    // id→delta-row mapping the overlay builder relies on.
-    let mut seen = std::collections::HashSet::new();
-    ids.retain(|id| seen.insert(*id));
-    Ok(ids)
 }
 
 fn parse_layers_to_transform(v: &Option<serde_json::Value>) -> Result<Option<Vec<usize>>> {

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -189,10 +189,25 @@ fn full_path_target_validates_on_leaf() {
 }
 
 #[test]
-fn zero_rank_rejected() {
+fn zero_rank_rejected_by_name() {
     let mut j = base_json();
     j["r"] = serde_json::json!(0);
-    assert!(parse_peft_adapter_config(&j.to_string()).is_err());
+    let err = parse_peft_adapter_config(&j.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("REJECT(r)"), "{err}");
+}
+
+#[test]
+fn nonpositive_alpha_rejected_by_name() {
+    for alpha in [0.0, -1.0] {
+        let mut j = base_json();
+        j["lora_alpha"] = serde_json::json!(alpha);
+        let err = parse_peft_adapter_config(&j.to_string())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("REJECT(lora_alpha)"), "{alpha}: {err}");
+    }
 }
 
 // ---- Feature 2: token overlay (embed / lm_head / vocab-extension) ----

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -305,13 +305,30 @@ fn unknown_trainable_token_module_rejected() {
 }
 
 #[test]
-fn trainable_token_indices_negative_rejected() {
-    let mut j = base_json();
-    j["trainable_token_indices"] = serde_json::json!([-1]);
-    let err = parse_peft_adapter_config(&j.to_string())
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+fn invalid_trainable_token_entries_rejected_by_name() {
+    for (value, detail) in [
+        (
+            serde_json::json!(-1),
+            "entries must be non-negative integers",
+        ),
+        (
+            serde_json::json!(1.5),
+            "entries must be non-negative integers",
+        ),
+        (
+            serde_json::json!("7"),
+            "entries must be non-negative integers",
+        ),
+        (serde_json::json!(4_294_967_296_u64), "exceeds u32 range"),
+    ] {
+        let mut j = base_json();
+        j["trainable_token_indices"] = serde_json::json!([value]);
+        let err = parse_peft_adapter_config(&j.to_string())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+        assert!(err.contains(detail), "{err}");
+    }
 }
 
 #[test]

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -102,7 +102,15 @@ fn q_proj_accepted() {
 fn gdn_module_rejected_named() {
     // `out_proj` is deliberately NOT in this list any more — see
     // `gdn_out_proj_is_accepted` below. Everything here feeds the recurrence.
-    for m in ["in_proj_qkvz", "in_proj_qkv", "in_proj_z", "conv1d"] {
+    for m in [
+        "in_proj_qkvz",
+        "in_proj_ba",
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_a",
+        "in_proj_b",
+        "conv1d",
+    ] {
         let mut j = base_json();
         j["target_modules"] = serde_json::json!([m]);
         let err = parse_peft_adapter_config(&j.to_string())

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -69,13 +69,12 @@ fn float_alpha_accepted() {
 }
 
 #[test]
-fn layers_to_transform_array_accepted() {
-    // The generated Holo fixture carries layers_to_transform=[3,7,...];
-    // it must be ACCEPTED (kept for logging), not rejected.
+fn layers_to_transform_array_does_not_block_adapter_loading() {
+    // Generated Holo configs carry this restriction. The tensor audit owns
+    // actual layer coverage, but parsing must not reject the PEFT field.
     let mut j = base_json();
     j["layers_to_transform"] = serde_json::json!([3, 7, 11, 15, 19, 23]);
-    let cfg = parse_peft_adapter_config(&j.to_string()).unwrap();
-    assert_eq!(cfg.layers_to_transform, Some(vec![3, 7, 11, 15, 19, 23]));
+    parse_peft_adapter_config(&j.to_string()).expect("supported PEFT layer list");
 }
 
 #[test]

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -50,10 +50,13 @@ fn explicit_target_modules_are_preserved_verbatim() {
 }
 
 #[test]
-fn rslora_scaling_alpha_over_sqrt_r() {
+fn rslora_scaling_preserves_inputs_and_uses_alpha_over_sqrt_rank() {
     let mut j = base_json();
     j["use_rslora"] = serde_json::json!(true);
     let cfg = parse_peft_adapter_config(&j.to_string()).unwrap();
+    assert_eq!(cfg.r, 16);
+    assert_eq!(cfg.lora_alpha, 32.0);
+    assert!(cfg.use_rslora);
     assert_eq!(cfg.scaling(), 8.0); // 32 / sqrt(16)
 }
 

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -239,25 +239,69 @@ fn modules_to_save_unknown_leaf_rejected() {
 }
 
 #[test]
-fn trainable_token_indices_list_form_parsed() {
+fn trainable_token_indices_list_form_preserves_row_order() {
     let mut j = base_json();
-    j["trainable_token_indices"] = serde_json::json!([256205, 42, 42, 7]);
+    j["trainable_token_indices"] = serde_json::json!([7, 42, 256205]);
     let cfg = parse_peft_adapter_config(&j.to_string()).unwrap();
-    // deduped, first-occurrence order preserved (delta rows align to it)
-    assert_eq!(cfg.trainable_token_indices, vec![256205, 42, 7]);
+    assert_eq!(cfg.trainable_token_indices, vec![7, 42, 256205]);
 }
 
 #[test]
-fn trainable_token_indices_dict_form_unioned() {
+fn duplicate_trainable_token_index_rejected() {
+    let mut j = base_json();
+    j["trainable_token_indices"] = serde_json::json!([7, 42, 42, 256205]);
+    let err = parse_peft_adapter_config(&j.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+    assert!(err.contains("duplicate id 42"), "{err}");
+}
+
+#[test]
+fn nonascending_trainable_token_indices_rejected() {
+    let mut j = base_json();
+    j["trainable_token_indices"] = serde_json::json!([42, 7, 256205]);
+    let err = parse_peft_adapter_config(&j.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+    assert!(err.contains("ids must be ascending"), "{err}");
+}
+
+#[test]
+fn trainable_token_indices_dict_form_accepts_shared_order() {
     let mut j = base_json();
     j["trainable_token_indices"] = serde_json::json!({
-        "embed_tokens": [256205, 10],
-        "lm_head": [10, 99]
+        "embed_tokens": [10, 99, 256205],
+        "lm_head": [10, 99, 256205]
     });
-    let mut cfg = parse_peft_adapter_config(&j.to_string()).unwrap();
-    // Order across dict values is object-iteration dependent; compare as a set.
-    cfg.trainable_token_indices.sort_unstable();
+    let cfg = parse_peft_adapter_config(&j.to_string()).unwrap();
     assert_eq!(cfg.trainable_token_indices, vec![10, 99, 256205]);
+}
+
+#[test]
+fn differing_per_module_trainable_token_indices_rejected() {
+    let mut j = base_json();
+    j["trainable_token_indices"] = serde_json::json!({
+        "embed_tokens": [10, 99],
+        "lm_head": [10, 256205]
+    });
+    let err = parse_peft_adapter_config(&j.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+    assert!(err.contains("per-module token lists differ"), "{err}");
+}
+
+#[test]
+fn unknown_trainable_token_module_rejected() {
+    let mut j = base_json();
+    j["trainable_token_indices"] = serde_json::json!({"classifier": [10]});
+    let err = parse_peft_adapter_config(&j.to_string())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("REJECT(trainable_token_indices)"), "{err}");
+    assert!(err.contains("unsupported module 'classifier'"), "{err}");
 }
 
 #[test]

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -146,7 +146,7 @@ fn all_linear_rejected_named() {
 }
 
 #[test]
-fn dora_bias_rank_pattern_rejected_named() {
+fn unsupported_inference_controls_are_rejected_by_name() {
     for (key, val, tag) in [
         ("use_dora", serde_json::json!(true), "REJECT(use_dora)"),
         ("bias", serde_json::json!("lora_only"), "REJECT(bias)"),
@@ -156,11 +156,9 @@ fn dora_bias_rank_pattern_rejected_named() {
             "REJECT(rank_pattern)",
         ),
         (
-            // `lm_head`/`embed_tokens` now ACCEPT (token overlay); an
-            // arbitrary module still rejects.
-            "modules_to_save",
-            serde_json::json!(["classifier"]),
-            "REJECT(modules_to_save)",
+            "alpha_pattern",
+            serde_json::json!({"k_proj": 8.0}),
+            "REJECT(alpha_pattern)",
         ),
         (
             "target_parameters",

--- a/crates/atlas-core/src/config/parsers/lora_tests.rs
+++ b/crates/atlas-core/src/config/parsers/lora_tests.rs
@@ -25,13 +25,28 @@ fn base_json() -> serde_json::Value {
 }
 
 #[test]
-fn happy_path_scaling_alpha_over_r() {
+fn standard_lora_scaling_preserves_inputs_and_uses_alpha_over_rank() {
     let cfg = parse_peft_adapter_config(&base_json().to_string()).unwrap();
     assert_eq!(cfg.r, 16);
     assert_eq!(cfg.lora_alpha, 32.0);
     assert!(!cfg.use_rslora);
     assert_eq!(cfg.scaling(), 2.0);
-    assert_eq!(cfg.target_modules.len(), 6);
+}
+
+#[test]
+fn explicit_target_modules_are_preserved_verbatim() {
+    let cfg = parse_peft_adapter_config(&base_json().to_string()).unwrap();
+    assert_eq!(
+        cfg.target_modules,
+        [
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Eight held audit commits for the PEFT/LoRA adapter parser, ported onto current main with both headline mutants re-executed against today's production. Six are test-only oracle repairs. **Two change production behavior: `trainable_token_indices` parsing is now fail-closed** (details below) — reviewers should weigh that section, not the test churn.

## Production behavior change: trainable-token parsing is now fail-closed

The `trainable_tokens_delta` tensor's rows align positionally to the parsed id list. The old parser flattened and deduped a union across the `embed_tokens`/`lm_head` dict form, which silently reordered or merged ids — a misaligned id→delta-row mapping applies the wrong rows to the wrong tokens without any error. The parser now requires one shared unique ascending list: duplicates, descending order, differing per-module lists, unknown modules, negatives, non-integers, and ids beyond u32 are each a named reject. An adapter that legitimately declares differing per-module lists was silently mis-applied before; now it is rejected with the reason. Accepting-but-corrupting became rejecting-by-name.

## Test problems found (each proven with an executed old-green mutant)

- The happy-path scaling test mixed scaling and target-module claims; split into two focused contracts.
- The rsLoRA test did not pin rank, alpha, or mode inputs, so a wrong-source scaling could satisfy it.
- `layers_to_transform_array_accepted` asserted a dead field; renamed to its actual acceptance-only claim.
- Three GDN target spellings present in the production reject arm (`in_proj_ba`, `in_proj_a`, `in_proj_b`) were untested — removing one from the reject arm silently admitted it. (Upstream meanwhile made `out_proj` accepted for GDN; the port preserves that feature change and tests around it.)
- The unsupported-controls test duplicated a `modules_to_save` row and missed `alpha_pattern`.
- Zero rank and non-positive alpha were rejected but the tests accepted any error; they now pin the `REJECT(r)` / `REJECT(lora_alpha)` reasons.

## Failure proof (replayed on current main, 567b5ebe7)

- Swapping the zero-rank rejection reason to `REJECT(lora_alpha)` fails `zero_rank_rejected_by_name` with the wrong-reason message printed.
- Removing `in_proj_ba` from the reject arm makes parsing succeed and `gdn_module_rejected_named` fail at `unwrap_err` with the accepted config printed.
- Each applied alone, production restored afterward (clean diff verified).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p atlas-core` (134 passed)
- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo clippy -p atlas-core --tests -- -D warnings`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos` · `git diff --check`
- [ ] `ATLAS_SKIP_BUILD=1 cargo clippy --workspace --tests --all-features -- -Dwarnings` (owned by Linux CI; this macOS host reaches Linux-only paths outside this diff)
- [ ] Tested against a real adapter checkpoint (not run: the rejection semantics are proven at the parser seam; no adapter was loaded onto a model)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

The fail-closed strictness is deliberate: every newly rejected shape was previously accepted into a silently wrong overlay mapping, so no correct adapter behavior is lost — but if a real published PEFT adapter in the wild uses differing per-module token lists intentionally, it now fails at load with a named reason instead of loading wrong; that trade is the review question. No adapter weights were loaded and no overlay kernel executed; consumption ties (overlay builder row alignment) are static traces of current source.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
