### PR TITLE
spark-runtime: pin independent oracles in 4 kv_cache checks

### DIFF
--- a/crates/spark-runtime/src/kv_cache/tests.rs
+++ b/crates/spark-runtime/src/kv_cache/tests.rs
@@ -184,7 +184,17 @@ fn test_read_write_block_roundtrip() {
     let b0 = cache.alloc_block().unwrap();
 
     // Write known pattern to K and V for layer 0.
+    // Independent byte-layout anchor: 16 tokens * 2 heads * 256 dim * 1 byte
+    // (FP8) = 8192, hand-derived the same way as `test_block_bytes_fp8`'s
+    // comment — NOT read back from `block_stride_bytes()` alone. Without this
+    // pin, a wrong production stride still sizes both the write buffer and the
+    // read buffer identically (both sides call the same function), so the
+    // roundtrip below would stay green even with a corrupted stride.
     let stride = cache.block_stride_bytes();
+    assert_eq!(
+        stride, 8192,
+        "FP8 block stride: 16 tokens * 2 heads * 256 dim * 1 byte"
+    );
     let k_data: Vec<u8> = (0..stride).map(|i| (i % 256) as u8).collect();
     let v_data: Vec<u8> = (0..stride).map(|i| ((i + 128) % 256) as u8).collect();
     cache.write_block(0, b0, &k_data, &v_data, &gpu).unwrap();
@@ -202,7 +212,13 @@ fn test_read_write_block_multiple_layers() {
     let mut cache = PagedKvCache::new(cfg, 4, &gpu).unwrap();
     let b0 = cache.alloc_block().unwrap();
 
+    // Independent byte-layout anchor — see test_read_write_block_roundtrip for
+    // why this must not be trusted purely from `block_stride_bytes()` itself.
     let stride = cache.block_stride_bytes();
+    assert_eq!(
+        stride, 8192,
+        "FP8 block stride: 16 tokens * 2 heads * 256 dim * 1 byte"
+    );
     for layer in 0..12 {
         let k: Vec<u8> = vec![layer as u8; stride];
         let v: Vec<u8> = vec![(layer + 100) as u8; stride];
@@ -324,9 +340,23 @@ fn test_compute_num_blocks_mixed_dtype() {
         ..test_config()
     };
 
-    let bytes_per_block = cfg.block_bytes_kv_all_layers();
+    // Independent oracle: hand-derived the same way as
+    // test_block_bytes_kv_all_layers_mixed (2 BF16 layers + 10 NVFP4 layers,
+    // K+V each) — NOT read back from `cfg.block_bytes_kv_all_layers()`.
+    // Deriving `bytes_per_block` from the same function `compute_num_blocks`
+    // calls internally made this test tautological: a bug living inside
+    // `block_bytes_kv_all_layers` itself moves both sides of the comparison
+    // together and is invisible here (it's covered by
+    // test_block_bytes_kv_all_layers_mixed instead). This only re-verifies
+    // that `compute_num_blocks` is wired to divide by the right thing.
+    let expected_bytes_per_block = 2 * 16384 * 2 + 10 * 4608 * 2;
+    assert_eq!(
+        cfg.block_bytes_kv_all_layers(),
+        expected_bytes_per_block,
+        "sanity: cfg matches the independently-derived per-block size"
+    );
     let n = PagedKvCache::compute_num_blocks(&cfg, 1_000_000).unwrap();
-    assert_eq!(n, 1_000_000 / bytes_per_block);
+    assert_eq!(n, 1_000_000 / expected_bytes_per_block); // = 6
 }
 
 #[test]
@@ -379,15 +409,32 @@ fn sliding_window_recycles_blocks() {
     // Simulate 2 sequences each writing 100 blocks.
     for seq_id in 0..2 {
         let mut block_table: Vec<u32> = Vec::new();
+        // The physical block an iteration's eviction frees sits alone on top
+        // of this sequence's slice of the (LIFO) free list, so the very next
+        // alloc must hand it straight back out. Tracking it turns "the pool
+        // never runs dry" (a count-only claim, insensitive to a FIFO-vs-LIFO
+        // or wrong-block-evicted defect) into the docstring's actual claim
+        // that physical block IDs are correctly recycled, not merely that
+        // some free block or other is found.
+        let mut last_evicted: Option<u32> = None;
         for step in 0..100 {
             let blk = cache.alloc_block().unwrap_or_else(|_| {
                 panic!("alloc failed at seq {seq_id} step {step}: no free blocks")
             });
+            if let Some(evicted) = last_evicted {
+                assert_eq!(
+                    blk, evicted,
+                    "seq {seq_id} step {step}: expected the slide to recycle the \
+                     just-evicted physical block {evicted}, got {blk} instead"
+                );
+            }
             block_table.push(blk);
             // Slide window: when block_table > cap, evict the oldest.
+            last_evicted = None;
             while block_table.len() > 4 {
                 let evicted = block_table.remove(0);
                 cache.free_block(evicted);
+                last_evicted = Some(evicted);
             }
         }
         // Free remaining blocks as if the sequence completed.


### PR DESCRIPTION
## Summary

RST mutation audit of all 24 registered `kv_cache::tests` checks (campaign IDs ATC-1886 through ATC-1909). Ten realistic production mutants were applied and reverted one at a time — dtype-factor copy-paste bugs, a dropped NVFP4 scale-byte term, a silent ref-count leak, the documented force-zero eviction regression, FIFO-instead-of-LIFO recycling, exhaustion masking, an off-by-one layer count, a FromStr variant typo, and an ignored per-layer dtype override. Twenty checks rejected their mutant as written. Four stayed green against a real defect and are repaired here. **No production changes: every surviving mutant traced to a test-oracle weakness, not a product bug.**

## The four oracle weaknesses (each proven with an executed old-green mutant)

- `test_read_write_block_roundtrip` and `test_read_write_block_multiple_layers` sized both the write and read buffers from `cache.block_stride_bytes()` — the value under test. Doubling the FP8 stride factor in production sized both sides identically and the roundtrips kept passing. Both now pin the hand-derived FP8 anchor (16 tokens × 2 heads × 256 dim × 1 byte = 8192) before using the stride.
- `test_compute_num_blocks_mixed_dtype` derived its expected value by calling `cfg.block_bytes_kv_all_layers()`, the same function `compute_num_blocks` divides by internally. Three independent corruptions of that function (dropped BF16 ×2, dropped NVFP4 scale bytes, ignored per-layer dtype override) all left this test green. It now checks against the independently derived `2·16384·2 + 10·4608·2`, with a sanity assert isolating which side broke.
- `sliding_window_recycles_blocks` promised "physical block IDs are correctly recycled" but observed only free-list counts. A FIFO-instead-of-LIFO allocation mutant — which does kill `alloc_after_free_round_trip_returns_same_block_lifo` — passed here unchanged. The slide loop now asserts the next alloc returns exactly the block the same iteration just evicted.

Each repaired check was re-run under its mutant (now fails at the new assertion for the intended reason) and against restored production (passes).

## What the twenty good checks defended

Byte sizing per dtype and in mixed-dtype aggregate is probed from four distinct angles (single-layer, uniform aggregate, mixed aggregate with fully independent arithmetic, and the constructed `PagedKvCache`'s actual strides), so a wrong factor cannot hide in any one path. The ref==2 eviction check (`return_evicted_block_keeps_shared_block_alive`) remains the sole owner of the documented force-zero regression class: the ref==1 variant coincides with the bug and cannot see it — a complementary partition worth knowing at review time, not a gap.

These strides and counts feed real consumers: attention prefill/decode kernel launch arguments take the per-layer strides, and prefix-cache block sharing relies on the ref-count/eviction semantics (static traces of current source; no kernel was launched in this audit).

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 cargo test -p spark-runtime --lib --no-default-features --features metal kv_cache` — the audited cluster is 33/33 green; the 6 `metal_backend::tests::parity_*` failures are pre-existing on pristine main under `ATLAS_SKIP_BUILD=1` ("Metal: unknown module": the skip-build flag skips shader compilation) and are byte-identical before and after this commit (verified via stash)
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos` · `git diff --check`
- [ ] `cargo clippy -p spark-runtime --no-default-features --features metal --tests` fails with 19 pre-existing lints in `metal_backend/tests/real_model_misc.rs`, untouched by this diff and byte-identical on pristine main (verified via stash); Linux CI clippy owns this PR's gate
- [ ] Tested against a real model / hardware (not applicable: host-side sizing/ref-count contracts; no GPU path exercised)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

The macOS default-feature build cannot link (`default = ["cuda"]` plus the `ATLAS_SKIP_BUILD` early-return in `crates/spark-runtime/build.rs:26-46` emits Linux-only stub link paths before any platform check) — recorded as a testability finding; a macOS branch in that early-return would let default commands work here. The audit stops at host-side config and paged-cache bookkeeping: device append/read kernels, real shader parity, and multi-sequence concurrent allocation remain owned by the Metal/CUDA lanes.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
