### PR TITLE
spark-server: bare tag-style call closed before its parameters streamed in

### DIFF
--- a/crates/spark-server/src/tool_parser/parse_single_b.rs
+++ b/crates/spark-server/src/tool_parser/parse_single_b.rs
@@ -270,7 +270,20 @@ pub(super) fn bare_function_end(text: &str) -> Option<usize> {
         if let Some(p) = text.find("</parameters>") {
             return Some(p + "</parameters>".len());
         }
-        // No parameters block — just <function>NAME</function>
+        // A `<parameters>` block has been OPENED but its close hasn't
+        // streamed in yet. Falling through to the "no parameters block"
+        // branch below would misread the name-closing `</function>` (which
+        // necessarily appears before `<parameters>` in this shape) as the
+        // end of a zero-argument call, truncating the block right before
+        // the params. The leftover `<parameters>...` text then has no
+        // `<function` prefix for the caller to recognise, so on the next
+        // `process()` call it falls through to plain content emission and
+        // leaks the raw XML into the client-visible text instead of being
+        // parsed as arguments. Wait for more tokens instead.
+        if text.contains("<parameters>") {
+            return None;
+        }
+        // No parameters block at all — just <function>NAME</function>
         if let Some(p) = text.find("</function>") {
             let after = p + "</function>".len();
             // Check if there's a trailing </function> (some models emit an extra one)

--- a/crates/spark-server/src/tool_parser/tests/group_b.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_b.rs
@@ -352,9 +352,8 @@ fn streaming_bare_function_flush() {
     // call). Fixed by holding the block incomplete once `<parameters>` has
     // opened, until its close (or end-of-stream via `flush()`) arrives.
     let mut det = StreamingToolDetector::new();
-    let out1 = det.process(
-        "Hello <function>test</function><parameters><name>x</name><value>1</value>",
-    );
+    let out1 =
+        det.process("Hello <function>test</function><parameters><name>x</name><value>1</value>");
     let premature_tool_calls = out1
         .iter()
         .filter(|o| matches!(o, DetectorOutput::ToolCall(..)))

--- a/crates/spark-server/src/tool_parser/tests/group_b.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_b.rs
@@ -342,22 +342,48 @@ fn parse_mike_screenshot_format() {
 
 #[test]
 fn streaming_bare_function_flush() {
+    // Regression: a bare tag-style call split across stream chunks so the
+    // NAME closes (`</function>`) before the `<parameters>` block does.
+    // `bare_function_end` used to treat the name-closing `</function>` as
+    // end-of-call whenever `</parameters>` hadn't streamed in yet, emitting
+    // a zero-argument call from `process()` alone and leaking the orphaned
+    // `<parameters>...` text as raw content on the next call (it has no
+    // `<function` prefix, so nothing recognizes it as part of the tool
+    // call). Fixed by holding the block incomplete once `<parameters>` has
+    // opened, until its close (or end-of-stream via `flush()`) arrives.
     let mut det = StreamingToolDetector::new();
-    // Feed complete content including bare function tag
     let out1 = det.process(
-        "Hello <function>test</function><parameters><name>x</name><value>1</value></parameters>",
+        "Hello <function>test</function><parameters><name>x</name><value>1</value>",
     );
-    // Flush triggers bare function detection on buffered content
+    let premature_tool_calls = out1
+        .iter()
+        .filter(|o| matches!(o, DetectorOutput::ToolCall(..)))
+        .count();
+    assert_eq!(
+        premature_tool_calls, 0,
+        "must not complete the call before </parameters> arrives (params would be dropped)"
+    );
+    // `</parameters>` never arrives (e.g. max_tokens cutoff) — end of
+    // stream. Flush must recover the call, with its argument, from the
+    // buffered partial block — this is the actual flush() code path this
+    // test's name refers to.
     let out2 = det.flush();
     let all: Vec<_> = out1.into_iter().chain(out2).collect();
     let has_content = all
         .iter()
         .any(|o| matches!(o, DetectorOutput::Content(s) if s.contains("Hello")));
-    let has_tool = all
-        .iter()
-        .any(|o| matches!(o, DetectorOutput::ToolCall(tc, _) if tc.function.name == "test"));
+    let tool_call = all.iter().find_map(|o| match o {
+        DetectorOutput::ToolCall(tc, _) => Some(tc),
+        _ => None,
+    });
     assert!(has_content, "Should have content before function tag");
-    assert!(has_tool, "Should detect bare function tag on flush");
+    let tc = tool_call.expect("Should detect bare function tag on flush");
+    assert_eq!(tc.function.name, "test");
+    let args: serde_json::Value = serde_json::from_str(&tc.function.arguments).unwrap();
+    assert_eq!(
+        args["x"], 1,
+        "flush must recover the parameter value, not drop it: {args:?}"
+    );
 }
 
 // ── Duplicated name sanitization (Bash=Bash bug) ──


### PR DESCRIPTION
## Summary

RST mutation audit of all 28 registered checks in `tool_parser/tests/group_b.rs` (campaign IDs ATC-2100 through ATC-2127). Twenty-seven checks are GOOD, each verified by an executed, restored production mutant failing for the intended reason. One check exposed a **real streaming product bug**, fixed here in its own commit.

## Production bug: a bare tag-style call that closes its name before its parameters stream in

When a bare `<function>NAME</function><parameters>...</parameters>` call arrives split across stream chunks so that `</parameters>` has not yet streamed in, `bare_function_end` misread the name-closing `</function>` as the end of a zero-argument call. `process()` then delivered a tool call with empty arguments, and the orphaned `<parameters>...` text — which has no `<function` prefix for anything to recognize — leaked verbatim into the next chunk's client-visible content. Token-by-token delivery makes this split the realistic case, not the exception.

The fix holds the block incomplete once `<parameters>` has opened until its close (or end-of-stream via `flush()`) arrives, mirroring the `</parameters>`-before-`</function>` precedence already used when both are present. Worst case (close never arrives, e.g. max_tokens cutoff) degrades to `flush()` recovery — which the repaired test proves preserves the argument value.

Discovery was empirical: a two-`process()`-call probe showed the zero-argument call plus `Content("<parameters>...")` leakage on pre-fix code; the repaired test fails on pre-fix code at the intended assertion and passes with the fix.

## Test repair

`streaming_bare_function_flush` claimed to exercise `flush()` but fed the entire block in one `process()` call — instrumentation showed `flush()` always returned empty for that fixture, and the oracle never inspected the parsed arguments. The stimulus now splits the stream before `</parameters>`, asserts no premature tool call, and requires `flush()` to recover the call with `x == 1` intact.

## The 27 good checks (mutants executed and restored, highlights)

- Field-bleed guards: disabling the `</function>`-before-next-`<parameter=` guard fails both consecutive-function checks through their distinct entry points.
- `normalize_tool_name` is a live SSOT: disabling `=`-truncation fails three checks; disabling colon-namespace stripping fails all six namespaced-name checks across their six distinct formats — each guards a different parser wiring against forgetting the normalizer.
- The unclosed-param check's doc-comment credits `advanced_to_func_close`, but disabling that exact line kills zero tests in the whole 168-test suite (dead code — the top guard fires first for every reachable shape); a boundary-shift mutant on the real mechanism uniquely fails the check. The stale attribution is recorded as a nonclaim; removing dead code was out of scope.
- `parse_mike_screenshot_format` never asserts on `arguments` for its elaborate malformed fixture; the actual parse was traced and is defensible, so this is recorded as a weak-oracle note rather than repaired with an arbitrary expected value.

## Test plan

- [x] `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000 cargo test -p spark-server --bin spark --no-default-features --features metal tool_parser` (168 passed, 0 failed, 1 ignored — same count as pre-audit baseline)
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check-license-headers.sh` (0 invalid)
- [x] `typos` · `git diff --check`
- [ ] `cargo clippy -p spark-server --tests --no-default-features --features metal -- -D warnings` fails only in `spark-runtime` metal files untouched by this diff, byte-identical on pristine main (verified); Linux CI clippy owns this PR's gate
- [ ] Tested against a live model stream (not run: the split-chunk stimulus reproduces the streaming shape at the detector seam; no scheduler pass was exercised)
- [x] Added or updated tests where applicable

## Scope and remaining uncertainty

`spark-server` has no lib target and its default features need Linux-only `spark-storage` APIs, so the macOS runner is the `--bin spark --no-default-features --features metal` form above (recorded in the audit ledger as a testability note). All functional ties are static unit-level parser/detector calls; nothing here proves scheduler-level delivery ordering.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
