### PR TITLE
spark-runtime: make 4 snapshot lease and tier-insert oracles load-bearing

### DIFF
--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_insert_tier.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_insert_tier.rs
@@ -104,7 +104,16 @@ fn insert_tail_rehomes_a_spilled_entry_to_hbm() {
     );
 }
 
-/// `insert_tail_sibling` — the third path, same contract.
+/// `insert_tail_sibling` — the third path, same contract, AND the same
+/// re-home obligation `insert_tail` carries (see the test above).
+///
+/// The re-home half was the suite's blind spot: deleting `entry.tiered =
+/// false` from this arm survived the WHOLE 86-check `radix_tree` registry.
+/// `reinsert_unspills` covers the plain-`insert` arm and
+/// `insert_tail_rehomes_a_spilled_entry_to_hbm` covers the tail arm; nothing
+/// covered this one, so a sibling save over a spilled prefix could strand its
+/// fresh slot — skipped by `lookup` and by both victim scans, hence reachable
+/// by nothing and freeable by nothing — for the process lifetime.
 #[test]
 fn insert_tail_sibling_over_a_spilled_entry_hands_back_no_slot() {
     let (mut idx, ph, freed) = spilled(0xD4, 8);
@@ -114,6 +123,15 @@ fn insert_tail_sibling_over_a_spilled_entry_hands_back_no_slot() {
     assert_eq!(
         displaced, None,
         "slot {freed} was already freed at spill time"
+    );
+    assert!(
+        !idx.entries[0].tiered,
+        "a fresh HBM save re-homes the prefix; leaving it `tiered` strands slot 14"
+    );
+    assert_eq!(
+        idx.evict_lru(),
+        Some(14),
+        "a re-homed sibling must be evictable — otherwise its slot leaks"
     );
 }
 

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
@@ -244,12 +244,19 @@ fn all_leased_pool_still_evicts() {
     assert_eq!(idx.len(), 1, "and the reclaim must actually have happened");
 }
 
-/// Sibling entries are exact-prefix keyed and carry NO `is_tail` gate: the
-/// same session and sessionless lookers may use them (a tail would refuse the
-/// sessionless looker). Different-NONZERO-session lookers are excluded by the
-/// long-standing general session filter that applies to every session-tagged
-/// snapshot — in practice two conversations sharing a >=1024-token prefix
-/// hash to the SAME session anyway.
+/// Sibling entries are exact-prefix keyed and carry NO session gate of any
+/// kind: same-session, sessionless AND different-session lookers may all use
+/// them (a tail would refuse the latter two). A sibling stores state at
+/// EXACTLY `token_count`, so it is a pure function of the verified token
+/// prefix — content-addressed, exactly like the KV radix, which shares blocks
+/// on token match with no session gate at all.
+///
+/// There is NO "general session filter" behind non-tail entries in
+/// `lookup_tiered` — an earlier version of this comment claimed one excluded
+/// different-nonzero-session lookers, and the third assertion below is the
+/// executable refutation. That is the intended contract (see the `is_tail`
+/// INVARIANT on `SnapshotEntry`), not a hole: it is what un-broke warm TTFT
+/// when `session_hash` proved unstable across turns of a growing prompt.
 #[test]
 fn sibling_not_session_gated_in_lookup() {
     let mut idx = SsmSnapshotIndex::new();
@@ -262,6 +269,12 @@ fn sibling_not_session_gated_in_lookup() {
     assert!(
         idx.lookup_tiered(&toks, 64, 0, 0).is_some(),
         "sibling must not carry the is_tail session gate"
+    );
+    // A DIFFERENT non-zero session: hit as well — the partition a re-added
+    // blanket gate would silently break while the two above stayed green.
+    assert!(
+        idx.lookup_tiered(&toks, 64, 8, 0).is_some(),
+        "a sibling is content-addressed: another session may restore from it"
     );
 }
 

--- a/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
+++ b/crates/spark-runtime/src/radix_tree/tests/snapshot_lease.rs
@@ -19,22 +19,31 @@ fn tail_lease_protects_live_session_is_tail() {
 
 /// Direct inversion of #278's off-target semantics: the live session's
 /// DEEPEST entry (the end-of-turn finish leaf, NOT a tail) is a normal
-/// eviction candidate. The old policy protected exactly this entry — which
+/// eviction candidate, while the tail is leased even when it is the pool's
+/// natural LRU victim. The old policy protected exactly this entry — which
 /// sits above `matched_tokens` and never restores — while the true restore
 /// point died (2026-07-20 rig: 0 hits with old protection on or off).
+///
+/// The pool holds THREE entries on purpose. With the tail as the only other
+/// entry the lease leaves exactly one candidate, so "no lease at all" and
+/// "lease the tail" pick the same victim and the oracle cannot tell them
+/// apart; the fresh shallow entry keeps both the lease and the within-session
+/// recency order observable in the one answer.
 #[test]
 fn finish_leaf_not_protected() {
     let idx = index(
         vec![
-            entry(7, 1, 6080, 50),      // finish leaf: deepest, oldest, NOT a tail
-            tail_entry(9, 1, 6064, 90), // true restore point
+            entry(6, 1, 100, 95),       // freshest, shallow, NOT a tail
+            entry(7, 1, 6080, 50),      // finish leaf: deepest, NOT a tail
+            tail_entry(9, 1, 6064, 40), // true restore point: OLDEST, leased
         ],
         1,
     );
     let v = idx.session_aware_victim(true, false).unwrap();
     assert_eq!(
         idx.entries[v].snapshot_id, 7,
-        "the deepest non-tail entry must be evictable"
+        "the deepest non-tail entry must be the victim: the tail is leased \
+         despite being the oldest, and recency still orders the unleased pair"
     );
 }
 
@@ -204,6 +213,11 @@ fn new_tail_sweeps_old_tail_and_sibling() {
 
 /// A pool consisting ONLY of leased entries (tail + sibling) must still
 /// yield a victim — the lease binds only while an unleased candidate exists.
+///
+/// The premise is asserted, not assumed: "some victim came back" is trivially
+/// true whenever the lease is INACTIVE, so without the `tail_lease_active`
+/// check this test passes even with the kill switch's polarity inverted (the
+/// lease off for everyone) — it would then be measuring nothing.
 #[test]
 fn all_leased_pool_still_evicts() {
     let mut idx = SsmSnapshotIndex::new();
@@ -212,8 +226,22 @@ fn all_leased_pool_still_evicts() {
     // Latch the lease onto session 7.
     let toks: Vec<u32> = (0..8).collect();
     let _ = idx.lookup_tiered(&toks, 0, 7, 0);
-    let v = idx.evict_lru();
-    assert!(v.is_some(), "only-leased pool must still yield a victim");
+    assert!(
+        idx.tail_lease_active(),
+        "the lease must actually be in force"
+    );
+    assert!(
+        idx.entries
+            .iter()
+            .all(|e| (e.is_tail || e.is_tail_sibling) && e.session_hash == 7),
+        "every entry must be a leased restore point of the live session"
+    );
+    assert_eq!(
+        idx.evict_lru(),
+        Some(1),
+        "only-leased pool must still yield a victim, oldest-first"
+    );
+    assert_eq!(idx.len(), 1, "and the reclaim must actually have happened");
 }
 
 /// Sibling entries are exact-prefix keyed and carry NO `is_tail` gate: the


### PR DESCRIPTION
## Summary

RST mutation audit of the 27 registered checks in `radix_tree/tests/snapshot_lease.rs`, `tests/snapshot_insert_tier.rs`, and `tests/snapshot_reap.rs` (campaign IDs ATC-1969 through ATC-1995). Thirty-five realistic production mutants were applied and reverted one at a time against `session_aware_victim_with_alpha`, `tail_lease_active`, the three `insert*` overwrite arms and the tail-supersede sweep, `lookup_tiered`, `evict_to_tier`, `promote`, `forget_tiered`, and the `PrefixCache` trait defaults. Twenty-three checks rejected their mutant as written. Four stayed green against a real defect and are repaired here. **No production changes: every surviving mutant traced to a test-oracle weakness, not a product bug.**

One surviving mutant was invisible to the **entire 86-check `radix_tree` registry**: deleting `entry.tiered = false` from the `insert_tail_sibling` overwrite arm (`snapshot_insert.rs:167`). A sibling save over a spilled prefix would then strand its fresh HBM slot for the process lifetime, skipped by `lookup` and by both victim scans, so reachable by nothing and freeable by nothing. `insert_tail_sibling_over_a_spilled_entry_hands_back_no_slot` now mirrors the tail-arm check: `!tiered` plus `evict_lru() == Some(slot)`.

## The four oracle weaknesses (each proven with an executed old-green mutant)

- `finish_leaf_not_protected`: the named victim was also the plain-LRU victim, so removing the lease entirely, or inverting within-session recency, stayed green. The pool now holds a fresh shallow non-tail entry with the tail as the oldest, so one answer requires both the lease and recency ordering.
- `all_leased_pool_still_evicts`: `assert!(v.is_some())` is vacuous whenever the lease is inactive; inverting the kill-switch polarity survived. It now asserts `tail_lease_active()`, that every entry is a leased restore point of the live session, the exact oldest-first victim, and that the reclaim happened.
- `sibling_not_session_gated_in_lookup`: its docstring claimed a "general session filter" excludes different-nonzero-session lookers. No such filter exists. Production intentionally makes non-tail entries content-addressed and cross-session safe (the `is_tail` INVARIANT on `SnapshotEntry`, and `snapshot_tier.rs:76-86`); a blanket gate re-added for different-nonzero sessions only survived. The third partition is now asserted and the docstring states the real contract.
- `insert_tail_sibling_over_a_spilled_entry_hands_back_no_slot`: see above.

Each repaired check was re-run under its mutant (fails at the new assertion for the intended reason) and against restored production (passes).

## What the good checks defended

The `freeable_slot` double-free guard is separately owned per insert arm and per site (overwrite vs supersede sweep) by mutants that kill exactly one check each. `forget_tiered`'s resident guard closes the promote-then-reap race without leaking a slot, and the reap stays out of the eviction counters so it cannot shorten a tail lease. Two notes, no code changed: the `session_aware_victim` doc (`snapshot.rs:334-335`) says the leased set is bounded at one entry, but with siblings leased the bound is two (`new_tail_sweeps_old_tail_and_sibling` asserts exactly that); the tier-blob orphan on every overwrite arm (`snapshot_insert.rs:52-64`) is already documented in-code as a tracked follow-up.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 cargo test -p spark-runtime --lib --no-default-features --features metal radix_tree` — 85 passed, 0 failed, 1 ignored (the ignore is lifted in #893)
- [x] unfiltered `spark-runtime` lib suite equals the pristine-main baseline measured on the same host: 268 passed, 35 failed, 7 ignored; all 35 are `metal_backend::tests::*` "Metal: unknown module" (skip-build shader artifact), identical failure set before and after
- [x] `cargo fmt --all -- --check` · `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid) · `typos` · `git diff --check`
- [ ] `cargo clippy -p spark-runtime --no-default-features --features metal --tests -- -D warnings` fails on 19 pre-existing lints, none under `radix_tree/`, identical with these files reverted to `main`; Linux CI clippy owns this gate
- [ ] Tested against a real model / hardware (not applicable: host-side snapshot-index bookkeeping)
- [x] Added or updated tests where applicable

## Related

Sibling audit PRs on disjoint files of the same module: `tests/adapter.rs` + `tests/basic.rs` (#892) and `tests/snapshot.rs` + `tests/snapshot_index.rs` (#893). All three merged together run 86 passed, 0 failed, 0 ignored.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
