### PR TITLE
atlas-closure: canonicalize paths before hashing + digest oracle repairs

### DIFF
--- a/crates/atlas-closure/src/lib.rs
+++ b/crates/atlas-closure/src/lib.rs
@@ -157,6 +157,11 @@ pub fn hash(root: &Path, inputs: &ClosureInputs) -> Result<String> {
 /// *newly* unresolvable include is worth a build warning even though it is not
 /// worth a build failure.
 pub fn hash_with_report(root: &Path, inputs: &ClosureInputs) -> Result<Closure> {
+    // `expand` canonicalizes every source. Canonicalize the comparison root as
+    // well, otherwise platform aliases such as macOS `/var` -> `/private/var`
+    // make `strip_prefix` fail and leak checkout-specific absolute paths into
+    // both the report and digest.
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let mut closure: BTreeSet<PathBuf> = BTreeSet::new();
     let mut raw: BTreeSet<(PathBuf, String)> = BTreeSet::new();
     for src in &inputs.sources {
@@ -168,12 +173,12 @@ pub fn hash_with_report(root: &Path, inputs: &ClosureInputs) -> Result<Closure> 
     let unresolved: BTreeSet<String> = raw
         .into_iter()
         .map(|(from, include)| {
-            let rel = from.strip_prefix(root).unwrap_or(&from);
+            let rel = from.strip_prefix(&canonical_root).unwrap_or(&from);
             format!("{} -> {include}", rel.display())
         })
         .collect();
     for cfg in &inputs.configs {
-        closure.insert(cfg.clone());
+        closure.insert(cfg.canonicalize().unwrap_or_else(|_| cfg.clone()));
     }
 
     let mut digest = Sha256::new();
@@ -194,7 +199,7 @@ pub fn hash_with_report(root: &Path, inputs: &ClosureInputs) -> Result<Closure> 
 
     digest.update(b"\x00files\x00");
     for path in &closure {
-        let rel = path.strip_prefix(root).unwrap_or(path);
+        let rel = path.strip_prefix(&canonical_root).unwrap_or(path);
         // The NAME is hashed as well as the bytes: moving identical content to
         // a different stem changes which kernel it shadows, so it is a
         // different compile even though the bytes match.

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -303,12 +303,13 @@ fn non_source_inputs_each_move_the_hash() {
     assert_ne!(with_cfg, hash(&d, &cfg).unwrap(), "config CONTENT");
 }
 
-/// ★ Identical bytes at a different stem is a different compile.
+/// ★ Identical bytes at a different repo-relative path are a different input.
 ///
-/// The stem decides which common file a source shadows, so content alone is not
-/// the identity — the name is hashed too.
+/// The stem decides which common file a source shadows, and the directory
+/// distinguishes a common source from a model override. Content alone is not
+/// the identity, so the full repo-relative path is hashed too.
 #[test]
-fn identical_content_under_a_different_name_hashes_differently() {
+fn identical_content_under_a_different_path_hashes_differently() {
     let d = tmp();
     let a = d.join("common/one.cu");
     let b = d.join("common/two.cu");
@@ -316,7 +317,18 @@ fn identical_content_under_a_different_name_hashes_differently() {
     write(&b, "__global__ void k() {}\n");
     assert_ne!(
         hash(&d, &inputs(vec![a])).unwrap(),
-        hash(&d, &inputs(vec![b])).unwrap()
+        hash(&d, &inputs(vec![b])).unwrap(),
+        "different stems"
+    );
+
+    let common = d.join("common/same.cu");
+    let model = d.join("model/nvfp4/same.cu");
+    write(&common, "__global__ void same() {}\n");
+    write(&model, "__global__ void same() {}\n");
+    assert_ne!(
+        hash(&d, &inputs(vec![common])).unwrap(),
+        hash(&d, &inputs(vec![model])).unwrap(),
+        "same stem in different source directories"
     );
 }
 

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -226,16 +226,28 @@ fn angle_bracket_includes_are_not_followed() {
     );
 }
 
-/// A commented-out include is not compiled, so hashing it would make a comment
-/// edit look like a source change.
+/// A commented-out include is not compiled, so a same-named local header must
+/// remain outside the closure and must not be reported as unresolved.
 #[test]
 fn commented_out_includes_are_ignored() {
     let d = tmp();
     let src = d.join("common/x.cu");
-    write(&src, "// #include \"absent.cuh\"\n__global__ void k() {}\n");
-    assert!(
-        hash(&d, &inputs(vec![src])).is_ok(),
-        "a commented include must not be resolved, let alone demanded"
+    let commented_header = d.join("common/commented.cuh");
+    write(
+        &src,
+        "// #include \"commented.cuh\"\n__global__ void k() {}\n",
+    );
+    write(&commented_header, "#define COMMENTED_VALUE 1\n");
+
+    let before = hash_with_report(&d, &inputs(vec![src.clone()])).unwrap();
+    assert!(before.unresolved.is_empty(), "{:?}", before.unresolved);
+
+    write(&commented_header, "#define COMMENTED_VALUE 2\n");
+    let after = hash_with_report(&d, &inputs(vec![src])).unwrap();
+    assert!(after.unresolved.is_empty(), "{:?}", after.unresolved);
+    assert_eq!(
+        before.digest, after.digest,
+        "a header named only by a commented include must stay outside the closure"
     );
 }
 

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -275,6 +275,16 @@ fn non_source_inputs_each_move_the_hash() {
     flags.flags.push("-O3".into());
     assert_ne!(base, hash(&d, &flags).unwrap(), "nvcc flags");
 
+    let mut define_then_undefine = inputs(vec![src.clone()]);
+    define_then_undefine.flags = vec!["-DSELECTED=1".into(), "-USELECTED".into()];
+    let mut undefine_then_define = inputs(vec![src.clone()]);
+    undefine_then_define.flags = vec!["-USELECTED".into(), "-DSELECTED=1".into()];
+    assert_ne!(
+        hash(&d, &define_then_undefine).unwrap(),
+        hash(&d, &undefine_then_define).unwrap(),
+        "nvcc flag order"
+    );
+
     let mut arch = inputs(vec![src.clone()]);
     arch.arch = "sm_120a".into();
     assert_ne!(base, hash(&d, &arch).unwrap(), "arch");

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -174,7 +174,13 @@ fn unresolved_entries_are_keyed_by_the_including_file() {
     write(&a, "#include \"gone.cuh\"\n");
     write(&b, "#include \"gone.cuh\"\n");
     let closure = hash_with_report(&d, &inputs(vec![a, b])).unwrap();
-    assert_eq!(closure.unresolved.len(), 2, "{:?}", closure.unresolved);
+    assert_eq!(
+        closure.unresolved,
+        BTreeSet::from([
+            "common/a.cu -> gone.cuh".to_string(),
+            "common/b.cu -> gone.cuh".to_string(),
+        ])
+    );
 }
 
 /// A preprocessor conditional is not evaluated, so an include in a branch this

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -310,10 +310,23 @@ fn the_hash_does_not_depend_on_the_checkout_location() {
 
     write(&d1.join("common/x.cu"), "__global__ void k() {}\n");
     write(&d2.join("common/x.cu"), "__global__ void k() {}\n");
+    write(&d1.join("model/MODEL.toml"), "[model]\nname = \"same\"\n");
+    std::fs::create_dir_all(d2.join("model")).unwrap();
+    write(&d2.join("model/MODEL.toml"), "[model]\nname = \"same\"\n");
+
+    // Use a lexical alias for one checkout root. `expand` canonicalizes source
+    // files, so the root must be normalized to the same form before paths are
+    // made relative. This reproduces aliases such as macOS `/var` ->
+    // `/private/var` without depending on the host platform.
+    let aliased_d1 = d1.join("model/..");
+    let mut first = inputs(vec![aliased_d1.join("common/x.cu")]);
+    first.configs.push(aliased_d1.join("model/MODEL.toml"));
+    let mut second = inputs(vec![d2.join("common/x.cu")]);
+    second.configs.push(d2.join("model/MODEL.toml"));
 
     assert_eq!(
-        hash(&d1, &inputs(vec![d1.join("common/x.cu")])).unwrap(),
-        hash(&d2, &inputs(vec![d2.join("common/x.cu")])).unwrap(),
+        hash(&aliased_d1, &first).unwrap(),
+        hash(&d2, &second).unwrap(),
         "the same commit checked out twice must hash the same"
     );
 }

--- a/crates/atlas-closure/src/lib_tests.rs
+++ b/crates/atlas-closure/src/lib_tests.rs
@@ -210,8 +210,20 @@ fn includes_inside_untaken_conditionals_are_still_walked() {
 fn angle_bracket_includes_are_not_followed() {
     let d = tmp();
     let src = d.join("common/x.cu");
+    let toolchain_header = d.join("common/cuda_fp16.h");
     write(&src, "#include <cuda_fp16.h>\n__global__ void k() {}\n");
-    assert!(hash(&d, &inputs(vec![src])).is_ok());
+    write(&toolchain_header, "#define TOOLCHAIN_VALUE 1\n");
+
+    let before = hash_with_report(&d, &inputs(vec![src.clone()])).unwrap();
+    assert!(before.unresolved.is_empty(), "{:?}", before.unresolved);
+
+    write(&toolchain_header, "#define TOOLCHAIN_VALUE 2\n");
+    let after = hash_with_report(&d, &inputs(vec![src])).unwrap();
+    assert!(after.unresolved.is_empty(), "{:?}", after.unresolved);
+    assert_eq!(
+        before.digest, after.digest,
+        "angle-bracket headers are represented by compiler provenance, not local content"
+    );
 }
 
 /// A commented-out include is not compiled, so hashing it would make a comment


### PR DESCRIPTION
## Summary

Six held audit commits for `atlas-closure`, the crate that computes the kernel-source closure digest consumed by benchmark-gate record reuse. Five strengthen digest oracles that previously accepted real hash defects; **one is a production fix: the comparison root and config paths are canonicalized before relativizing**, which fixes two failing tests on macOS and stops checkout-specific absolute paths from leaking into the report and digest. All three headline mutants were re-executed against today's production.

## Production change and its digest impact

`hash_with_report` relativized against the caller's uncanonicalized root while `expand` canonicalizes every source, so on hosts with path aliases (macOS `/var` → `/private/var`) `strip_prefix` failed and absolute paths entered both the unresolved report and the digest — the digest then depended on the checkout location. The fix canonicalizes the root (with a fallback to the raw path) and canonicalizes config entries the same way. On Linux CI, where the passed root and config paths are already canonical absolute paths, relative paths and digests are unchanged — existing benchmark records are not invalidated by recomputation. Digests change only where they were previously wrong (aliased roots leaking absolutes).

## Test problems found (each proven with an executed old-green mutant)

- `unresolved_entries_are_keyed_by_the_including_file` counted entries; production emitting `slot-0`/`slot-1` keys instead of including-file identities stayed green. Now requires the exact repo-relative `common/a.cu -> gone.cuh` / `common/b.cu -> gone.cuh` set.
- `angle_bracket_includes_are_not_followed` accepted `is_ok()`; parsing angle brackets as quoted includes survived because missing includes are nonfatal. Now places a same-name local header, requires an empty unresolved report, and requires the digest unchanged after editing that header.
- `commented_out_includes_are_ignored` — same pattern for `//` comments.
- `non_source_inputs_each_move_the_hash` proved flag presence only; sorting flags before hashing survived. Now compares define-then-undefine against the reverse order and requires distinct digests.
- The different-path test survived a basename-only hash. Now adds byte-identical `common/same.cu` vs `model/nvfp4/same.cu` and requires distinct digests (the name selects which kernel is shadowed, so it is a different compile).

## Failure proof (replayed on current main, 567b5ebe7)

- Sorting flags before hashing: the flag-order assertion fails with both digests equal.
- Hashing only the file basename: the same-content-different-path assertion fails with both digests equal.
- Reverting the canonicalization: 3 tests fail on this macOS host (the two originally-failing tests plus the strengthened unresolved-identities test, which now also depends on correct relativization); restoring it returns the crate to 15/15.

## Production consequence

A surviving digest defect preserves benchmark-gate records that should have been invalidated: flag-order changes, moved same-content kernels, or checkout-relative aliasing could all reuse stale hardware records. These oracles are what make record reuse trustworthy.

## Test plan

- [x] `cargo test -p atlas-closure` (15 passed, 0 failed)
- [x] `cargo clippy -p atlas-closure --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos` · `git diff --check`
- [ ] Tested against a real model / hardware (not applicable: host-side hashing crate; no kernel compiled)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

The Linux-digest-stability claim above is a static argument (canonical inputs in, identical outputs out), not a replay against committed records; if the gate CI passes on this PR with existing records accepted, that is the executed confirmation. Include-graph parsing itself (conditionals, cycles, transitive expansion) already had sound oracles and is unchanged.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
