### PR TITLE
ci: route Metal checks to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
     # suppresses the implicit success() on `needs` — so this job RUNS. Written
     # as `== 'false'` it would fail CLOSED and silently un-gate Rust changes.
     if: ${{ !cancelled() && needs.changes.outputs.web_only != 'true' }}
-    runs-on: macos-14
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -383,7 +383,7 @@ jobs:
       # feature opts out of cudarc workspace-wide and into the Metal
       # runtime backend (objc2-metal). xcrun + metallib are part of
       # macOS's built-in Xcode Command Line Tools and don't need a
-      # separate install on macos-14 runners.
+      # separate install on the self-hosted Apple Silicon runner.
       # `-p spark-server --features metal` activates the metal
       # feature on every transitive workspace crate via spark-server's
       # forwarding feature flags. Single-flag spelling — no long


### PR DESCRIPTION
## What

Route the existing macOS aarch64 Metal job to the organization's on-demand Apple Silicon runner using GitHub's default `self-hosted`, `macOS`, and `ARM64` labels.

## Why

This lets the on-demand M5 runner pick up Atlas PR Metal checks instead of leaving them on GitHub-hosted `macos-14`. The workflow already runs for every pull request; when the runner is off, matching jobs remain queued until it is enabled (subject to GitHub's normal queue limits). Runs created before this change must be rerun because runner labels are fixed when the job is created.

## Security

Atlas is public, so pull-request code can execute on this self-hosted machine while the runner is enabled. The runner is intentionally on-demand and dedicated to this workload.

## Validation

- `ruby -e "require 'yaml'; YAML.safe_load_file('.github/workflows/ci.yml', aliases: true)"`
- `git diff --check`
- `actionlint .github/workflows/ci.yml` (only the same three pre-existing SC2016 informational findings as `main`)

## Benchmarks

Not applicable; workflow routing only.

## Authorship

AI-assisted change prepared by Codex at Tom's direction.