### PR TITLE
stack/perf-plumbing: 2 PRs, one campaign — module-load dedup + EP null-group skip

### DIFF
--- a/.benchmarks/agentic-webserver/2026-09-06-da016237db.json
+++ b/.benchmarks/agentic-webserver/2026-09-06-da016237db.json
@@ -1,0 +1,490 @@
+{
+  "schema": 1,
+  "benchmark_id": "agentic-webserver",
+  "benchmark_name": "Agentic Webserver Test",
+  "git_sha": "da016237db",
+  "recorded_at": 1788726920,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "build_timeout_s": "600",
+    "command_timeout_s": "180",
+    "iterations": "10",
+    "max_tokens": "8192",
+    "max_turns": "40",
+    "request_timeout_s": "900",
+    "s_per_turn_budget": "8.5",
+    "serve_timeout_s": "30",
+    "wall_budget_s": "1800"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "agentic-webserver",
+    "--param",
+    "build_timeout_s=600",
+    "--param",
+    "command_timeout_s=180",
+    "--param",
+    "iterations=10",
+    "--param",
+    "max_tokens=8192",
+    "--param",
+    "max_turns=40",
+    "--param",
+    "request_timeout_s=900",
+    "--param",
+    "s_per_turn_budget=8.5",
+    "--param",
+    "serve_timeout_s=30",
+    "--param",
+    "wall_budget_s=1800",
+    "--yes",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788726122,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 52.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.6
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8402520,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7688924,
+      "gpu_compute_apps": [
+        {
+          "pid": 469536,
+          "name": "./target/release/spark",
+          "used_mib": 108713
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788726920,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 59.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8852392,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7682468,
+      "gpu_compute_apps": [
+        {
+          "pid": 469536,
+          "name": "./target/release/spark",
+          "used_mib": 108739
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 798,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 7.0,
+      "hottest_chassis_delta_c": 10.800000000000004
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "decode_tps": 39.21041743546954,
+    "followed_directions": 10.0,
+    "iterations": 10.0,
+    "s_per_turn": 4.950070729088051,
+    "step:curled": 10.0,
+    "step:ran_server": 10.0,
+    "step:ran_tests": 10.0,
+    "step:tore_down": 10.0,
+    "step:wrote_project": 10.0,
+    "step:wrote_tests": 10.0,
+    "sum_agent_wall_s": 787.0612459250001,
+    "sum_completion_tokens": 30861.0,
+    "sum_tool_calls": 141.0,
+    "sum_turns": 159.0,
+    "sum_wall_s": 795.963123832,
+    "webserver_ok": 10.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "10/10 webserver_ok · 10/10 followed_directions · 4.950s/turn ≤ 8.500 · Σwall 796s ≤ 1800s",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · decode_tps=39.21, followed_directions=10.00, iterations=10.00, s_per_turn=4.95, step:curled=10.00, step:ran_server=10.00, step:ran_tests=10.00, step:tore_down=10.00, step:wrote_project=10.00, step:wrote_tests=10.00, sum_agent_wall_s=787.06, sum_completion_tokens=30861.00, sum_tool_calls=141.00, sum_turns=159.00, sum_wall_s=795.96, webserver_ok=10.00 · Pass: 10/10 webserver_ok · 10/10 followed_directions · 4.950s/turn ≤ 8.500 · Σwall 796s ≤ 1800s",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/agentic-webserver/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/agentic-webserver/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"872GU6y6Y671AvO4PhlDig+2OTlJbQ5fnUr1/X/fDWznpqBNHk8Cdw36RZYAGIVW2KLtnk+pGzP/4h74AD6+DA=="}

--- a/.benchmarks/bfcl-subset-echolp/2026-09-06-da016237db.json
+++ b/.benchmarks/bfcl-subset-echolp/2026-09-06-da016237db.json
@@ -1,0 +1,481 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset-echolp",
+  "benchmark_name": "BFCL (subset, echolp draw)",
+  "git_sha": "da016237db",
+  "recorded_at": 1788723768,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "hallucination_pct": "12",
+    "live_pct": "23",
+    "max_new_tokens": "1024",
+    "min_normalized": "86.5",
+    "min_overall": "86.1",
+    "non_live_pct": "46",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset-echolp",
+    "--param",
+    "hallucination_pct=12",
+    "--param",
+    "live_pct=23",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=86.5",
+    "--param",
+    "min_overall=86.1",
+    "--param",
+    "non_live_pct=46",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2411.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1788716274,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 52.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.7
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 390098772451,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 7849424,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 6293240,
+      "gpu_compute_apps": [
+        {
+          "pid": 3947095,
+          "name": "./target/release/spark",
+          "used_mib": 108714
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788723768,
+      "machine": {
+        "hostname": "spark-43fa",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 60.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 390098772451,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 3353832,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 2361896,
+      "gpu_compute_apps": [
+        {
+          "pid": 3947095,
+          "name": "./target/release/spark",
+          "used_mib": 108740
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 7494,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 13.700000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +14 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-43fa"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 86.79,
+    "overall_accuracy": 86.45,
+    "samples": 1004.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 86.45 (baseline min 86.10) · normalized 86.79 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · normalized_single_turn_score=86.79, overall_accuracy=86.45, samples=1004.00 · Pass: overall 86.45 (baseline min 86.10) · normalized 86.79 (baseline min 86.50) · n=1004 — clears this checkpoint's committed bars",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset-echolp/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/bfcl-subset-echolp/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"efe157d6f6360027","sig":"U3ZjziBJmGs4Co3Y5C09QwiAuDmAO+BvbA0tHkAQUHnA1zCp9xuyvwHfEZoUNuCWgV4HoOONTGL2BZfHoJ04DQ=="}

--- a/.benchmarks/bfcl-subset/2026-09-06-da016237db.json
+++ b/.benchmarks/bfcl-subset/2026-09-06-da016237db.json
@@ -1,0 +1,476 @@
+{
+  "schema": 1,
+  "benchmark_id": "bfcl-subset",
+  "benchmark_name": "BFCL (subset)",
+  "git_sha": "da016237db",
+  "recorded_at": 1788722143,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "hallucination_pct": "10",
+    "live_pct": "10",
+    "max_new_tokens": "1024",
+    "min_normalized": "83.32",
+    "min_overall": "83.41999999999999",
+    "non_live_pct": "62",
+    "request_timeout_s": "600",
+    "subset_floor": "25",
+    "temperature": "0"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "bfcl-subset",
+    "--param",
+    "hallucination_pct=10",
+    "--param",
+    "live_pct=10",
+    "--param",
+    "max_new_tokens=1024",
+    "--param",
+    "min_normalized=83.32",
+    "--param",
+    "min_overall=83.41999999999999",
+    "--param",
+    "non_live_pct=62",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "subset_floor=25",
+    "--param",
+    "temperature=0",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.126.09",
+    "sm_clock_mhz": 2392.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1788716289,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 49.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.6
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 61022353370,
+        "sw_thermal_us": 38515,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 33289152,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 20511876,
+      "gpu_compute_apps": [
+        {
+          "pid": 1199446,
+          "name": "./target/release/spark",
+          "used_mib": 84916
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788722143,
+      "machine": {
+        "hostname": "spark-256a",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.126.09"
+      },
+      "gpu_temp_c": 71.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 81.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 74.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.8
+        }
+      ],
+      "sm_clock_mhz": 2392.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 61022353370,
+        "sw_thermal_us": 38515,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32204292,
+      "mem_total_kb": 127601452,
+      "page_cache_kb": 28175864,
+      "gpu_compute_apps": [
+        {
+          "pid": 1199446,
+          "name": "./target/release/spark",
+          "used_mib": 85052
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 5854,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 22.0,
+      "hottest_chassis_delta_c": 23.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +23 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-256a"
+  },
+  "metrics": {
+    "normalized_single_turn_score": 84.12,
+    "overall_accuracy": 84.22,
+    "samples": 995.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · normalized_single_turn_score=84.12, overall_accuracy=84.22, samples=995.00 · Pass: overall 84.22 (baseline min 83.42) · normalized 84.12 (baseline min 83.32) · n=995 — clears this checkpoint's committed bars",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/bfcl-subset/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/bfcl-subset/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"daa4bc7c19f25eda","sig":"Xwqon9265vB2NxbfcbelCY7xEWByd9KJXmsnd2dttEqlGYuovucm6hUoeM1sai+TdaAUkysNoIoS5fCjHpuiDw=="}

--- a/.benchmarks/concurrency-sweep-dflash2/2026-09-06-da016237db.json
+++ b/.benchmarks/concurrency-sweep-dflash2/2026-09-06-da016237db.json
@@ -1,0 +1,530 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep-dflash2",
+  "benchmark_name": "Concurrency Sweep (DFlash2)",
+  "git_sha": "da016237db",
+  "recorded_at": 1788727427,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 2, 4, 8, 16",
+    "isls": "512",
+    "min_c1": "19.05",
+    "min_c128": "0",
+    "min_c16": "57",
+    "min_c2": "35.38",
+    "min_c32": "0",
+    "min_c4": "41.77",
+    "min_c64": "0",
+    "min_c8": "49.62",
+    "min_peak": "57",
+    "osl": "200",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep-dflash2",
+    "--param",
+    "concurrencies=1, 2, 4, 8, 16",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=19.05",
+    "--param",
+    "min_c128=0",
+    "--param",
+    "min_c16=57",
+    "--param",
+    "min_c2=35.38",
+    "--param",
+    "min_c32=0",
+    "--param",
+    "min_c4=41.77",
+    "--param",
+    "min_c64=0",
+    "--param",
+    "min_c8=49.62",
+    "--param",
+    "min_peak=57",
+    "--param",
+    "osl=200",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "dflash=true",
+    "--serve-override",
+    "dflash_gamma=8",
+    "--serve-override",
+    "draft_model=incoai/Qwen3.8-27B-DFlash2",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=16",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-dflash2",
+  "serve_overrides": {
+    "dflash": "true",
+    "dflash_gamma": "8",
+    "draft_model": "incoai/Qwen3.8-27B-DFlash2",
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "16",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2483.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788727196,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 51.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13455792,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5904864,
+      "gpu_compute_apps": [
+        {
+          "pid": 477431,
+          "name": "./target/release/spark",
+          "used_mib": 104982
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788727427,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 69.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 76.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 68.7
+        }
+      ],
+      "sm_clock_mhz": 2483.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 12491764,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5911780,
+      "gpu_compute_apps": [
+        {
+          "pid": 477431,
+          "name": "./target/release/spark",
+          "used_mib": 105268
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 231,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 18.0,
+      "hottest_chassis_delta_c": 18.1
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +18 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "c16_aggregate_tok_s": 63.90468604318197,
+    "c16_ttft_p50_ms": 8039.362136999999,
+    "c1_aggregate_tok_s": 22.26028709797699,
+    "c1_ttft_p50_ms": 168.17838700000001,
+    "c2_aggregate_tok_s": 44.57590308669821,
+    "c2_ttft_p50_ms": 1025.256768,
+    "c4_aggregate_tok_s": 44.679030772146966,
+    "c4_ttft_p50_ms": 2877.552394,
+    "c8_aggregate_tok_s": 56.346158927683426,
+    "c8_ttft_p50_ms": 4754.3311619999995,
+    "cache_uncontrolled_cells": 0.0,
+    "min_cached_prompt_pct": 99.69604863221885,
+    "min_cached_prompt_tokens": 656.0,
+    "min_completion_tokens": 200.0,
+    "peak_aggregate_tok_s": 63.90468604318197,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "5 cells, zero errors, zero vacuous — every populated floor met (C1 22.3/19.1 · C2 44.6/35.4 · C4 44.7/41.8 · C8 56.3/49.6 · C16 63.9/57.0 · peak 63.9/57.0)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c16_aggregate_tok_s=63.90, c16_ttft_p50_ms=8039.36, c1_aggregate_tok_s=22.26, c1_ttft_p50_ms=168.18, c2_aggregate_tok_s=44.58, c2_ttft_p50_ms=1025.26, c4_aggregate_tok_s=44.68, c4_ttft_p50_ms=2877.55, c8_aggregate_tok_s=56.35, c8_ttft_p50_ms=4754.33, cache_uncontrolled_cells=0.00, min_cached_prompt_pct=99.70, min_cached_prompt_tokens=656.00, min_completion_tokens=200.00, peak_aggregate_tok_s=63.90, vacuous_cells=0.00 · Pass: 5 cells, zero errors, zero vacuous — every populated floor met (C1 22.3/19.1 · C2 44.6/35.4 · C4 44.7/41.8 · C8 56.3/49.6 · C16 63.9/57.0 · peak 63.9/57.0)",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep-dflash2/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/concurrency-sweep-dflash2/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"TTxNAygBVhqmDda4wrsEMd3rjD62kIORN6fW6Yz/3qnQSWmJx15unuhdlTPIbm1SO8kyd412M+jb1RpGm66YCg=="}

--- a/.benchmarks/concurrency-sweep/2026-09-06-da016237db.json
+++ b/.benchmarks/concurrency-sweep/2026-09-06-da016237db.json
@@ -1,0 +1,527 @@
+{
+  "schema": 1,
+  "benchmark_id": "concurrency-sweep",
+  "benchmark_name": "Concurrency Sweep",
+  "git_sha": "da016237db",
+  "recorded_at": 1788724995,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "concurrencies": "1, 2, 4, 8, 16, 32, 64, 128",
+    "isls": "512",
+    "min_c1": "17.2",
+    "min_c128": "107.6",
+    "min_c16": "82.55",
+    "min_c2": "24.05",
+    "min_c32": "96.8",
+    "min_c4": "35.7",
+    "min_c64": "107.6",
+    "min_c8": "45.7",
+    "min_peak": "107.6",
+    "osl": "320",
+    "prompt_mode": "natural",
+    "request_timeout_s": "600",
+    "warmup": "1"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "concurrency-sweep",
+    "--param",
+    "concurrencies=1, 2, 4, 8, 16, 32, 64, 128",
+    "--param",
+    "isls=512",
+    "--param",
+    "min_c1=17.2",
+    "--param",
+    "min_c128=107.6",
+    "--param",
+    "min_c16=82.55",
+    "--param",
+    "min_c2=24.05",
+    "--param",
+    "min_c32=96.8",
+    "--param",
+    "min_c4=35.7",
+    "--param",
+    "min_c64=107.6",
+    "--param",
+    "min_c8=45.7",
+    "--param",
+    "min_peak=107.6",
+    "--param",
+    "osl=320",
+    "--param",
+    "prompt_mode=natural",
+    "--param",
+    "request_timeout_s=600",
+    "--param",
+    "warmup=1",
+    "--serve-override",
+    "kv_cache_dtype=fp8",
+    "--serve-override",
+    "max_batch_size=128",
+    "--serve-override",
+    "max_model_len=4096",
+    "--serve-override",
+    "ssm_cache_slots=8",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "serve_overrides": {
+    "kv_cache_dtype": "fp8",
+    "max_batch_size": "128",
+    "max_model_len": "4096",
+    "ssm_cache_slots": "8"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2457.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788723516,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 44.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 50.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 44.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 50.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.5
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407039298683,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14107532,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 6589312,
+      "gpu_compute_apps": [
+        {
+          "pid": 449537,
+          "name": "./target/release/spark",
+          "used_mib": 103005
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788724995,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 72.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 77.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.7
+        }
+      ],
+      "sm_clock_mhz": 2483.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407039298683,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 12904708,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 6599628,
+      "gpu_compute_apps": [
+        {
+          "pid": 449537,
+          "name": "./target/release/spark",
+          "used_mib": 103523
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 1479,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 28.0,
+      "hottest_chassis_delta_c": 26.599999999999994
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +27 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "c128_aggregate_tok_s": 114.46912016656799,
+    "c128_ttft_p50_ms": 59015.808167,
+    "c16_aggregate_tok_s": 90.11997313391589,
+    "c16_ttft_p50_ms": 8230.58057,
+    "c1_aggregate_tok_s": 18.743170078878332,
+    "c1_ttft_p50_ms": 156.594444,
+    "c2_aggregate_tok_s": 29.933668451381216,
+    "c2_ttft_p50_ms": 1826.2390269999999,
+    "c32_aggregate_tok_s": 104.92191027805767,
+    "c32_ttft_p50_ms": 15699.847404,
+    "c4_aggregate_tok_s": 52.46096954758948,
+    "c4_ttft_p50_ms": 3074.742204,
+    "c64_aggregate_tok_s": 115.6332647167112,
+    "c64_ttft_p50_ms": 30011.409236,
+    "c8_aggregate_tok_s": 64.14475432048756,
+    "c8_ttft_p50_ms": 4904.710593,
+    "cache_uncontrolled_cells": 0.0,
+    "min_cached_prompt_pct": 99.54476479514416,
+    "min_cached_prompt_tokens": 656.0,
+    "min_completion_tokens": 269.0,
+    "peak_aggregate_tok_s": 115.6332647167112,
+    "vacuous_cells": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "8 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/17.2 · C2 29.9/24.1 · C4 52.5/35.7 · C8 64.1/45.7 · C16 90.1/82.5 · C32 104.9/96.8 · C64 115.6/107.6 · C128 114.5/107.6 · peak 115.6/107.6)",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · c128_aggregate_tok_s=114.47, c128_ttft_p50_ms=59015.81, c16_aggregate_tok_s=90.12, c16_ttft_p50_ms=8230.58, c1_aggregate_tok_s=18.74, c1_ttft_p50_ms=156.59, c2_aggregate_tok_s=29.93, c2_ttft_p50_ms=1826.24, c32_aggregate_tok_s=104.92, c32_ttft_p50_ms=15699.85, c4_aggregate_tok_s=52.46, c4_ttft_p50_ms=3074.74, c64_aggregate_tok_s=115.63, c64_ttft_p50_ms=30011.41, c8_aggregate_tok_s=64.14, c8_ttft_p50_ms=4904.71, cache_uncontrolled_cells=0.00, min_cached_prompt_pct=99.54, min_cached_prompt_tokens=656.00, min_completion_tokens=269.00, peak_aggregate_tok_s=115.63, vacuous_cells=0.00 · Pass: 8 cells, zero errors, zero vacuous — every populated floor met (C1 18.7/17.2 · C2 29.9/24.1 · C4 52.5/35.7 · C8 64.1/45.7 · C16 90.1/82.5 · C32 104.9/96.8 · C64 115.6/107.6 · C128 114.5/107.6 · peak 115.6/107.6)",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/concurrency-sweep/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/concurrency-sweep/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"iPu3SU0KP6qYQxvaI0NJe7w/asC1/5KA9lG1BXdKn+JdGt9jUmCU53X2ODNyA9BdMTtlSIrfK/81v8sGlEZIDw=="}

--- a/.benchmarks/decode-floor/2026-09-06-da016237db.json
+++ b/.benchmarks/decode-floor/2026-09-06-da016237db.json
@@ -1,0 +1,456 @@
+{
+  "schema": 1,
+  "benchmark_id": "decode-floor",
+  "benchmark_name": "Decode Floor Gate",
+  "git_sha": "da016237db",
+  "recorded_at": 1788725882,
+  "target_model": "unsloth/Qwen3.8-27B-NVFP4",
+  "params": {
+    "min_tok_s": "22.2",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "decode-floor",
+    "--param",
+    "min_tok_s=22.2",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.8/qwen3.8-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2463.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788725765,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 46.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 52.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 45.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 46.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 47.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 48.5
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 13821796,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 10423396,
+      "gpu_compute_apps": [
+        {
+          "pid": 469215,
+          "name": "./target/release/spark",
+          "used_mib": 103234
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788725882,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 75.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 83.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 80.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 83.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 70.1
+        }
+      ],
+      "sm_clock_mhz": 2463.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 14206664,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 10423408,
+      "gpu_compute_apps": [
+        {
+          "pid": 469215,
+          "name": "./target/release/spark",
+          "used_mib": 103239
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 117,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 29.0,
+      "hottest_chassis_delta_c": 31.499999999999993
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +31 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "accept_len_mean": 2.682571857571858,
+    "output_tokens": 795.0,
+    "runs": 3.0,
+    "server_decode_tok_s": 23.19740269602776
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median decode 23.2 tok/s over 3 pinned runs (accept_len_mean 2.68) — clears the 22.2 tok/s floor",
+  "summary": "unsloth/Qwen3.8-27B-NVFP4 · accept_len_mean=2.68, output_tokens=795.00, runs=3.00, server_decode_tok_s=23.20 · Pass: median decode 23.2 tok/s over 3 pinned runs (accept_len_mean 2.68) — clears the 22.2 tok/s floor",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/decode-floor/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/decode-floor/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"pPNzY2NQxbrWgblYpGaQnKKEJRGQ3EQRUGAfhzyGs9xszF8TCxkZBO7hyC3JTJDSWfwFtjWSKwTgqR3unihBCA=="}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-09-06-da016237db.json
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-09-06-da016237db.json
@@ -1,0 +1,470 @@
+{
+  "schema": 1,
+  "benchmark_id": "ssm-state-poisoning-gate",
+  "benchmark_name": "SSM State Poisoning Gate",
+  "git_sha": "da016237db",
+  "recorded_at": 1788727034,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "1024",
+    "request_timeout_s": "300",
+    "rounds": "12"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ssm-state-poisoning-gate",
+    "--param",
+    "max_tokens=1024",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "rounds=12",
+    "--serve-override",
+    "disable_thinking=true",
+    "--serve-override",
+    "ssm_cache_slots=256",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "serve_overrides": {
+    "disable_thinking": "true",
+    "ssm_cache_slots": "256"
+  },
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2444.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1788726952,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 51.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 51.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8997380,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7680556,
+      "gpu_compute_apps": [
+        {
+          "pid": 476608,
+          "name": "./target/release/spark",
+          "used_mib": 108713
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788727033,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 65.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 72.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 72.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.8
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 9080884,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7682976,
+      "gpu_compute_apps": [
+        {
+          "pid": 476608,
+          "name": "./target/release/spark",
+          "used_mib": 108739
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 81,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 14.0,
+      "hottest_chassis_delta_c": 11.200000000000003
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +11 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "collapsed": 0.0,
+    "invariant": 12.0,
+    "jittered": 0.0,
+    "min_cached_prompt_tokens": 1026.0,
+    "rounds": 12.0,
+    "sum_wall_s": 81.326250875,
+    "unmeasured": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "12 of 12 replays byte-identical to the reference",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · collapsed=0.00, invariant=12.00, jittered=0.00, min_cached_prompt_tokens=1026.00, rounds=12.00, sum_wall_s=81.33, unmeasured=0.00 · Pass: 12 of 12 replays byte-identical to the reference",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ssm-state-poisoning-gate/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/ssm-state-poisoning-gate/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"dqd0HJnACZV30Z+I6Hr+zlqpZurWmKiRHHKgtI06aFm+lAnChRty34BU8w+6J+mYvZJ8yhQJLffAy2ojAQoADg=="}

--- a/.benchmarks/ttft-cold-gate/2026-09-06-da016237db.json
+++ b/.benchmarks/ttft-cold-gate/2026-09-06-da016237db.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-cold-gate",
+  "benchmark_name": "Cold TTFT Regression Gate",
+  "git_sha": "da016237db",
+  "recorded_at": 1788726088,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-cold-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2450.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788726040,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 53.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.8
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8350500,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7688628,
+      "gpu_compute_apps": [
+        {
+          "pid": 469421,
+          "name": "./target/release/spark",
+          "used_mib": 108713
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788726087,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 68.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 77.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 63.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 77.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 66.4
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8500848,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7691096,
+      "gpu_compute_apps": [
+        {
+          "pid": 469421,
+          "name": "./target/release/spark",
+          "used_mib": 108737
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 47,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 15.0,
+      "hottest_chassis_delta_c": 16.1
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +16 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "median_ms": 899.6211500000001,
+    "p90_ms": 2017.778824,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=899.62, p90_ms=2017.78, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 +0.1% (limit +5.0%)",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-cold-gate/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/ttft-cold-gate/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"X7d1LD0mK32mKGFPayBdUR5K2UiVLdegjc2GesC0EkZqUa2x8Zz92vkwHM90RFlzad6i5J5f9hMEdm4oJYg6Aw=="}

--- a/.benchmarks/ttft-warm-gate/2026-09-06-da016237db.json
+++ b/.benchmarks/ttft-warm-gate/2026-09-06-da016237db.json
@@ -1,0 +1,467 @@
+{
+  "schema": 1,
+  "benchmark_id": "ttft-warm-gate",
+  "benchmark_name": "Warm TTFT Regression Gate",
+  "git_sha": "da016237db",
+  "recorded_at": 1788726007,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "median_limit_pct": "3",
+    "p90_limit_pct": "5",
+    "prompt_lengths": "256, 1024, 4096",
+    "repeats": "12",
+    "request_timeout_s": "300",
+    "update_baseline": "true"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "ttft-warm-gate",
+    "--param",
+    "median_limit_pct=3",
+    "--param",
+    "p90_limit_pct=5",
+    "--param",
+    "prompt_lengths=256, 1024, 4096",
+    "--param",
+    "repeats=12",
+    "--param",
+    "request_timeout_s=300",
+    "--param",
+    "update_baseline=true",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2489.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "speed",
+    "before": {
+      "captured_at": 1788725915,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 54.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.5
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8579980,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7516284,
+      "gpu_compute_apps": [
+        {
+          "pid": 469296,
+          "name": "./target/release/spark",
+          "used_mib": 108713
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788726007,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 71.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 79.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 65.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 79.3
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.2
+        }
+      ],
+      "sm_clock_mhz": 2489.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 8560292,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7518932,
+      "gpu_compute_apps": [
+        {
+          "pid": 469296,
+          "name": "./target/release/spark",
+          "used_mib": 108737
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 92,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 17.0,
+      "hottest_chassis_delta_c": 17.4
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "valid",
+      "concerns": [
+        "hottest chassis zone moved +17 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "median_ms": 828.3428865,
+    "p90_ms": 2032.0019029999999,
+    "samples": 36.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "median +0.1% (limit +3.0%) · p90 +0.2% (limit +5.0%)",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · median_ms=828.34, p90_ms=2032.00, samples=36.00 · Pass: median +0.1% (limit +3.0%) · p90 +0.2% (limit +5.0%)",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/ttft-warm-gate/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/ttft-warm-gate/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"aQMJ3TwYpsv9Ykc8dGNLLNrw+rOdVCW8e1j5mfukHzqEmokKi3EyUQVJj/CZDOabdOdsmwwnXEnwxT5ZXJgoAw=="}

--- a/.benchmarks/video-fidelity/2026-09-06-da016237db.json
+++ b/.benchmarks/video-fidelity/2026-09-06-da016237db.json
@@ -1,0 +1,462 @@
+{
+  "schema": 1,
+  "benchmark_id": "video-fidelity",
+  "benchmark_name": "Video Fidelity",
+  "git_sha": "da016237db",
+  "recorded_at": 1788727160,
+  "target_model": "unsloth/Qwen3.6-27B-NVFP4",
+  "params": {
+    "max_tokens": "320",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "video-fidelity",
+    "--param",
+    "max_tokens=320",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-27b-nvfp4-unsloth",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2431.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1788727142,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 55.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 55.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 56.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 67.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 57.0
+        }
+      ],
+      "sm_clock_mhz": 2411.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 34286000,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5886608,
+      "gpu_compute_apps": [
+        {
+          "pid": 476848,
+          "name": "./target/release/spark",
+          "used_mib": 84916
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788727160,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 62.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 69.4
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 58.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 59.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.5
+        }
+      ],
+      "sm_clock_mhz": 2489.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 32083032,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5886936,
+      "gpu_compute_apps": [
+        {
+          "pid": 476848,
+          "name": "./target/release/spark",
+          "used_mib": 87152
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 18,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 7.0,
+      "hottest_chassis_delta_c": 4.5
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +4 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "conc_1_correct": 1.0,
+    "conc_1_wall_ms": 722.0,
+    "conc_2_correct": 2.0,
+    "conc_2_wall_ms": 1443.0,
+    "conc_4_correct": 4.0,
+    "conc_4_wall_ms": 2893.0,
+    "control_held": 1.0,
+    "legs_asserted": 14.0,
+    "legs_passed": 14.0,
+    "legs_skipped": 0.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14/14 legs passed, control held, 0 skipped",
+  "summary": "unsloth/Qwen3.6-27B-NVFP4 · conc_1_correct=1.00, conc_1_wall_ms=722.00, conc_2_correct=2.00, conc_2_wall_ms=1443.00, conc_4_correct=4.00, conc_4_wall_ms=2893.00, control_held=1.00, legs_asserted=14.00, legs_passed=14.00, legs_skipped=0.00 · Pass: 14/14 legs passed, control held, 0 skipped",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/video-fidelity/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/video-fidelity/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"vv4gzLbfuh3H6bfi+ZtHMn+UVhRwMBr5AMOxhhai1tcXC/VeIcG6JNIJAR4dj2E4b4WmzR/MJ6rTxJ5HdQvoAw=="}

--- a/.benchmarks/vision-fidelity/2026-09-06-da016237db.json
+++ b/.benchmarks/vision-fidelity/2026-09-06-da016237db.json
@@ -1,0 +1,464 @@
+{
+  "schema": 1,
+  "benchmark_id": "vision-fidelity",
+  "benchmark_name": "Vision Fidelity",
+  "git_sha": "da016237db",
+  "recorded_at": 1788727124,
+  "target_model": "Qwen/Qwen3.6-35B-A3B-FP8",
+  "params": {
+    "max_tokens": "128",
+    "request_timeout_s": "300"
+  },
+  "command": [
+    "spark",
+    "benchmark",
+    "run",
+    "vision-fidelity",
+    "--param",
+    "max_tokens=128",
+    "--param",
+    "request_timeout_s=300",
+    "--pull-request-gate"
+  ],
+  "served_by": "qwen3.6/qwen3.6-35b-a3b-fp8-bf16head",
+  "atlas_version": "1.0.0-beta-preview",
+  "hardware": {
+    "gpu": "NVIDIA GB10",
+    "driver": "580.159.03",
+    "sm_clock_mhz": 2476.0,
+    "source": "nvidia-smi"
+  },
+  "hardware_state": {
+    "sensitivity": "correctness",
+    "before": {
+      "captured_at": 1788727070,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 52.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 60.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.8
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 52.6
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 60.5
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 54.1
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 53.8
+        }
+      ],
+      "sm_clock_mhz": 2405.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 9084540,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 7680808,
+      "gpu_compute_apps": [
+        {
+          "pid": 476725,
+          "name": "./target/release/spark",
+          "used_mib": 108713
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "after": {
+      "captured_at": 1788727124,
+      "machine": {
+        "hostname": "spark-28c2",
+        "machine_id": "7af66f30966a49b6886e00e2fce4b42f",
+        "gpu": "NVIDIA GB10",
+        "driver": "580.159.03"
+      },
+      "gpu_temp_c": 65.0,
+      "chassis_temps_c": [
+        {
+          "name": "acpitz",
+          "temp_c": 73.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.7
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 71.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 61.2
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 62.0
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 73.9
+        },
+        {
+          "name": "acpitz",
+          "temp_c": 64.4
+        }
+      ],
+      "sm_clock_mhz": 2476.0,
+      "sm_clock_max_mhz": 3003.0,
+      "throttle_counters": {
+        "sw_power_cap_us": 407312451851,
+        "sw_thermal_us": 0,
+        "hw_thermal_us": 0,
+        "hw_power_brake_us": 0,
+        "sync_boost_us": 0
+      },
+      "throttle_active": {
+        "sw_power_cap": false,
+        "sw_thermal": false,
+        "hw_thermal": false,
+        "hw_power_brake": false
+      },
+      "mem_available_kb": 6879148,
+      "mem_total_kb": 127600748,
+      "page_cache_kb": 5859664,
+      "gpu_compute_apps": [
+        {
+          "pid": 476725,
+          "name": "./target/release/spark",
+          "used_mib": 110880
+        }
+      ],
+      "cpu_governor": "performance",
+      "persistence_mode": true,
+      "sources": [
+        "nvidia-smi",
+        "procfs",
+        "sysfs"
+      ]
+    },
+    "delta": {
+      "elapsed_s": 54,
+      "sw_power_cap_us": 0,
+      "sw_thermal_us": 0,
+      "hw_thermal_us": 0,
+      "hw_power_brake_us": 0,
+      "gpu_temp_delta_c": 13.0,
+      "hottest_chassis_delta_c": 13.400000000000006
+    },
+    "precheck": {
+      "decision": "proceed"
+    },
+    "postcheck": {
+      "validity": "not-applicable",
+      "concerns": [
+        "hottest chassis zone moved +13 °C"
+      ]
+    },
+    "perf_class": "gb10@spark-28c2"
+  },
+  "metrics": {
+    "conc_1_wall_ms": 1966.0,
+    "conc_2_wall_ms": 3809.0,
+    "conc_4_wall_ms": 7491.0,
+    "concurrency_levels_clean": 3.0,
+    "control_held": 1.0,
+    "geometry_asserted": 14.0,
+    "geometry_cells": 14.0,
+    "geometry_matched": 14.0,
+    "integrity_measured": 10.0,
+    "integrity_passed": 10.0,
+    "probes_passed": 3.0,
+    "probes_total": 3.0
+  },
+  "frame_status": "Completed",
+  "verdict": "PASS",
+  "verdict_reason": "14 geometry cells matched, 3/3 probes, control held",
+  "summary": "Qwen/Qwen3.6-35B-A3B-FP8 · conc_1_wall_ms=1966.00, conc_2_wall_ms=3809.00, conc_4_wall_ms=7491.00, concurrency_levels_clean=3.00, control_held=1.00, geometry_asserted=14.00, geometry_cells=14.00, geometry_matched=14.00, integrity_measured=10.00, integrity_passed=10.00, probes_passed=3.00, probes_total=3.00 · Pass: 14 geometry cells matched, 3/3 probes, control held",
+  "perf_env": {
+    "ATLAS_PREFILL_CODISPATCH": "0",
+    "ATLAS_PREFILL_CODISPATCH_SETTLE_MS": "10",
+    "ATLAS_PREFILL_CODISPATCH_WINDOW_MS": "100"
+  },
+  "closure": {
+    "gb10/deepseek-v4-flash/nvfp4": {
+      "hash": "193fa0c34afaaabf8a3c3d53a3c9bfe09ca00de4738e0c8aeec99a5bae8de7dc",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-26b-a4b/nvfp4": {
+      "hash": "ee70cd97809ccbb3a49575e43edeb35c7db55b77f44f376d3a5ae7e0619a6e9e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/gemma-4-31b/nvfp4": {
+      "hash": "da0f878b4c010973eeaea14647c3c5c71102c4751042ead5a9ac054675510df3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-0.8b/nvfp4": {
+      "hash": "32fe7973ed2f8139eaa30e9452c5c7b2ad64fd4e2bbb37a9b6452e6960241730",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-35b-a3b/nvfp4": {
+      "hash": "dde2c857a8be065881964fd42f18ba04a698450005ad003aca1636798b38b93b",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/holo-3.1-4b/nvfp4": {
+      "hash": "9e6953c50802404f4ed057b77b32f8af99e10062e7a8c71f859020057cfa870a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/laguna-s-2.1/nvfp4": {
+      "hash": "28e7a237a229bb47b0b9d33437f95f7f11ec5e65b1c4e986631ef4588c170aaf",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/longcat-flash-lite/nvfp4": {
+      "hash": "74a24226b4fffcf0470c472a03a165e5b29500532dc355f478c96fb70b8fc346",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/minimax-m2-229b/nvfp4": {
+      "hash": "7b5fc619690d8847791231e514cfcd1881672e8d985ce910e3059fd9da533a09",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/mistral-small-4/nvfp4": {
+      "hash": "4d524d8d22372430dbc5f76a20357253db984b7c4f7fbe5682f8e12814b521b4",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-3-nano-30b-a3b/nvfp4": {
+      "hash": "e81019284f6ad146914389c5c83a49184ad9180efa20545885cb303279d47f2a",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-labs-3-puzzle-75b-a9b/nvfp4": {
+      "hash": "8b1d0a3922ebc0857b6e9c6529ce010cf32af7ceba2d17bf38b0b19794ff0834",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nemotron-super-120b-a12b/nvfp4": {
+      "hash": "f56fad180eaec2fe3ab4f7809e763c5c594688186951e897aa90150b83ea7eb3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/nllb-200-3.3b/nvfp4": {
+      "hash": "3e4db9639f5ffb9e796931194452f27fb258accd7e0355038fe77950eb076ea3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/ornith-1.0-9b/nvfp4": {
+      "hash": "ac0b6042183ceb24a3fe8d05bda852bb36afba88a50f78f41cd2ce5af9c457d3",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-next-80b-a3b/nvfp4": {
+      "hash": "c77d2a325a55385a081087263ccdd8e27a2c04b1d26c192c97af5a60b53f163d",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3-vl-30b-a3b/nvfp4": {
+      "hash": "c174da1a1236899fcc882bc82e9297d3dc6ff0e53047397d359623338819dd43",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    },
+    "gb10/qwen3.5-122b-a10b/nvfp4": {
+      "hash": "ea2ce2d3b5f59c76ac4e67f3411927dcb48de6fc6330918949e9b36b6f194e4e",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-27b/nvfp4": {
+      "hash": "8d1aac07868c059de6adaf4805154c875bf80efedbaa76801f0d472f71e6b4ac",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-35b-a3b/nvfp4": {
+      "hash": "71678cf48c687447340cfeff779b11954a8302647cb3803553287b7e32bd08b5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.5-397b-a17b/nvfp4": {
+      "hash": "a7f6c3644747f6e84c29d76456699a6bb5811b470efe89a5c5f266ff068a8138",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-27b/nvfp4": {
+      "hash": "2fd107baa3372493ef65c45adb48b33585d105b3e12b3b2de900aa3c37a97339",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.6-35b-a3b/nvfp4": {
+      "hash": "9b8377aee424649a9bdd7745d09a6cc3a30a972dbe10280604dc7ee910377ba8",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-27b/nvfp4": {
+      "hash": "7da53f8136388050cb96b67883fc58e3e5c43f7ab11c28768d688147ea3b00c5",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/qwen3.8-flash-next/nvfp4": {
+      "hash": "b27a2dc5e4510658d2afc4907e312394308a0f4f595323d46e134cbb4bb9ff73",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS"
+      ]
+    },
+    "gb10/step3p7-flash/nvfp4": {
+      "hash": "9ec24b8cf8d408c1e4a76ca8b962feb1dcb7f5c1a4ccaa9f606ca8fb8e37a1ae",
+      "arch": "sm_121f",
+      "compiler": "Build cuda_13.0.r13.0/compiler.36424714_0",
+      "flags": [
+        "--fmad=false",
+        "-DTQ_PLUS_SIGNS",
+        "-DHDIM=128"
+      ]
+    }
+  }
+}

--- a/.benchmarks/vision-fidelity/2026-09-06-da016237db.json.sig
+++ b/.benchmarks/vision-fidelity/2026-09-06-da016237db.json.sig
@@ -1,0 +1,1 @@
+{"v":1,"key":"02156264cbf75bd7","sig":"hQ3bv+/2/x3tu/u+clHx0LUTPELe642P09wzLg3JSVfJgT/Ho3DKTHgUpAMb8wXWu9L81jmrscOMLDX8DFELCw=="}

--- a/crates/atlas-core/src/registry.rs
+++ b/crates/atlas-core/src/registry.rs
@@ -24,10 +24,10 @@ use cudarc::nvrtc::Ptx;
 pub use crate::cuda_host::{CudaHost, host, release};
 use crate::error::{AtlasError, Result};
 
-// Raw CUDA driver API
+// Raw CUDA driver API. (`cuModuleLoadData`/`cuModuleUnload` left this list
+// when the raw handles became views into the cudarc-loaded modules — the
+// registry no longer loads or unloads anything through the raw API.)
 unsafe extern "C" {
-    fn cuModuleLoadData(module: *mut *mut c_void, image: *const c_void) -> i32;
-    fn cuModuleUnload(hmod: *mut c_void) -> i32;
     fn cuModuleGetFunction(hfunc: *mut *mut c_void, hmod: *mut c_void, name: *const i8) -> i32;
     fn cuLaunchKernel(
         f: *mut c_void,
@@ -223,25 +223,18 @@ impl AtlasRegistry {
             let module = ctx
                 .load_module(ptx)
                 .map_err(|e| AtlasError::ModuleLoad(format!("{name}: {e}")))?;
-            modules.insert(name, module);
 
-            // Load via raw CUDA API (for launch_on_stream — avoids cudarc layout issues)
-            let mut raw_mod: *mut c_void = std::ptr::null_mut();
-            let status = if is_binary {
-                // Self-describing binary object: pass the bytes directly.
-                unsafe { cuModuleLoadData(&mut raw_mod, blob.as_ptr() as *const c_void) }
-            } else {
-                let src_nul = CString::new(blob)
-                    .map_err(|e| AtlasError::ModuleLoad(format!("{name}: CString: {e}")))?;
-                unsafe { cuModuleLoadData(&mut raw_mod, src_nul.as_ptr() as *const c_void) }
-            };
-            if status != 0 {
-                return Err(AtlasError::ModuleLoad(format!(
-                    "{name}: cuModuleLoadData failed: {}",
-                    cuda_error_text(status)
-                )));
-            }
-            raw_modules.insert(name, raw_mod);
+            // The raw handle for launch_on_stream (which avoids cudarc's
+            // struct layouts) is the SAME module: derive it instead of
+            // JIT-compiling the blob a second time through
+            // `cuModuleLoadData`. The double load kept a second copy of
+            // every module's SASS resident and doubled driver-JIT time at
+            // boot for the entire kernel set. Lifetime: the handle is owned
+            // by the `Arc<CudaModule>` stored right beside it — `modules`
+            // and `raw_modules` live and die together in this struct, and
+            // `unload_raw` no longer unloads (cudarc's `Drop` does).
+            raw_modules.insert(name, module.cu_module_raw() as *mut c_void);
+            modules.insert(name, module);
         }
 
         Ok(AtlasRegistry {
@@ -314,23 +307,18 @@ impl AtlasRegistry {
         Ok(raw)
     }
 
-    /// Unload every raw module. Idempotent; `Drop` calls it.
+    /// Retire the raw handles. Idempotent; `Drop` calls it.
     ///
-    /// The cudarc-owned `modules` map unloads itself when its `Arc<CudaModule>`s
-    /// drop; only the handles obtained through the raw driver API need this.
+    /// Since the raw map stopped being a second `cuModuleLoadData` of every
+    /// blob and became views into the cudarc-owned `modules`, there is
+    /// nothing to `cuModuleUnload` here — the `Arc<CudaModule>`s unload the
+    /// one real copy when they drop. Draining first keeps the invariant
+    /// that no raw handle survives its module: the maps are torn down
+    /// together, raw side first.
     pub(crate) fn unload_raw(&mut self) -> Vec<String> {
-        let mut failures = Vec::new();
-        for (name, raw) in self.raw_modules.drain() {
-            // SAFETY: `raw` came from `cuModuleLoadData` in `init` on this
-            // process's context, has not been unloaded (the map is drained), and
-            // no launch can be in flight — the caller guarantees quiescence.
-            let status = unsafe { cuModuleUnload(raw) };
-            // A context that is already gone took its modules with it.
-            if status != 0 && !is_teardown_noop(status) {
-                failures.push(format!("{name}: {}", cuda_error_text(status)));
-            }
-        }
-        failures
+        self.raw_modules.drain().for_each(drop);
+        self.modules.drain().for_each(drop);
+        Vec::new()
     }
 
     /// Get the raw CUstream handle for Atlas's own stream.

--- a/crates/atlas-plugin/src/benchmarks/video/driver.rs
+++ b/crates/atlas-plugin/src/benchmarks/video/driver.rs
@@ -449,6 +449,46 @@ impl Benchmark for VideoFidelity {
             }
 
             // ── Mixed: an image and a video in one request ───────────────
+            //
+            // TWO cells, because one question could not tell two failures
+            // apart and for a while was read as accusing the wrong component.
+            //
+            //   * `mixed-media` asks for the clip's colors as a LIST. That is
+            //     a question about the ENGINE (are the clip's frames all
+            //     there?) only if the model cooperates, and qwen3.8-27B does
+            //     not: it treats the still as FRAME 1 OF THE VIDEO, so it
+            //     enumerates from the image and the clip's last color falls
+            //     off the end of a four-item list. What this cell really
+            //     measures is whether the CHECKPOINT keeps two media items
+            //     apart. qwen3.6 does; qwen3.8 does not. Kept strict, because
+            //     that difference is worth catching — but read as a model
+            //     property, not as an engine defect.
+            //
+            //   * `mixed-media-pads` MEASURES the contract instead of asking
+            //     about it: t(image+video) must equal t(image) + t(video) -
+            //     t(text), in the server's own `usage.prompt_tokens`. A pad
+            //     run of the wrong length cannot satisfy that, and no model
+            //     opinion enters. It is the cell whose failure should be
+            //     believed, and the only one entitled to accuse the contract.
+            //
+            // A content question was tried here first and does NOT work. On
+            // the failing pair every wording ("ends on", "final frame", "name
+            // the fourth", "the still is not part of the video") returned the
+            // same wrong color 5/5 — but swapping the grayscale still for a
+            // solid magenta one returned the RIGHT one, while the served rows
+            // were the identical 4 groups / 196 tokens in both cases. Whatever
+            // a still's colour can move is the model, not the splice.
+            //
+            // Measured on 2026-08-21 against a serve where `mixed-media` was
+            // red: the contract was INTACT. The clip's own allocation was
+            // identical in every ordering (4 temporal groups, 14x14 patches,
+            // 196 vision tokens), asked for the fourth frame the model said
+            // "Yellow", asked to describe the frames it called the still
+            // "Frame 1", and swapping the grayscale still for a solid magenta
+            // one returned all four clip colors from the plain list question.
+            // Beware when re-testing: this model's answers move across
+            // paraphrases (3, 4 and 6 colors for one clip), so a single
+            // wording is not evidence in either direction.
             Phase::Mixed => {
                 self.phase = Phase::Integrity;
                 let h = self.handle()?;
@@ -489,9 +529,10 @@ impl Benchmark for VideoFidelity {
                             CountCell::Mismatch {
                                 id: "mixed-media",
                                 detail: format!(
-                                    "image + video together: wanted [{}], got [{}] — the \
-                                     ordering contract between collection, markers and pad \
-                                     expansion is off",
+                                    "image + video together: wanted [{}], got [{}]. This cell \
+                                     does NOT localise the cause: see mixed-media-pads, which \
+                                     asks for the LAST frame directly and is the one that \
+                                     accuses the pad/marker contract",
                                     vid.colors.join(", "),
                                     super::score::colors_in_order(reply, PALETTE).join(", ")
                                 ),
@@ -513,20 +554,107 @@ impl Benchmark for VideoFidelity {
                         }
                     }
                 };
-                let line = match &cell {
-                    CountCell::Match { detail, .. } => {
-                        LogLine::info(format!("mixed-media: {detail}"))
+                // The contract cell: PAD ARITHMETIC, not a question about
+                // pixels. Four short requests, and the identity
+                //
+                //     t(image + video) == t(image) + t(video) - t(text)
+                //
+                // must hold exactly. Every term is a `usage.prompt_tokens`
+                // the server reports, so a pad run of the wrong length shows
+                // up as a non-zero delta and no model opinion is involved.
+                //
+                // It is a MEASUREMENT, not a probe, on purpose. A content
+                // question cannot do this job here: swapping the grayscale
+                // still for a solid magenta one changes whether the model
+                // reports the clip's last color, while the served rows are
+                // byte-for-byte the same 4 groups / 196 tokens either way. A
+                // desync is content-independent; anything a still's colour can
+                // move is the model, not the contract (measured 2026-08-21).
+                let model = h.target().model.clone();
+                let short = 16;
+                let b_text = request::text_array_body(&model, request::ORDER_PROMPT, short);
+                let b_img =
+                    request::image_body(&model, "image/png", png, request::ORDER_PROMPT, short);
+                let b_vid =
+                    request::video_body(&model, vid.mime, vid.bytes, request::ORDER_PROMPT, short);
+                let b_both = request::mixed_body(
+                    &model,
+                    png,
+                    vid.mime,
+                    vid.bytes,
+                    request::ORDER_PROMPT,
+                    short,
+                );
+                let t_text = http::chat_stream(h.target(), &b_text, self.timeout()).await;
+                let t_img = http::chat_stream(h.target(), &b_img, self.timeout()).await;
+                let t_vid = http::chat_stream(h.target(), &b_vid, self.timeout()).await;
+                let t_both = http::chat_stream(h.target(), &b_both, self.timeout()).await;
+                let tail_cell = match (t_text, t_img, t_vid, t_both) {
+                    (Ok(tx), Ok(ti), Ok(tv), Ok(tb)) => {
+                        let predicted =
+                            (ti.prompt_tokens + tv.prompt_tokens).saturating_sub(tx.prompt_tokens);
+                        if tb.prompt_tokens == predicted {
+                            CountCell::Match {
+                                id: "mixed-media-pads",
+                                detail: format!(
+                                    "pad arithmetic exact: image {} + video {} - text {} = {} \
+                                     served",
+                                    ti.prompt_tokens,
+                                    tv.prompt_tokens,
+                                    tx.prompt_tokens,
+                                    tb.prompt_tokens
+                                ),
+                            }
+                        } else {
+                            CountCell::Mismatch {
+                                id: "mixed-media-pads",
+                                detail: format!(
+                                    "pad run is the WRONG LENGTH in a mixed request: image {} + \
+                                     video {} - text {} predicts {predicted}, server charged {} \
+                                     (off by {}) — this IS the collection/marker/pad-expansion \
+                                     contract",
+                                    ti.prompt_tokens,
+                                    tv.prompt_tokens,
+                                    tx.prompt_tokens,
+                                    tb.prompt_tokens,
+                                    tb.prompt_tokens as i64 - predicted as i64
+                                ),
+                            }
+                        }
                     }
-                    CountCell::Mismatch { detail, .. } => {
-                        LogLine::warn(format!("mixed-media: {detail}"))
+                    (tx, ti, tv, tb) => {
+                        let msg = [tx.err(), ti.err(), tv.err(), tb.err()]
+                            .into_iter()
+                            .flatten()
+                            .map(|e| one_line(format!("{e:#}")))
+                            .next()
+                            .unwrap_or_else(|| "unknown".to_string());
+                        if request::is_decoder_unavailable(&msg) {
+                            CountCell::Skipped {
+                                id: "mixed-media-pads",
+                                why: msg,
+                            }
+                        } else {
+                            CountCell::Error {
+                                id: "mixed-media-pads",
+                                msg,
+                            }
+                        }
                     }
-                    CountCell::Skipped { why, .. } => {
-                        LogLine::info(format!("mixed-media: skipped — {why}"))
-                    }
-                    CountCell::Error { msg, .. } => LogLine::warn(format!("mixed-media: {msg}")),
                 };
+                let describe = |c: &CountCell, id: &str| match c {
+                    CountCell::Match { detail, .. } => LogLine::info(format!("{id}: {detail}")),
+                    CountCell::Mismatch { detail, .. } => LogLine::warn(format!("{id}: {detail}")),
+                    CountCell::Skipped { why, .. } => {
+                        LogLine::info(format!("{id}: skipped — {why}"))
+                    }
+                    CountCell::Error { msg, .. } => LogLine::warn(format!("{id}: {msg}")),
+                };
+                let line = describe(&cell, "mixed-media");
+                let tail_line = describe(&tail_cell, "mixed-media-pads");
                 self.counts.push(cell);
-                Ok(self.frame("mixed", vec![line]))
+                self.counts.push(tail_cell);
+                Ok(self.frame("mixed", vec![line, tail_line]))
             }
 
             // ── Integrity: the shapes that need MORE THAN ONE video item ─

--- a/crates/atlas-plugin/src/benchmarks/video/request.rs
+++ b/crates/atlas-plugin/src/benchmarks/video/request.rs
@@ -80,6 +80,43 @@ pub fn text_only_body(model: &str, prompt: &str, max_tokens: usize) -> Value {
     })
 }
 
+/// One request carrying a single IMAGE, and one carrying only text — the two
+/// baselines the pad-arithmetic cell subtracts.
+///
+/// Both send `content` as an ARRAY, matching [`video_body`] and [`mixed_body`].
+/// [`text_only_body`] sends a bare string instead, which renders through a
+/// different template branch and costs a different number of tokens: using it
+/// as the baseline makes the arithmetic disagree by a constant that has
+/// nothing to do with pad runs. That is why these exist rather than reusing it.
+pub fn image_body(model: &str, mime: &str, png: &[u8], prompt: &str, max_tokens: usize) -> Value {
+    json!({
+        "model": model,
+        "stream": true,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "chat_template_kwargs": {"enable_thinking": false},
+        "messages": [{"role": "user", "content": [
+            {"type": "image_url", "image_url": {"url": data_uri(mime, png)}},
+            {"type": "text", "text": prompt},
+        ]}],
+    })
+}
+
+/// Text only, as a content ARRAY. See [`image_body`] for why this is not
+/// [`text_only_body`].
+pub fn text_array_body(model: &str, prompt: &str, max_tokens: usize) -> Value {
+    json!({
+        "model": model,
+        "stream": true,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "chat_template_kwargs": {"enable_thinking": false},
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": prompt},
+        ]}],
+    })
+}
+
 /// Does this error read as "the server cannot decode that container"?
 ///
 /// A server without ffmpeg is a DEPLOYMENT choice, not a defect, so those legs

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -60,14 +60,14 @@ pub struct GdnFlags {
     /// shape measured (#459). Closing that needs single-row routing for the
     /// whole verify forward, which is future work.
     ///
-    /// ★ Do not read "default off" as "default harmless". The divergence this
-    /// closes is not a cosmetic one-token difference at temperature 0: the
-    /// flipped token lands in a repetition attractor that the drafter then
-    /// AGREES with (7/7 accepted), so replies collapse into repetition or
-    /// unrelated text. Measured 2026-08-21 on qwen3.8-27B-NVFP4 + DFlash2,
-    /// `video-fidelity` went 0/2 and 0/4 correct at C=2/C=4 by default and
-    /// 2/2, 4/4 with this flag on. The operator-facing consequences and a
-    /// repro live on `ServeArgs::exact_verify`.
+    /// ★ Attribution warning, learned the hard way: a 2026-08-21 measurement
+    /// showed gross output degeneration (video-fidelity 0/2, 0/4 at C=2/C=4)
+    /// that this flag appeared to fix. The real cause was the K=4 verdict
+    /// rewind bug (#699); this flag only changed dispatch so the bug stopped
+    /// firing. The 1-ULP divergence this flag actually closes has never been
+    /// shown to cause more than an occasional flipped token at temperature 0.
+    /// If flipping this flag changes gross behavior, suspect a dispatch-
+    /// sensitive scheduler bug first. Details on `ServeArgs::exact_verify`.
     pub exact_verify: bool,
 }
 

--- a/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/gdn_flags.rs
@@ -59,6 +59,15 @@ pub struct GdnFlags {
     /// implementations round differently — ~5e-5 of lanes by 1 ULP, on every
     /// shape measured (#459). Closing that needs single-row routing for the
     /// whole verify forward, which is future work.
+    ///
+    /// ★ Do not read "default off" as "default harmless". The divergence this
+    /// closes is not a cosmetic one-token difference at temperature 0: the
+    /// flipped token lands in a repetition attractor that the drafter then
+    /// AGREES with (7/7 accepted), so replies collapse into repetition or
+    /// unrelated text. Measured 2026-08-21 on qwen3.8-27B-NVFP4 + DFlash2,
+    /// `video-fidelity` went 0/2 and 0/4 correct at C=2/C=4 by default and
+    /// 2/2, 4/4 with this flag on. The operator-facing consequences and a
+    /// repro live on `ServeArgs::exact_verify`.
     pub exact_verify: bool,
 }
 

--- a/crates/spark-model/src/layers/vision_encoder/enc_impl/forward.rs
+++ b/crates/spark-model/src/layers/vision_encoder/enc_impl/forward.rs
@@ -12,6 +12,47 @@ use spark_runtime::gpu::GpuBackend;
 
 use super::super::VisionEncoder;
 
+/// Do the packed merged rows this batch will write fit `buf_out`?
+///
+/// #799: this bound existed as a `debug_assert!`, which is compiled out of the
+/// `--release` binaries we serve. A single video request then wrote 4.7x past
+/// the allocation, raising `CUDA_ERROR_ILLEGAL_ADDRESS` and poisoning the CUDA
+/// context — the process survived and answered 503 to every later request, for
+/// every tenant, until it was restarted.
+///
+/// The caller's own doc comment says the scheduler caps `Σp <= p_max` "so this
+/// is normally unreachable". Video defeats that cap: all temporal groups of one
+/// clip arrive as a SINGLE media item and are encoded as one batch, so the
+/// per-item cap never sees the sum. 19 groups of 30x34 patches merge to 4845
+/// rows against a 1024-row buffer.
+///
+/// A `Result` rather than an assert, and a free function rather than a method,
+/// for the same reason `check_pixel_len` next door is one: the refusal is the
+/// behaviour worth testing, and a bound that can only be exercised with a GPU
+/// attached is a bound nothing will exercise. Prose is not a bound; this is.
+fn check_packed_rows(mp_i: &[usize], mp_off: &[usize], p_max: usize) -> Result<()> {
+    anyhow::ensure!(
+        mp_i.len() == mp_off.len(),
+        "vision: {} merged row counts but {} offsets; the packed layout is inconsistent",
+        mp_i.len(),
+        mp_off.len()
+    );
+    let end = match (mp_off.last(), mp_i.last()) {
+        (Some(off), Some(n)) => off
+            .checked_add(*n)
+            .ok_or_else(|| anyhow::anyhow!("vision: merged row offset {off} + {n} overflows"))?,
+        _ => 0,
+    };
+    anyhow::ensure!(
+        end <= p_max,
+        "vision: this batch packs {end} merged rows into an output buffer of {p_max} rows. \
+         A video arrives as one media item whose temporal groups encode as a single batch, \
+         which defeats the scheduler's per-item cap. Send fewer frames, or allocate a \
+         larger vision scratch."
+    );
+    Ok(())
+}
+
 impl VisionEncoder {
     /// Single-image forward (back-compat shim). For N=1 this issues the SAME
     /// kernels with the SAME args in the SAME order as the old per-image path
@@ -246,10 +287,7 @@ impl VisionEncoder {
         gpu: &dyn GpuBackend,
         stream: u64,
     ) -> Result<Vec<(usize, usize, usize)>> {
-        debug_assert!(
-            mp_off.last().map(|o| o + mp_i.last().unwrap()).unwrap_or(0) <= self.p_max,
-            "oversized vision batch: Σmerged_p exceeds buf_out rows"
-        );
+        check_packed_rows(mp_i, mp_off, self.p_max)?;
         let pos_interp_on = std::env::var("ATLAS_VISION_POSINTERP")
             .map(|v| v != "0")
             .unwrap_or(true);
@@ -290,5 +328,67 @@ impl VisionEncoder {
             .iter()
             .map(|(_px, gh, gw)| (gh / sms, gw / sms, (gh * gw) / (sms * sms)))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_packed_rows;
+
+    /// The batch from issue #799, with its real numbers. A Qwen3.8-27B serve at
+    /// `--vision-max-pixels 262144` allocates 1024 patch rows; one video of 19
+    /// temporal groups at 30x34 patches merges 2x2 to 255 rows per group, so
+    /// the packed write ends at 4845 — 4.7x the allocation.
+    ///
+    /// Before this check that write happened, in release, and poisoned the CUDA
+    /// context: the server then answered 503 to every request, for every
+    /// tenant, until restarted. It must now be a refused request instead.
+    #[test]
+    fn refuses_the_video_batch_that_poisoned_the_cuda_context() {
+        let groups = 19;
+        let merged_per_group = (30 / 2) * (34 / 2); // 255
+        let mp_i = vec![merged_per_group; groups];
+        let mp_off: Vec<usize> = (0..groups).map(|g| g * merged_per_group).collect();
+        assert_eq!(mp_off.last().unwrap() + mp_i.last().unwrap(), 4845);
+
+        let err = check_packed_rows(&mp_i, &mp_off, 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("4845"),
+            "must name the rows it would have written: {err}"
+        );
+        assert!(err.contains("1024"), "must name the capacity: {err}");
+    }
+
+    /// The ordinary path the scheduler's cap produces must still pass, or the
+    /// fix trades an outage for a refusal of every image request.
+    #[test]
+    fn admits_a_batch_that_fits() {
+        assert!(check_packed_rows(&[100, 200], &[0, 100], 1024).is_ok());
+        // Exactly full is not over-full.
+        assert!(check_packed_rows(&[24], &[1000], 1024).is_ok());
+        // One row past is.
+        assert!(check_packed_rows(&[25], &[1000], 1024).is_err());
+    }
+
+    /// An empty batch writes nothing. The previous expression reached
+    /// `mp_i.last().unwrap()` whenever `mp_off` was non-empty, so a length
+    /// mismatch was a panic rather than an error.
+    #[test]
+    fn handles_empty_and_mismatched_layouts_without_panicking() {
+        assert!(check_packed_rows(&[], &[], 1024).is_ok());
+        let err = check_packed_rows(&[], &[0], 1024).unwrap_err().to_string();
+        assert!(err.contains("inconsistent"), "{err}");
+    }
+
+    /// `usize` addition on attacker-influenced geometry must not wrap into a
+    /// passing comparison.
+    #[test]
+    fn an_overflowing_offset_is_an_error_not_a_wrap() {
+        let err = check_packed_rows(&[2], &[usize::MAX - 1], 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("overflows"), "{err}");
     }
 }

--- a/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
+++ b/crates/spark-runtime/cuda/cutlass_nvfp4_grouped_gemm.cu
@@ -13,6 +13,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime_api.h>
+#include <cstdlib>
 #include <vector>
 
 #include "cute/tensor.hpp"
@@ -353,15 +354,48 @@ struct GroupedAPrep {
 };
 
 // Gather+pack A once (per active group), upload the A-side argument arrays.
+//
+// `b_valid_ptrs` (nullable) is the per-expert B weight-pointer table. Under
+// EXPERT PARALLELISM the router and the sort stay GLOBAL-width, so a rank
+// receives routed rows (m_e > 0) for experts it does not own — and those
+// experts' weights are null placeholders (`ExpertWeight::null()`). Grouping
+// them would bind a null B and fault the grouped GEMM with an illegal address,
+// which is exactly what made the CUTLASS MoE path unusable under EP while the
+// hand-written ptrtable kernels survived (they open with `if (B_expert == 0)
+// return;`). Skipping the group here reproduces that semantic: the rank
+// contributes nothing for a remote expert, its C rows stay as pre-zeroed by
+// the EP memset in forward_prefill_routed, and the owning rank's contribution
+// arrives via the all-reduce.
+//
+// Pass nullptr to disable filtering. Single-GPU tables are never null, so this
+// is a strict no-op off EP.
 static GroupedAPrep prep_grouped_a(
     const __nv_bfloat16* A_global,
     const int* sorted_token_ids,
     const int* expert_offsets_host,
+    const unsigned long long* b_valid_ptrs,
     int num_experts,
     int n,
     int k,
     unsigned char* ws,
     cudaStream_t stream) {
+  // A/B arm: ATLAS_CUTLASS_EP_NULL_GUARD=0 restores the pre-fix behaviour
+  // (group every expert with rows, null B included). Off EP the two arms are
+  // identical; under EP the disabled arm faults, which is what makes this a
+  // usable experiment rather than just a switch.
+  static const bool null_guard = [] {
+    const char* v = getenv("ATLAS_CUTLASS_EP_NULL_GUARD");
+    return !(v != nullptr && v[0] == '0');
+  }();
+  // Both passes below must apply the SAME predicate or the per-group staging
+  // offsets (a_grp_off/sfa_grp_off, indexed by `gi`) desynchronize from the
+  // groups actually built.
+  auto group_active = [&](int e) -> bool {
+    if (expert_offsets_host[e + 1] - expert_offsets_host[e] <= 0) {
+      return false;
+    }
+    return !null_guard || b_valid_ptrs == nullptr || b_valid_ptrs[e] != 0;
+  };
   GroupedAPrep p;
   std::vector<const ElementA::DataType*> hA;
   std::vector<const ElementSF*> hSFA;
@@ -374,7 +408,7 @@ static GroupedAPrep prep_grouped_a(
   size_t sfa_acc = 0;
   for (int e = 0; e < num_experts; ++e) {
     int m_e = expert_offsets_host[e + 1] - expert_offsets_host[e];
-    if (m_e <= 0) {
+    if (!group_active(e)) {
       continue;
     }
     auto lsa =
@@ -397,7 +431,7 @@ static GroupedAPrep prep_grouped_a(
   for (int e = 0; e < num_experts; ++e) {
     int ms = expert_offsets_host[e];
     int m_e = expert_offsets_host[e + 1] - ms;
-    if (m_e <= 0) {
+    if (!group_active(e)) {
       continue;
     }
     auto lsa =
@@ -511,6 +545,13 @@ static int launch_projection(
     int e = a.eidx[g];
     int m_e = a.me[g];
     size_t ms = (size_t)a.ms[g];
+    // A null B/SFB here means a group survived the prep filter that should not
+    // have (see `b_valid_ptrs` on prep_grouped_a — EP remote experts). Report it
+    // as a status instead of letting the grouped GEMM fault on a null
+    // dereference, which surfaces as an opaque CUDA 700 far from the cause.
+    if (packed_ptrs[e] == 0 || sfb_ptrs[e] == 0) {
+      return -140;
+    }
     hB[g] = reinterpret_cast<const ElementB::DataType*>(packed_ptrs[e]);
     hSFB[g] = reinterpret_cast<const ElementSF*>(sfb_ptrs[e]);
     hC[g] = reinterpret_cast<const ElementC*>(C_bf16 + ms * n);
@@ -617,8 +658,11 @@ extern "C" int atlas_cutlass_nvfp4_grouped_gate_up_fused(
   }
   unsigned char* ws = static_cast<unsigned char*>(workspace);
   // Pack A ONCE (gate + up share the same activation).
+  // gate/up/down are null for the SAME (remote) experts, so gate's table is a
+  // sufficient validity mask for the shared A-prep.
   GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16),
-                                  sorted_token_ids, expert_offsets_host, num_experts,
+                                  sorted_token_ids, expert_offsets_host,
+                                  gate_packed_ptrs, num_experts,
                                   n, k, ws, stream);
   if (a.G == 0) {
     return 0;
@@ -680,7 +724,8 @@ extern "C" int atlas_cutlass_nvfp4_grouped_down(
   }
   unsigned char* ws = static_cast<unsigned char*>(workspace);
   GroupedAPrep a = prep_grouped_a(static_cast<const __nv_bfloat16*>(A_bf16), nullptr,
-                                  expert_offsets_host, num_experts, n, k, ws, stream);
+                                  expert_offsets_host, packed_ptrs, num_experts, n, k,
+                                  ws, stream);
   if (a.G == 0) {
     return 0;
   }

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -318,6 +318,18 @@ pub struct ServeArgs {
     /// so a smoke test that only asks small questions will not see this.
     /// Fastest repro is a prompt whose correct answer is a short ordered list.
     ///
+    /// ★ AND THE COST CAN BE NEGATIVE. The ~+22-36% below is a per-decode-STEP
+    /// figure; end-to-end throughput also depends on how many drafts survive
+    /// verification, which is precisely what the divergence damages. Corrupted
+    /// verify logits REJECT CORRECT DRAFTS — the drafter proposes roughly what
+    /// the true model would say and a verifier reading wrong logits disagrees.
+    /// Measured at C=1 on the config above (one prompt, n=3 after a warm
+    /// request): 27.29 tok/s and 35.0% mean acceptance by default, versus
+    /// 32.45 tok/s and 45.5% acceptance with this flag on — +18.9% throughput
+    /// for turning exactness ON. Where the divergence actually bites, this is
+    /// not a tradeoff. The crossover against the concurrency rungs, where the
+    /// step costs below were measured, still needs its own sweep.
+    ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output
     /// bitwise-equal to non-speculative output end to end, and setting it

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -297,10 +297,35 @@ pub struct ServeArgs {
 
     /// Sequential-decode-exact GDN/SSM verify chain — OPT-IN (default: off).
     ///
+    /// ★ WHAT THE DEFAULT COSTS IN PRACTICE, because "a flipped argmax" reads
+    /// milder than it behaves (measured 2026-08-21, qwen3.8-27B-NVFP4 + DFlash2
+    /// on GB10, one binary, this flag the only variable):
+    ///
+    ///     prompt "count from 1 to 10"   default: `1, 2, 100, 100, 100, ...`
+    ///                                   exact:   `1, 2, 3, 4, 5, ..., 10`
+    ///     video-fidelity C=1/C=2/C=4    default: 1/1, 0/2, 0/4 correct
+    ///                                   exact:   1/1, 2/2, 4/4 correct
+    ///
+    /// A flipped token does not stay one wrong token. It lands the sequence in
+    /// a repetition attractor, and the DRAFTER THEN AGREES with it — verify
+    /// steps go 7/7 accepted — so the loop is locked in and the reply
+    /// degenerates into repetition or unrelated text until the token cap. This
+    /// is why the symptom looks like a broken drafter while acceptance
+    /// telemetry looks healthy: the accepts are honest, the logits they check
+    /// against are not the ones sequential decode would have produced.
+    ///
+    /// A short reply can hide it entirely — a 2-token "Paris" answer survives —
+    /// so a smoke test that only asks small questions will not see this.
+    /// Fastest repro is a prompt whose correct answer is a short ordered list.
+    ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output
     /// bitwise-equal to non-speculative output end to end, and setting it
-    /// will not give you a reproducible spec-on serve.
+    /// will not give you a reproducible spec-on serve. Measured with the flag
+    /// ON, the residual is still visible: an occasional single wrong token,
+    /// and the same request at temperature 0 answering with 45 tokens once and
+    /// 50 the next time — because the accepted-row COUNT varies with runtime
+    /// scheduling, so the row-count-selected projection kernel varies with it.
     ///
     /// Why not (measured on GB10, issue #459): every FFN and attention
     /// projection is computed by a kernel selected on ROW COUNT. A token

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -297,26 +297,24 @@ pub struct ServeArgs {
 
     /// Sequential-decode-exact GDN/SSM verify chain — OPT-IN (default: off).
     ///
-    /// ★ WHAT THE DEFAULT COSTS IN PRACTICE, because "a flipped argmax" reads
-    /// milder than it behaves (measured 2026-08-21, qwen3.8-27B-NVFP4 + DFlash2
-    /// on GB10, one binary, this flag the only variable):
+    /// ★ THIS FLAG IS NOT A CORRECTNESS SWITCH. A 2026-08-21 measurement on
+    /// this doc's earlier revision showed the default chain degenerating
+    /// ("count from 1 to 10" → `1, 2, 100, 100, ...`; video-fidelity 0/2 and
+    /// 0/4 at C=2/C=4) and this flag fixing all of it. That attribution was
+    /// WRONG. The degeneration was a scheduler bug — the K=4 verdict rewound
+    /// a sequence by its pending-draft count instead of the forward's row
+    /// count, erasing committed tokens (fixed in #699) — and this flag only
+    /// changed the gate's dispatch pattern so the bug stopped firing. With
+    /// #699 in place every one of those repros passes with the flag OFF.
     ///
-    ///     prompt "count from 1 to 10"   default: `1, 2, 100, 100, 100, ...`
-    ///                                   exact:   `1, 2, 3, 4, 5, ..., 10`
-    ///     video-fidelity C=1/C=2/C=4    default: 1/1, 0/2, 0/4 correct
-    ///                                   exact:   1/1, 2/2, 4/4 correct
-    ///
-    /// A flipped token does not stay one wrong token. It lands the sequence in
-    /// a repetition attractor, and the DRAFTER THEN AGREES with it — verify
-    /// steps go 7/7 accepted — so the loop is locked in and the reply
-    /// degenerates into repetition or unrelated text until the token cap. This
-    /// is why the symptom looks like a broken drafter while acceptance
-    /// telemetry looks healthy: the accepts are honest, the logits they check
-    /// against are not the ones sequential decode would have produced.
-    ///
-    /// A short reply can hide it entirely — a 2-token "Paris" answer survives —
-    /// so a smoke test that only asks small questions will not see this.
-    /// Fastest repro is a prompt whose correct answer is a short ordered list.
+    /// What the default chain actually does is what #435/#459 measured: ~5e-5
+    /// of lanes differ by 1 ULP against sequential decode, which can flip an
+    /// occasional argmax at temperature 0. No case of that flip causing gross
+    /// degeneration has survived root-causing; every "the default chain broke
+    /// my output" report so far has traced to a different bug that this flag
+    /// happened to perturb. If this flag ever appears to fix a correctness
+    /// problem, treat that as a dispatch-sensitivity SYMPTOM and go find the
+    /// real bug before pinning the flag.
     ///
     /// ★ THE COST IS REAL, and measuring it needs a validated serve profile.
     /// Measured on the LEAN profile (32K ctx, 8 seqs, NO prefix caching — the
@@ -328,9 +326,9 @@ pub struct ServeArgs {
     ///
     /// i.e. -7% to -31%. An earlier measurement of this same flag reported it
     /// as a THROUGHPUT WIN; that was taken on a serve with prefix caching on
-    /// at 128K, where the default arm was pathologically bad for an unrelated
-    /// reason, and it is withdrawn. Benchmark a correctness flag only on a
-    /// profile you have separately validated for throughput.
+    /// at 128K, where the default arm was degenerating under the #699 bug,
+    /// and it is withdrawn. Benchmark a numerics flag only on a profile you
+    /// have separately validated for throughput — and for correctness.
     ///
     /// It does not buy reproducibility either. On the pinned `decode-floor`
     /// benchmark this flag returned 943/553/943 tokens across three IDENTICAL

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -318,17 +318,23 @@ pub struct ServeArgs {
     /// so a smoke test that only asks small questions will not see this.
     /// Fastest repro is a prompt whose correct answer is a short ordered list.
     ///
-    /// ★ AND THE COST CAN BE NEGATIVE. The ~+22-36% below is a per-decode-STEP
-    /// figure; end-to-end throughput also depends on how many drafts survive
-    /// verification, which is precisely what the divergence damages. Corrupted
-    /// verify logits REJECT CORRECT DRAFTS — the drafter proposes roughly what
-    /// the true model would say and a verifier reading wrong logits disagrees.
-    /// Measured at C=1 on the config above (one prompt, n=3 after a warm
-    /// request): 27.29 tok/s and 35.0% mean acceptance by default, versus
-    /// 32.45 tok/s and 45.5% acceptance with this flag on — +18.9% throughput
-    /// for turning exactness ON. Where the divergence actually bites, this is
-    /// not a tradeoff. The crossover against the concurrency rungs, where the
-    /// step costs below were measured, still needs its own sweep.
+    /// ★ THE COST IS REAL, and measuring it needs a validated serve profile.
+    /// Measured on the LEAN profile (32K ctx, 8 seqs, NO prefix caching — the
+    /// profile this project's recorded baselines were taken on), code prompt,
+    /// aggregate tok/s at C=1/2/4/8:
+    ///
+    ///     default   56 /  88 / 113 / 123    accept 85 / 86 / 80 / 74 %
+    ///     exact     52 /  72 /  78 /  98    accept 81 / 76 / 58 / 64 %
+    ///
+    /// i.e. -7% to -31%. An earlier measurement of this same flag reported it
+    /// as a THROUGHPUT WIN; that was taken on a serve with prefix caching on
+    /// at 128K, where the default arm was pathologically bad for an unrelated
+    /// reason, and it is withdrawn. Benchmark a correctness flag only on a
+    /// profile you have separately validated for throughput.
+    ///
+    /// It does not buy reproducibility either. On the pinned `decode-floor`
+    /// benchmark this flag returned 943/553/943 tokens across three IDENTICAL
+    /// runs — the row-count residual below, showing up directly.
     ///
     /// SCOPE, and it is narrower than this flag once claimed: it makes the
     /// GDN/SSM verify chain exact. It does NOT make speculative output

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -403,12 +403,25 @@ fn apply_rollback(a: &mut ActiveSeq, keep_len: usize, dropped: usize) {
     // 5. Rewind the grammar FSM by the same token count so the
     //    constrained-decoding matcher stays in sync with the truncated
     //    token stream. Every dropped token is a post-`</think>` content
-    //    token (the watchdogs that call this fire after thinking has
-    //    closed) and was therefore fed to `grammar_state.accept_token`,
-    //    so `rollback(dropped)` is exact. Reuses the existing
-    //    spec-decode grammar-rewind path (`GrammarState::rollback`).
+    //    token, so it was fed to `grammar_state.accept_token`.
+    //
+    //    That did NOT make `rollback(dropped)` exact, and #842 is what it
+    //    cost: `accept_token` returns true for stop/EOS and in the TERMINATED
+    //    state without advancing the matcher, so a `json_schema` matcher that
+    //    has already closed its object records no steps for the tokens that
+    //    follow. One report dropped 96 tokens against 1 recorded step; the
+    //    assert inside the matcher then panicked the scheduler thread and the
+    //    server accepted requests forever without generating.
     if let Some(ref mut gs) = a.grammar_state {
-        gs.rollback(dropped);
+        match grammar_rewind(dropped, gs.num_history_steps()) {
+            Some(n) => gs.rollback(n),
+            None => tracing::warn!(
+                "grammar rollback skipped: {dropped} tokens dropped but the matcher \
+                 recorded only {} steps. Constrained output may drift for this \
+                 sequence; it is not a reason to kill the scheduler (#842).",
+                gs.num_history_steps()
+            ),
+        }
     }
 
     // 6. Reset the watchdog accumulators so the just-cleared window does
@@ -448,6 +461,32 @@ pub trait RomHead: Send + Sync {
 // A trained ROM head belongs to the MODEL that was trained with it, so the
 // seam is `SchedCtx::rom_head` rather than a process global — correct by
 // construction before the artifact loader lands, rather than after.
+
+/// How far to rewind the grammar matcher for `dropped` sequence tokens.
+///
+/// `None` means "do not rewind at all": the caller's count cannot be reconciled
+/// with the matcher's history, so any rewind would be a guess.
+///
+/// The three speculative-decode callers of `GrammarState::rollback` all pass a
+/// delta of `num_history_steps()` measured across the span they are undoing —
+/// see `spec_step.rs` and `verify_pipeline_helper.rs`. The watchdog path passed
+/// a raw count of sequence tokens instead, and `accept_token` returns true
+/// without advancing the matcher for stop/EOS tokens and in the terminated
+/// state. A `json_schema` matcher terminates as soon as its object closes, so
+/// every token after that is a token the matcher never recorded.
+///
+/// Rewinding `min(dropped, steps)` was rejected: with a terminated matcher the
+/// recorded steps belong to tokens that are being KEPT, so a partial rewind
+/// would corrupt the state that a panic at least left visible. Refusing is the
+/// honest answer, and it is the correct one in the reported case — those 96
+/// tokens genuinely advanced the matcher zero times.
+///
+/// This removes the outage. It does not make the accounting exact; that needs
+/// the anchor the speculative paths have, captured where the droppable window
+/// begins.
+fn grammar_rewind(dropped: usize, history_steps: usize) -> Option<usize> {
+    (dropped <= history_steps).then_some(dropped)
+}
 
 #[cfg(test)]
 #[path = "rollback_tests.rs"]

--- a/crates/spark-server/src/scheduler/rollback_tests.rs
+++ b/crates/spark-server/src/scheduler/rollback_tests.rs
@@ -257,3 +257,48 @@ fn rom_head_absent_by_default() {
             .is_none()
     );
 }
+
+/// #842: the watchdog path rewound the grammar matcher by a count of SEQUENCE
+/// tokens, while the matcher only records a step for tokens that actually
+/// advanced it. `accept_token` returns true for stop/EOS and in the terminated
+/// state without advancing, so a `json_schema` matcher that has closed its
+/// object records nothing for the tokens that follow.
+///
+/// The reported panic was `cannot roll back 96 tokens: only 1 steps recorded`,
+/// raised by an `assert!` inside the matcher — on the scheduler thread. The
+/// server then accepted requests forever and generated nothing, looking healthy
+/// from `/v1/models`, until it was killed.
+#[test]
+fn the_reported_mismatch_refuses_to_rewind_instead_of_panicking() {
+    // Both reported occurrences, with their real numbers.
+    assert_eq!(super::grammar_rewind(96, 1), None);
+    assert_eq!(super::grammar_rewind(88, 1), None);
+}
+
+/// The ordinary case must still rewind, or the fix trades a crash for grammar
+/// state that silently stops tracking the token stream.
+#[test]
+fn an_accountable_span_still_rewinds_exactly() {
+    assert_eq!(super::grammar_rewind(4, 4), Some(4));
+    assert_eq!(super::grammar_rewind(4, 9), Some(4));
+    assert_eq!(super::grammar_rewind(0, 0), Some(0));
+}
+
+/// One step short is still short. The boundary is where an off-by-one would
+/// reintroduce the panic, since the matcher asserts `n <= history`.
+#[test]
+fn the_boundary_is_inclusive_on_the_safe_side() {
+    assert_eq!(super::grammar_rewind(5, 5), Some(5));
+    assert_eq!(super::grammar_rewind(6, 5), None);
+}
+
+/// A partial rewind was considered and rejected. With a terminated matcher the
+/// recorded steps belong to tokens that are being KEPT, so `min(dropped, steps)`
+/// would rewind past the truncation point and corrupt state that the panic at
+/// least left visible. This pins the decision so a later "helpful" clamp has to
+/// argue with it.
+#[test]
+fn it_does_not_silently_clamp_to_the_available_history() {
+    assert_ne!(super::grammar_rewind(96, 1), Some(1));
+    assert_eq!(super::grammar_rewind(96, 1), None);
+}

--- a/vendor/cudarc/src/driver/safe/core.rs
+++ b/vendor/cudarc/src/driver/safe/core.rs
@@ -1895,6 +1895,16 @@ unsafe impl Send for CudaFunction {}
 unsafe impl Sync for CudaFunction {}
 
 impl CudaModule {
+    /// The raw driver handle for this loaded module. (Atlas vendor addition:
+    /// lets `AtlasRegistry` derive `cuModuleGetFunction` handles from the ONE
+    /// module this struct loaded instead of JIT-compiling every PTX blob a
+    /// second time through the raw driver API.) The handle stays owned by
+    /// this `CudaModule`: callers must not `cuModuleUnload` it and must not
+    /// use it after the module drops.
+    pub fn cu_module_raw(&self) -> sys::CUmodule {
+        self.cu_module
+    }
+
     /// Loads a function from the loaded module with the given name.
     pub fn load_function(self: &Arc<Self>, fn_name: &str) -> Result<CudaFunction, DriverError> {
         let fn_name_c = CString::new(fn_name).unwrap();


### PR DESCRIPTION
## The plan (aggregation PR)

Two sieve-cleared perf PRs composed for **one certification campaign instead of two**. Commit boundaries preserved (patch-id-verified byte-equivalent to the sieved PR diffs); source branches stay intact.

| order | PR | what | attribution signature |
|---|---|---|---|
| 1 | #705 | registry: load each kernel module once, derive the raw handle | **boot-phase** — cold-TTFT/shutdown symptoms, or loud `CUDA_ERROR_INVALID_HANDLE`; no steady-state footprint |
| 2 | #781 | cutlass: skip null-weight expert groups under EP + fail-fast `-140` guard | **grouped-GEMM phase** — prefill numerics/crash in MoE GEMM |

Disjoint phase signatures → a failing gate maps to a constituent without bisecting.

## Offline gates (composed head `f3e1cff84d`, base = current main)

`cargo check --workspace --all-targets` EXIT=0 · atlas-core **128/128** · spark-runtime **277/277** · LoC cap ok · sieves: both `sieve:cleared` (live-tree verified).

## Adversarial review: PUBLISH, 4 conditions

1. **Blocking pre-campaign smoke:** single-node MoE inference smoke on this branch (coherent output, no `-140`) — #781's modified kernel body runs on every grouped-GEMM call yet its only runtime evidence is two-node EP=2; the single-node config the campaign exercises is precisely the one never executed. Gate C2 does not substitute (dense 27B never enters grouped MoE GEMM)
2. **Claim hygiene:** #781's +5.7% is EP=2/two-node evidence and stays **uncertified by this campaign** — the campaign buys "does not regress single-node", nothing more
3. #705's ~14% boot claim is quoted only after a cheap same-box boot A/B, else marked "PR-claimed, unverified"
4. Attribution map above is part of the record

Campaign (~5 GPU-h, owed: vendor/ + crates/ + .cu are PERF_PATHS) starts only on explicit human approval. Constituents close with landing evidence after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc