### PR TITLE
spark-runtime: repair 9 unreachable or vacuous prefix-cache snapshot checks

### DIFF
--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -209,24 +209,53 @@ fn test_partial_suffix_eviction_frees_both_blocks() {
     assert!(evicted.physical.contains(&20));
 }
 
+/// A real child node SUPERSEDES the partial-suffix slot it overlaps: the slot
+/// is cleared and the KV block it held comes back in `released_blocks` so the
+/// caller can drop the cache's reference on it.
+///
+/// Rewritten (was `#[ignore]`d as "tests removed behavior"): the OLD
+/// assertions expected the 20-token prefix to become unmatchable, which the
+/// sub-block child-key arm made false — the deeper node now serves those 20
+/// tokens. The clearing itself is NOT removed behaviour; what it must produce
+/// is the released-block accounting asserted below, and no serving of the
+/// retired block. The partial→partial overwrite arm is covered by
+/// `tests::basic::test_partial_suffix_block_is_owned_and_released`; this is
+/// the distinct child-supersedes-partial arm.
 #[test]
-#[ignore = "tests removed behavior — partial-suffix clearing was replaced \
-            with partial-block-matching during the radix-tree refactor; \
-            assertions need rewriting against the new lookup semantics"]
 fn test_partial_suffix_cleared_when_extended() {
     let tree = RadixTree::new();
-    // Insert 20 tokens (1 full + 4 partial)
+    // Insert 20 tokens (1 full + a 4-token partial held in block 20).
     let tokens_20: Vec<u32> = (0..20).collect();
-    tree.insert(&tokens_20, &[10, 20], &[], 16, 0, 0);
+    let first = tree.insert(&tokens_20, &[10, 20], &[], 16, 0, 0);
+    assert!(
+        first.blocks.contains(&20),
+        "the partial slot takes a ref on block 20; got {:?}",
+        first.blocks
+    );
 
-    // Insert 32 tokens (2 full blocks, extends past partial)
+    // Insert 32 tokens: a real child now covers [16..32), superseding the slot.
     let tokens_32: Vec<u32> = (0..32).collect();
-    tree.insert(&tokens_32, &[10, 30], &[], 16, 0, 0);
+    let extended = tree.insert(&tokens_32, &[10, 30], &[], 16, 0, 0);
+    assert_eq!(
+        extended.released_blocks,
+        vec![20],
+        "the superseded partial block must be handed back, not leaked"
+    );
+    assert!(
+        extended.blocks.contains(&30),
+        "the superseding child block is acquired; got {:?}",
+        extended.blocks
+    );
 
-    // Lookup 20 tokens — partial suffix was cleared by the 32-token insert
+    // Lookup 20 tokens — served by the DEEPER node (block 30) through the
+    // sub-block child-key arm, never by the retired partial block 20.
     let m = tree.lookup(&tokens_20, 16, 0, 0);
-    assert_eq!(m.matched_tokens, 16);
-    assert_eq!(m.matched_blocks, vec![10]);
+    assert_eq!(m.matched_tokens, 20);
+    assert_eq!(m.matched_blocks, vec![10, 30]);
+    assert!(
+        !m.matched_blocks.contains(&20),
+        "the retired partial block must never be served again"
+    );
     tree.release(&tokens_20, 16, 0);
 
     // Lookup 32 tokens — full match

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -406,4 +406,21 @@ fn test_ssm_snapshot_adapter_isolation_via_tree() {
     assert_eq!(m_a.matched_tokens, 32);
     assert_eq!(m_a.ssm_snapshot, Some(42));
     tree.release(&tokens, 16, A);
+
+    // Give B its OWN KV for the same tokens (disjoint radix root) so B's walk
+    // HITS. Without this, `lookup` short-circuits on `matched_tokens == 0` and
+    // never reaches the snapshot index — so `m_b.ssm_snapshot == None` above is
+    // proved by the tree's root isolation alone and says nothing about whether
+    // the snapshot KEY carries the adapter.
+    tree.insert(&tokens, &[30, 40], &[], 16, 0, B);
+    tree.release(&tokens, 16, B);
+    let m_b2 = tree.lookup(&tokens, 16, 0, B);
+    assert_eq!(m_b2.matched_tokens, 32, "B now has its own cached KV");
+    assert_eq!(m_b2.matched_blocks, vec![30, 40]);
+    assert_eq!(
+        m_b2.ssm_snapshot, None,
+        "A's SSM snapshot must not restore for B even on a B-side KV hit"
+    );
+    assert_eq!(m_b2.ssm_snapshot_tier_key, None);
+    tree.release(&tokens, 16, B);
 }

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot.rs
@@ -17,8 +17,18 @@ fn test_insert_without_snapshot() {
 
     tree.insert(&tokens, &[10], &[], 16, 0, 0);
     let m = tree.lookup(&tokens, 16, 0, 0);
+    // The KV walk must actually HIT first. `lookup` skips the snapshot index
+    // entirely when `matched_tokens == 0`, so without this the snapshot
+    // assertions below also hold for a tree that matches nothing at all.
+    assert_eq!(m.matched_tokens, 16);
+    assert_eq!(m.matched_blocks, vec![10]);
     assert_eq!(m.ssm_snapshot, None);
     assert_eq!(m.ssm_snapshot_tokens, 0);
+    // The tier fields are the other half of "no snapshot": a spilled anchor
+    // arrives there, not in `ssm_snapshot`.
+    assert_eq!(m.ssm_snapshot_tier_key, None);
+    assert_eq!(m.ssm_snapshot_tier_tokens, 0);
+    assert!(!m.ssm_snapshot_is_tail);
     tree.release(&tokens, 16, 0);
 }
 
@@ -152,8 +162,9 @@ fn test_partial_suffix_not_matched_for_full_block_request() {
     let tokens: Vec<u32> = (0..20).collect();
     tree.insert(&tokens, &[10, 20], &[], 16, 0, 0);
 
-    // Lookup 32 tokens — 2 full blocks in request. Partial suffix is 4 tokens
-    // but remainder is 0 (32 % 16 == 0), so partial check is skipped.
+    // Lookup 32 tokens — 2 full blocks in request. Only the first matches, and
+    // the unmatched remainder is a WHOLE block (16), so the sub-block arms are
+    // out of range for it.
     let tokens_32: Vec<u32> = (0..32).collect();
     let m = tree.lookup(&tokens_32, 16, 0, 0);
 
@@ -161,6 +172,26 @@ fn test_partial_suffix_not_matched_for_full_block_request() {
     assert_eq!(m.matched_tokens, 16);
     assert_eq!(m.matched_blocks, vec![10]);
     tree.release(&tokens_32, 16, 0);
+
+    // The case the name is actually about: a BLOCK-ALIGNED request. Its
+    // remainder is zero, so the sub-block arms must not run at all — an empty
+    // suffix is a prefix of every stored key, so a missing `remainder > 0`
+    // guard appends the 4-token partial block to a 16-token match and hands
+    // the caller a block table longer than `matched_tokens` describes.
+    let tokens_16: Vec<u32> = (0..16).collect();
+    let m16 = tree.lookup(&tokens_16, 16, 0, 0);
+    assert_eq!(m16.matched_tokens, 16);
+    assert_eq!(
+        m16.matched_blocks,
+        vec![10],
+        "the partial slot must not be appended to a block-aligned match"
+    );
+    assert_eq!(
+        m16.matched_blocks.len(),
+        m16.matched_tokens / 16,
+        "block table must stay aligned with matched_tokens"
+    );
+    tree.release(&tokens_16, 16, 0);
 }
 
 #[test]
@@ -217,7 +248,9 @@ fn test_partial_suffix_multi_block_prefix() {
     let m = tree.lookup(&tokens, 16, 0, 0);
 
     assert_eq!(m.matched_tokens, 396);
-    assert_eq!(m.matched_blocks.len(), 25);
+    // Identity AND order, not just the count: a count-only oracle accepts a
+    // walk that returns 25 wrong blocks (e.g. each node's parent block).
+    assert_eq!(m.matched_blocks, block_table);
     tree.release(&tokens, 16, 0);
 }
 

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -370,12 +370,20 @@ fn reinsert_unspills() {
 #[test]
 fn test_snapshot_index_insert_lookup_roundtrip() {
     let mut idx = SsmSnapshotIndex::new();
-    let tokens: Vec<u32> = (0..32).collect();
+    // 48 verified tokens, anchored at 32: the prompt is longer than the anchor.
+    let tokens: Vec<u32> = (0..48).collect();
     let prefix_hash = super::hash_token_prefix(&tokens, 32, 0);
 
     assert!(idx.insert(prefix_hash, 42, 100, 32).is_none());
-    let result = idx.lookup(&tokens, 32, 100, 0);
+    // Look up with MORE matched tokens than the anchor covers. At
+    // `matched_tokens == token_count` the two possible sources of the returned
+    // depth are indistinguishable, and returning the caller's matched_tokens
+    // instead of the entry's own depth would make the restore site skip SSM
+    // tokens it never had state for.
+    let result = idx.lookup(&tokens, 48, 100, 0);
     assert_eq!(result, Some((42, 32)));
+    // An anchor deeper than the verified prefix is not a candidate at all.
+    assert_eq!(idx.lookup(&tokens, 31, 100, 0), None);
 }
 
 #[test]

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_index.rs
@@ -52,10 +52,10 @@ fn index(entries: Vec<SnapshotEntry>, live: u64) -> SsmSnapshotIndex {
     }
 }
 
-/// Pure-LRU within a session: the older entry is the victim regardless of
-/// how often it was hit historically (regression for the 07-10 fossil
-/// pathology — the old `last_access * (1 + hit_count)` score let a once-hit
-/// old entry outlive every fresh save).
+/// Pure-LRU within a session once the lease is DISARMED: the older entry is
+/// the victim even when it is the live session's deep `is_tail` restore point.
+/// id 9 has to be a tail — with a pool of plain entries `tail_protect` is
+/// inert and the check says nothing about the flag it is named after.
 #[test]
 fn deep_tail_evicted_without_tail_protect() {
     let idx = index(
@@ -63,7 +63,7 @@ fn deep_tail_evicted_without_tail_protect() {
             entry(
                 /*id*/ 7, /*sess*/ 1, /*tok*/ 8192, /*last*/ 100,
             ),
-            entry(
+            tail_entry(
                 /*id*/ 9, /*sess*/ 1, /*tok*/ 16000, /*last*/ 50,
             ),
         ],
@@ -72,6 +72,11 @@ fn deep_tail_evicted_without_tail_protect() {
     // Victim is the OLDER entry (id 9) under pure LRU.
     let v = idx.session_aware_victim(false, false).unwrap();
     assert_eq!(idx.entries[v].snapshot_id, 9);
+    // Control on the SAME pool: armed, the lease spares that tail. Without
+    // this pair, a `leased` predicate that ignores `tail_protect` entirely is
+    // indistinguishable from one that honours it.
+    let armed = idx.session_aware_victim(true, false).unwrap();
+    assert_eq!(idx.entries[armed].snapshot_id, 7);
 }
 
 // ─────────── 07-10 fossil-pinning regressions (re-landed, #317 revert) ──────────
@@ -88,10 +93,19 @@ fn eviction_ignores_hit_history() {
     let toks: Vec<u32> = (0..100).collect();
     let ph = super::hash_token_prefix(&toks, 40, 0);
     idx.insert(ph, /*slot*/ 1, /*session*/ 7, /*tok*/ 40);
-    // Hit the anchor 5 times (each legitimately bumps recency).
+    // A never-hit entry saved AFTER the anchor: fresher on save order alone.
+    let ph50 = super::hash_token_prefix(&toks, 50, 0);
+    idx.insert(ph50, /*slot*/ 4, /*session*/ 7, /*tok*/ 50);
+    // Hit the anchor 5 times. `matched_tokens = 40` keeps the depth-50 entry
+    // out of range, so only slot 1 is touched.
     for _ in 0..5 {
-        assert!(idx.lookup_tiered(&toks, 60, 7, 0).is_some());
+        assert!(idx.lookup_tiered(&toks, 40, 7, 0).is_some());
     }
+    // Those hits must have MOVED recency: slot 1 is now fresher than the
+    // never-hit slot 4, so slot 4 dies first. Without this the five lookups
+    // above are decorative — the assertion below holds whether or not a hit
+    // bumps `last_access` at all.
+    assert_eq!(idx.evict_lru(), Some(4), "a hit must refresh recency");
     // Two fresh saves AFTER the last hit — strictly more recent.
     let ph80 = super::hash_token_prefix(&toks, 80, 0);
     let ph90 = super::hash_token_prefix(&toks, 90, 0);
@@ -153,6 +167,20 @@ fn lookup_tracks_live_session() {
     // No matching entries — lookup returns None but must still latch the session.
     let _ = idx.lookup(&[1, 2, 3], 3, /*session*/ 42, /*adapter*/ 0);
     assert_eq!(idx.last_lookup_session, 42);
+    // A sessionless (single-turn) lookup must not steal the latch.
+    let _ = idx.lookup(&[1, 2, 3], 3, /*session*/ 0, /*adapter*/ 0);
+    assert_eq!(idx.last_lookup_session, 42, "session 0 must not latch");
+    // The SERVING path latches too, and renews the lease by clearing the
+    // eviction counter. `lookup` is the retained reference implementation;
+    // production arms the tail lease from `lookup_tiered`, so asserting only
+    // on `lookup` leaves the latch that actually runs unprotected.
+    idx.evictions_since_lookup = 7;
+    let _ = idx.lookup_tiered(&[1, 2, 3], 3, /*session*/ 99, /*adapter*/ 0);
+    assert_eq!(idx.last_lookup_session, 99);
+    assert_eq!(
+        idx.evictions_since_lookup, 0,
+        "a live lookup renews the lease"
+    );
 }
 
 /// Telemetry: a miss records full-recompute; a hit records the residual


### PR DESCRIPTION
## Summary

RST mutation audit of the 34 registered checks in `radix_tree/tests/snapshot.rs` and the 17 own functions of `tests/snapshot_index.rs` (campaign IDs ATC-1935 through ATC-1968). Thirty realistic production mutants were applied and reverted one at a time against the sub-block matching arms in `inner.rs`, the `RadixTree` lookup wrapper, `SsmSnapshotIndex::{lookup,lookup_tiered,insert,evict_to_tier,promote}`, and `hash_token_prefix`. Twenty-five checks rejected their mutant as written. Nine stayed green against a real defect and are repaired here, including one check that was `#[ignore]`d on a false premise and is now live. **No production changes: every surviving mutant traced to a test-oracle or reachability weakness, not a product bug.**

Four of the surviving mutants were invisible to the **entire 86-check `radix_tree` registry**:

| Mutant (reverted) | What it breaks | Now owned by |
|---|---|---|
| `remainder > 0` guard deleted from the sub-block gate (`inner.rs:198-200`) | a block-aligned request gets the 4-token partial block appended to a 16-token match: block table longer than `matched_tokens` describes | `test_partial_suffix_not_matched_for_full_block_request` |
| `lookup_tiered` hit no longer refreshes `last_access` (`snapshot_tier.rs:100`) | hot anchors age like never-used ones and are evicted first | `eviction_ignores_hit_history` |
| live-session latch removed from `lookup_tiered` (`snapshot_tier.rs:63-66`) | the tail lease never arms on the serving path | `lookup_tracks_live_session` |
| child-supersede stops reporting the retired partial block in `released_blocks` (`inner.rs:375`) | the caller never `dec_ref`s it: permanent block leak | `test_partial_suffix_cleared_when_extended` |

## The nine weaknesses (each proven with an executed old-green mutant)

- `test_insert_without_snapshot` asserted only `lookup`'s default outputs, which also hold when the KV walk matches nothing (an inverted context-chain guard killed 10 siblings, not this). It now asserts the hit first, plus the tier fields.
- `test_partial_suffix_not_matched_for_full_block_request` never reached the arm its name describes: `remainder` in `walk` is the unmatched token count, not `len % block_size`, so the 32-token stimulus was stopped by a different clause (the in-test comment was wrong). A genuinely block-aligned 16-token lookup is added.
- `test_partial_suffix_cleared_when_extended` was ignored as "tests removed behavior". The child-supersedes-partial clearing is live and reports the block through `InsertAcquired::released_blocks`, consumed by `block_mgmt.rs:190`; only the lookup expectation was stale (the sub-block child-key arm now serves the 20-token prefix from the deeper node). Rewritten and un-ignored.
- `test_partial_suffix_multi_block_prefix` asserted `matched_blocks.len() == 25`; returning each node's parent block killed 14 checks but not this one. It now asserts the full block table.
- `test_ssm_snapshot_adapter_isolation_via_tree`: adapter B had no cached KV, so `lookup` short-circuited before the snapshot index and the disjoint radix roots proved the assertion for free. B now caches its own KV, hits 32 tokens, and still gets no snapshot.
- `deep_tail_evicted_without_tail_protect` had no `is_tail` entry in the pool, so `tail_protect` was inert. id 9 is now a tail, with an armed control on the same pool.
- `eviction_ignores_hit_history`: the five hits were decorative because the anchor was oldest either way. A never-hit later save now dies first.
- `lookup_tracks_live_session` asserted the latch only on the retained reference `lookup`, which is dead code in production. It now covers the sessionless must-not-latch arm and the `lookup_tiered` latch plus lease renewal.
- `test_snapshot_index_insert_lookup_roundtrip` looked up at `matched_tokens == token_count`, so the returned depth's source was indistinguishable. It now looks up 48 verified tokens against the depth-32 anchor and pins the empty-candidate `None` at 31.

Each repaired check was re-run under its mutant (fails at the new assertion for the intended reason) and against restored production (passes).

## What the good checks defended, and known hazards without coverage

Sole owners across all 86 checks: partial-suffix content verification, partial block freed on evict, each sub-block arm's `>=`, the root guard, winner-only recency bump, the recompute metrics, the tiered skip in `lookup`, and un-spill on re-insert. Two hazards are documented in-code and covered by nothing: the tier blob orphaned by a re-insert over a spilled entry (`snapshot_insert.rs:43-64`, knowingly unreclaimed) and the sub-block arms handing back a block whose KV was computed for a longer key (`inner.rs:190-196`, the `ATLAS_PREFIX_SUBBLOCK` A/B lever).

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 cargo test -p spark-runtime --lib --no-default-features --features metal radix_tree` — 86 passed, 0 failed, 0 ignored
- [x] unfiltered `spark-runtime` lib suite: baseline on pristine main 268 passed, 35 failed, 7 ignored; after 269 passed, 35 failed, 6 ignored. The delta is exactly the un-ignored check; the 35 `metal_backend::tests::*` "Metal: unknown module" skip-build failures are an identical set before and after
- [x] `cargo fmt --all -- --check` · `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid) · `typos` · `git diff --check`
- [ ] `cargo clippy -p spark-runtime --no-default-features --features metal --tests -- -D warnings` fails on 19 pre-existing lints, none under `radix_tree/`, identical with these files reverted to `main`; Linux CI clippy owns this gate
- [ ] Tested against a real model / hardware (not applicable: host-side prefix-cache and snapshot-index bookkeeping)
- [x] Added or updated tests where applicable

## Related

Sibling audit PRs on disjoint files of the same module: `tests/adapter.rs` + `tests/basic.rs` (#892) and `tests/snapshot_lease.rs` + `tests/snapshot_insert_tier.rs` + `tests/snapshot_reap.rs` (#894). All three merged together run 86 passed, 0 failed, 0 ignored.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
