### PR TITLE
xgrammar: give schema-object tests a real accept/reject oracle

### DIFF
--- a/crates/xgrammar/src/schema/tests.rs
+++ b/crates/xgrammar/src/schema/tests.rs
@@ -10,7 +10,39 @@
 // parseability).
 
 use super::*;
+use crate::compiler::GrammarCompiler;
 use crate::grammar::parse_ebnf_default;
+use crate::matcher::GrammarMatcher;
+use crate::tokenizer::{TokenizerInfo, VocabType};
+
+/// Compile `ebnf` (root rule `root`) and test whether it matches
+/// `input` **exactly** — every byte accepted AND the root rule fully
+/// complete (not merely a legal prefix). This is the accept/reject
+/// oracle the converter tests need: `parse_ebnf_default(&got).is_ok()`
+/// only proves the *grammar text* is syntactically well-formed EBNF,
+/// never that the grammar accepts/rejects the JSON instances the
+/// source schema was supposed to allow/forbid.
+///
+/// A dummy empty-vocabulary tokenizer is enough: `accept_bytes` /
+/// `is_grammar_completed` walk the Earley parser directly and never
+/// consult the vocabulary (that only matters for token-bitmask fill,
+/// which no caller here needs).
+pub(super) fn accepts(ebnf: &str, input: &str) -> bool {
+    let tok = TokenizerInfo::new(&[], VocabType::Raw, None, None, false);
+    let compiler = GrammarCompiler::new(tok, 1, false, -1);
+    let cg = compiler
+        .compile_grammar_from_ebnf(ebnf, "root")
+        .expect("generated grammar should compile");
+    let mut m = GrammarMatcher::from_compiled_grammar(cg);
+    m.accept_bytes(input.as_bytes(), false) && m.is_grammar_completed()
+}
+
+/// Convert `schema` under `opts` then check whether the resulting
+/// grammar accepts `input` as a complete match.
+pub(super) fn schema_accepts(schema: &str, opts: &SchemaConverterOptions, input: &str) -> bool {
+    let ebnf = json_schema_to_ebnf(schema, opts).expect("schema should convert");
+    accepts(&ebnf, input)
+}
 
 /// The basic-rule prelude every converted grammar starts with, in
 /// `any_whitespace = false` mode — matches the Python

--- a/crates/xgrammar/src/schema/tests_objects.rs
+++ b/crates/xgrammar/src/schema/tests_objects.rs
@@ -207,23 +207,42 @@ fn object_preserves_property_order() {
 
 #[test]
 fn any_of_combinator() {
-    let got = json_schema_to_ebnf(
-        r#"{"anyOf":[{"type":"integer"},{"type":"string"}]}"#,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r#"{"anyOf":[{"type":"integer"},{"type":"string"}]}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(got.contains("root ::="));
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: `anyOf` must restrict to the union of its branches, not
+    // merely list them alongside an implicit catch-all that admits any
+    // JSON value (e.g. a bare boolean, which is in neither branch).
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, "5"));
+    assert!(schema_accepts(schema, &opts, "\"x\""));
+    assert!(
+        !schema_accepts(schema, &opts, "true"),
+        "boolean is in neither anyOf branch and must be rejected"
+    );
 }
 
 #[test]
 fn one_of_treated_like_any_of() {
-    let got = json_schema_to_ebnf(
-        r#"{"oneOf":[{"type":"integer"},{"type":"boolean"}]}"#,
-        &no_space(),
-    )
-    .unwrap();
+    // NONCLAIM: xgrammar's grammar-based constraint cannot enforce
+    // `oneOf`'s "exactly one branch matches" exclusivity at generation
+    // time (matching upstream's documented simplification) — this test
+    // only claims the union-of-branches restriction that `anyOf` gives,
+    // same underlying `generate_any_of` as `any_of_combinator` above
+    // (redundant with it for a mutant that widens that shared union to
+    // "any"; kept separately because the two exercise disjoint branch
+    // types: integer|string there vs integer|boolean here).
+    let schema = r#"{"oneOf":[{"type":"integer"},{"type":"boolean"}]}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, "5"));
+    assert!(schema_accepts(schema, &opts, "true"));
+    assert!(
+        !schema_accepts(schema, &opts, "\"x\""),
+        "string is in neither oneOf branch and must be rejected"
+    );
 }
 
 #[test]
@@ -251,9 +270,21 @@ fn any_of_must_be_array() {
 
 #[test]
 fn type_array() {
-    let got = json_schema_to_ebnf(r#"{"type":["string","integer","null"]}"#, &no_space()).unwrap();
+    let schema = r#"{"type":["string","integer","null"]}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(got.contains("root ::="));
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: a type array must *restrict* to the listed types, not
+    // merely list them alongside an implicit escape hatch that accepts
+    // everything else too.
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, "\"hello\""));
+    assert!(schema_accepts(schema, &opts, "5"));
+    assert!(schema_accepts(schema, &opts, "null"));
+    assert!(
+        !schema_accepts(schema, &opts, "true"),
+        "boolean is not in the type array and must be rejected"
+    );
 }
 
 #[test]

--- a/crates/xgrammar/src/schema/tests_objects.rs
+++ b/crates/xgrammar/src/schema/tests_objects.rs
@@ -64,22 +64,45 @@ fn object_additional_properties_schema() {
 
 #[test]
 fn object_additional_properties_false() {
-    let got = json_schema_to_ebnf(
-        r#"{"type":"object","properties":{"a":{"type":"integer"}},"additionalProperties":false}"#,
-        &no_space(),
-    )
-    .unwrap();
+    let schema =
+        r#"{"type":"object","properties":{"a":{"type":"integer"}},"additionalProperties":false}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // The oracle: `additionalProperties:false` means the compiled
+    // grammar must accept only the declared property and reject any
+    // extra key (JSON Schema `additionalProperties` semantics) — not
+    // merely "the generated EBNF text parses".
+    let opts = no_space();
+    assert!(
+        schema_accepts(schema, &opts, r#"{"a": 1}"#),
+        "declared property alone must be accepted"
+    );
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"a": 1, "b": 2}"#),
+        "additionalProperties:false must reject an undeclared key"
+    );
 }
 
 #[test]
 fn object_min_max_properties() {
-    let got = json_schema_to_ebnf(
-        r#"{"type":"object","additionalProperties":{"type":"integer"},"minProperties":1,"maxProperties":3}"#,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r#"{"type":"object","additionalProperties":{"type":"integer"},"minProperties":1,"maxProperties":3}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: `minProperties`/`maxProperties` must actually bound the
+    // number of properties the compiled grammar accepts, not merely
+    // appear as inert numbers that never reach the generated repeat
+    // count.
+    let opts = no_space();
+    assert!(
+        !schema_accepts(schema, &opts, r#"{}"#),
+        "minProperties:1 must reject the empty object"
+    );
+    assert!(schema_accepts(schema, &opts, r#"{"a": 1}"#));
+    assert!(schema_accepts(schema, &opts, r#"{"a": 1, "b": 2, "c": 3}"#));
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"a": 1, "b": 2, "c": 3, "d": 4}"#),
+        "maxProperties:3 must reject a fourth property"
+    );
 }
 
 #[test]
@@ -94,22 +117,40 @@ fn object_min_greater_than_max_unsatisfiable() {
 
 #[test]
 fn object_pattern_properties() {
-    let got = json_schema_to_ebnf(
-        r#"{"type":"object","patternProperties":{"^x":{"type":"integer"}}}"#,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r#"{"type":"object","patternProperties":{"^x":{"type":"integer"}}}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: a `patternProperties` key regex must actually gate which
+    // keys are legal, not just decorate a grammar that accepts any key.
+    // (xgrammar's regex converter compiles a `pattern` to a *whole-key*
+    // match — `^`/`$` are stray no-ops it strips per `regex/mod.rs` —
+    // so `"^x"` accepts only the literal key `x`, not any key merely
+    // starting with `x`; see that module's documented anchor handling.)
+    let opts = no_space();
+    assert!(
+        schema_accepts(schema, &opts, r#"{"x": 1}"#),
+        "the key matching the (whole-key) pattern must be accepted"
+    );
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"y": 1}"#),
+        "a key NOT matching the pattern must be rejected (strict_mode has no additionalProperties)"
+    );
 }
 
 #[test]
 fn object_property_names() {
-    let got = json_schema_to_ebnf(
-        r#"{"type":"object","propertyNames":{"type":"string","minLength":1}}"#,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r#"{"type":"object","propertyNames":{"type":"string","minLength":1}}"#;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: `propertyNames` sub-schema constraints (here `minLength:1`)
+    // must actually gate keys, not just get parsed and then dropped for
+    // an unconstrained key rule.
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, r#"{"a": 1}"#));
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"": 1}"#),
+        "propertyNames minLength:1 must reject the empty-string key"
+    );
 }
 
 #[test]
@@ -225,22 +266,34 @@ fn type_array_empty_is_any() {
 
 #[test]
 fn ref_to_defs() {
-    let got = json_schema_to_ebnf(
-        r##"{"$defs":{"Pos":{"type":"integer","minimum":0}},"type":"object","properties":{"x":{"$ref":"#/$defs/Pos"}},"required":["x"]}"##,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r##"{"$defs":{"Pos":{"type":"integer","minimum":0}},"type":"object","properties":{"x":{"$ref":"#/$defs/Pos"}},"required":["x"]}"##;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // Oracle: the `$ref`-resolved target schema's constraints
+    // (`type: integer`) must actually reach the compiled grammar — a
+    // resolver that silently degraded every ref to "any" (as it does
+    // for a malformed URI) would still pass `parse_ebnf_default`.
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, r#"{"x": 5}"#));
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"x": "not-an-integer"}"#),
+        "$ref target's type:integer must be enforced, not degraded to any"
+    );
 }
 
 #[test]
 fn ref_to_definitions() {
-    let got = json_schema_to_ebnf(
-        r##"{"definitions":{"Name":{"type":"string"}},"type":"object","properties":{"n":{"$ref":"#/definitions/Name"}},"required":["n"]}"##,
-        &no_space(),
-    )
-    .unwrap();
+    let schema = r##"{"definitions":{"Name":{"type":"string"}},"type":"object","properties":{"n":{"$ref":"#/definitions/Name"}},"required":["n"]}"##;
+    let got = json_schema_to_ebnf(schema, &no_space()).unwrap();
     assert!(parse_ebnf_default(&got).is_ok());
+    // Same oracle as `ref_to_defs`, but for the legacy `definitions`
+    // (draft-4/6/7) pointer root instead of `$defs`.
+    let opts = no_space();
+    assert!(schema_accepts(schema, &opts, r#"{"n": "hello"}"#));
+    assert!(
+        !schema_accepts(schema, &opts, r#"{"n": 5}"#),
+        "$ref target's type:string must be enforced, not degraded to any"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

RST mutation audit of `crates/xgrammar/src/schema/tests_objects.rs` (46 checks, campaign IDs ATC-2200 through ATC-2245). The file has one dominant oracle shape: convert the schema, assert the generated text parses as EBNF. That proves the grammar *text* is well-formed; it never proves the compiled grammar accepts what the schema allows or rejects what it forbids — which is the entire job of a constrained-decoding grammar. This PR adds a real accept/reject oracle and uses it to repair the eleven highest-risk checks, each proven with an executed old-green/new-red mutant. **Test-only: no production code changed, and no product bug was found — every surviving mutant traced to a test-oracle gap.**

## The oracle

`accepts(ebnf, input)` / `schema_accepts(schema, opts, input)` in `schema/tests.rs`: compiles the generated EBNF through `GrammarCompiler::compile_grammar_from_ebnf`, drives `GrammarMatcher::accept_bytes` over the instance, and requires `is_grammar_completed()` — a full match, not a legal prefix. An empty-vocabulary `TokenizerInfo` suffices because `accept_bytes` walks the Earley parser directly; the vocabulary only matters for token-bitmask fill, which these tests never touch.

## Problems found (each proven with an executed mutant that left the old test green)

- **Valid `$ref`s degrading to accept-anything survived both ref tests** (the highest-severity gap): making `resolve_ref` route every successfully resolved `#/$defs/...` and `#/definitions/...` ref through the malformed-URI `Any` fallback still produced parseable EBNF, so `ref_to_defs` and `ref_to_definitions` stayed green while every ref'd constraint was silently discarded. Both now assert instance-level accept/reject against the ref target's type.
- `additionalProperties: false` ignored (forced `true`) — old test green; now `{"a":1}` accepted, `{"a":1,"b":2}` rejected.
- `minProperties`/`maxProperties` silently dropped (bounds never reached the generated repeat count) — old test green; now the empty object and a fourth property are rejected, one and three accepted.
- `patternProperties` key regex replaced with `.*` — old test green; now a matching key is accepted and a non-matching key rejected (assertions calibrated to the documented whole-key match semantics in `regex/mod.rs`).
- `propertyNames` sub-schema swapped for an unconstrained string — old test green; now the empty-string key (violating `minLength: 1`) is rejected.
- Appending an always-accepting `basic_any` alternative to type-array and anyOf/oneOf unions — all three of `type_array`, `any_of_combinator`, `one_of_treated_like_any_of` stayed green; each now rejects an instance outside every branch. (Nonclaim: `oneOf` exclusivity is not statically enforceable and is deliberately treated as `anyOf`, matching upstream.)

Control in the other direction: the error-kind family was spot-checked with a fall-back-to-empty mutant on `required`-must-be-array, which the existing test correctly fails — that family's oracles are specific, not accept-any-error.

## Coverage honesty

Eleven checks carry full empirical mutation evidence; the golden exact-string tests (`object_single_required_property`, `object_non_strict_required`) were mutation-tested and hold for the semantic claim, though their fixtures are generator-captured and brittle to reformatting. The remaining checks were classified statically and are recorded in the campaign ledger: most share the parses-but-never-matches gap and are queued for the same `schema_accepts` treatment (priorities: `all_of_multiple_degrades_to_any`, `object_additional_properties_schema`, the ref error paths); the six XML tool-calling checks are marked inconclusive until the harness is verified against `TagDispatch` semantics rather than guessed at.

## Test plan

- [x] `cargo test -p xgrammar --lib` (822 passed, 0 failed)
- [x] `cargo clippy -p xgrammar --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (2,407 valid, 0 invalid)
- [x] `typos` · `git diff --check`
- [ ] Tested against a real model / hardware (not applicable: grammar-compilation contracts; no logit masking executed)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

This proves schema-to-grammar accept/reject behavior at the Earley-matcher seam; it does not exercise token-bitmask fill or live constrained decoding. `crates/xgrammar` is a from-scratch Rust port (per its PORT_PLAN/DESIGN docs), so the tests are Atlas-owned and in scope; upstream-inherited simplifications (whole-key patterns, oneOf-as-anyOf) are asserted as documented behavior, not "fixed".

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
