### PR TITLE
ci: route test-macos-metal to an opt-in macOS burst runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,18 @@ jobs:
     # suppresses the implicit success() on `needs` — so this job RUNS. Written
     # as `== 'false'` it would fail CLOSED and silently un-gate Rust changes.
     if: ${{ !cancelled() && needs.changes.outputs.web_only != 'true' }}
-    runs-on: macos-14
+    # Runner routing, in priority order:
+    #   fork PR       -> always macos-14. atlas is public, and a self-hosted Mac
+    #                    must never execute code from an untrusted fork. This is
+    #                    the rule that makes the burst runner safe at all.
+    #   everything else -> MACOS_RUNNER_LABEL when set (the on-demand Mac),
+    #                    otherwise macos-14.
+    # `head.repo.fork` is empty for push / merge_group / workflow_dispatch, so
+    # those fall through to the variable. The variable is managed by
+    # cmd-runner-health.yml: it is set only while a runner carrying the burst
+    # label is actually online, and cleared back to macos-14 when the Mac goes
+    # Off — otherwise a job would queue forever against a label nobody answers.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'macos-14' || vars.MACOS_RUNNER_LABEL || 'macos-14' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable

--- a/.github/workflows/cmd-runner-health.yml
+++ b/.github/workflows/cmd-runner-health.yml
@@ -83,3 +83,71 @@ jobs:
             # a red health check every 15 minutes trains people to ignore it.
             echo "::warning title=Cannot switch runners automatically::the token cannot write CMD_RUNNER_LABEL (needs 'administration: write' on the certification App). Set it by hand to '$want'."
           fi
+
+  macos-health:
+    name: macOS burst runner health
+    # Same idea as the job above, for the opt-in macOS burst runner that
+    # ci.yml's test-macos-metal job routes to. The crucial difference: for a
+    # BURST runner, offline is the normal resting state, not a failure. The Mac
+    # is a workstation that opts in for a while and then goes Off again, so a
+    # cleared variable is routine and is reported as a notice, never a warning.
+    #
+    # Without this, turning the Mac Off would leave MACOS_RUNNER_LABEL pointing
+    # at a label no online runner carries, and every Metal job would sit in
+    # "waiting for a runner" instead of falling back to GitHub-hosted.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint the certification App token
+        id: apptoken
+        if: vars.CERTIFICATION_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.CERTIFICATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CERTIFICATION_APP_PRIVATE_KEY }}
+
+      - name: Point the Metal job at a runner that answers
+        env:
+          GH_TOKEN: ${{ steps.apptoken.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          WANT: atlas-macos-burst
+          FALLBACK: macos-14
+        run: |
+          set -uo pipefail
+          # The burst controller removes the label before it stops the service,
+          # so "online AND carrying the label" is the only honest test of
+          # whether a job routed here would actually be picked up.
+          online=$(gh api "repos/$REPO/actions/runners" \
+                     --jq "[.runners[] | select(any(.labels[]; .name == \"$WANT\")) | select(.status == \"online\")] | length" \
+                     2>/dev/null) || online=UNKNOWN
+          case "$online" in ''|*[!0-9]*) online=UNKNOWN ;; esac
+
+          cur=$(gh api "repos/$REPO/actions/variables/MACOS_RUNNER_LABEL" --jq '.value' 2>/dev/null) || cur=""
+          echo "runners online with '$WANT': $online   MACOS_RUNNER_LABEL=${cur:-<unset>}"
+
+          if [ "$online" = "UNKNOWN" ]; then
+            echo "::warning title=Runner health unknown::could not read the runner list; leaving MACOS_RUNNER_LABEL as ${cur:-<unset>}."
+            exit 0
+          fi
+
+          want="$WANT"
+          [ "$online" -eq 0 ] && want="$FALLBACK"
+          if [ "$cur" = "$want" ]; then
+            echo "already correct - nothing to do."
+            exit 0
+          fi
+
+          # The variable may not exist yet on the first run; PATCH fails on a
+          # missing variable, so fall back to POST to create it.
+          if gh api -X PATCH "repos/$REPO/actions/variables/MACOS_RUNNER_LABEL" \
+               -f name=MACOS_RUNNER_LABEL -f value="$want" >/dev/null 2>&1 \
+             || gh api -X POST "repos/$REPO/actions/variables" \
+                  -f name=MACOS_RUNNER_LABEL -f value="$want" >/dev/null 2>&1; then
+            if [ "$want" = "$FALLBACK" ]; then
+              echo "::notice title=Burst Mac is Off::test-macos-metal is on $FALLBACK. This is the normal resting state."
+            else
+              echo "::notice title=Burst Mac is Available::test-macos-metal moved to $WANT."
+            fi
+            echo "MACOS_RUNNER_LABEL: ${cur:-<unset>} -> $want"
+          else
+            echo "::warning title=Cannot switch runners automatically::the token cannot write MACOS_RUNNER_LABEL (needs 'administration: write' on the certification App). Set it by hand to '$want'."
+          fi


### PR DESCRIPTION
## What

`test-macos-metal` is the only job in the repo that needs a Mac. This routes it to an opt-in self-hosted Apple Silicon runner when one is available, and leaves it on GitHub-hosted `macos-14` otherwise.

```yaml
runs-on: ${{ github.event.pull_request.head.repo.fork && 'macos-14' || vars.MACOS_RUNNER_LABEL || 'macos-14' }}
```

## Why it is safe on a public repo

**Fork PRs are pinned to `macos-14`, unconditionally.** A self-hosted runner executes workflow code as the host user, so untrusted fork code must never reach it. `head.repo.fork` is empty for `push` / `merge_group` / `workflow_dispatch`, so those fall through to the variable.

Worth being explicit about the boundary this draws: reviewed code that lands via push or the merge queue *does* run on the Mac. That is the same trust level as merging — but it is a real property of the change, not an accident.

## Why the health job is required

The burst Mac is Off most of the time by design. If `MACOS_RUNNER_LABEL` outlived the runner, every Metal job would sit in *waiting for a runner* against a label nobody answers.

So `cmd-runner-health.yml` now manages `MACOS_RUNNER_LABEL` exactly the way it already manages `CMD_RUNNER_LABEL` — set only while a runner carrying the burst label is genuinely online, cleared back to `macos-14` when it goes away. Because offline is the *resting state* for a burst runner rather than a fault, `macos-health` reports transitions as notices instead of warnings. It also falls back to `POST` on first run, since `PATCH` fails on a variable that does not exist yet.

## Rollout

**This PR is inert on its own.** With `MACOS_RUNNER_LABEL` unset the expression falls through to `macos-14`, exactly as today. Nothing changes until a runner with the `atlas-macos-burst` label comes online and the health job sets the variable.

The runner itself is registered and currently **Off** with its scheduling label absent, so it cannot pick up work yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)