### PR TITLE
tests: reject incomplete and stale serve-matrix evidence

### DIFF
--- a/.claude/skills/atlas-release/references/verify-matrix.md
+++ b/.claude/skills/atlas-release/references/verify-matrix.md
@@ -100,8 +100,10 @@ result. Missing manifest ⇒ hard FAIL unless you pass `--allow-missing-manifest
 "planned-but-absent = FAIL" property in.
 
 The per-model bars (constants at the top of the script, chosen up front):
-- **present** — the model is in the manifest **and** has a results file (booted
-  past the `/v1/models` health check).
+- **present** — the model is in the manifest and has a matching result with
+  nonempty required probe groups. The orchestrator clears planned prior results
+  before boot attempts and rejects output from failed suite subprocesses. Archive
+  completed artifacts before another run; use one orchestrator per checkout.
 - **coherence** ≥ 2 of 3 probes PASS (tolerates the one temp>0 creative probe).
 - **codegen** — the fibonacci exec smoke PASS.
 - **tools** — at least one real PASS, **or** all `N/A` (known-gap parser). An
@@ -114,9 +116,12 @@ The per-model bars (constants at the top of the script, chosen up front):
   approach proposed by @Sujimoshi in #253; folded into the gate here to keep one
   roster/SSOT rather than a parallel suite.)
 
+The detailed evidence and remaining provenance limits are in
+[`docs/testing/serve-matrix-rst-audit-2026-09-04.md`](../../../../docs/testing/serve-matrix-rst-audit-2026-09-04.md).
+
 Validated against fixtures (full-pass / planned-but-missing / below-bar /
 known-gap-all-N/A / tps-regression / no-baseline / require-baselines) in
-`tests/test_gate_results.py` (23 tests). Run order for `/atlas-release gate`:
+`tests/test_gate_results.py` and `tests/test_gate_results_orchestrator.py` (host-only). Run order for `/atlas-release gate`:
 ```bash
 ATLAS_IMAGE=<tag> python3 tests/run_all_models.py               # boots + probes matrix -> *.json + _manifest.json
 python3 scripts/test_coherence.py --url http://localhost:8888   # leak/determinism/tools, exit 1 on fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,14 @@ jobs:
       # GPU, no network.
       - run: bash .github/scripts/harvest-triage-test.sh
 
+  serve-matrix-gate:
+    name: serve matrix verdict contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Exercise release evidence and subprocess failure paths without a GPU.
+      - run: python3 -m unittest discover -s tests -p 'test_gate_results*.py' -v
+
   test:
     name: cargo test --workspace
     needs: [changes]

--- a/docs/testing/serve-matrix-rst-audit-2026-09-04.md
+++ b/docs/testing/serve-matrix-rst-audit-2026-09-04.md
@@ -1,0 +1,142 @@
+# Serve-matrix evidence audit, 2026-09-04
+
+Targets Avarok-Cybersecurity/atlas `main` at `567b5ebe7784ac3657a4ae97940f6783c8414393`,
+revalidated September 5. This tranche changes the Python release harness and
+its checks. It changes no inference, model, kernel, or Rust code.
+
+The decision under examination is whether the documented serve-matrix command
+may authorize an image release. The coverage model is artifact presence,
+required probe groups, numerical validity, declared model identity, and process
+completion. A green result remains limited to these observations.
+
+## Findings and repairs
+
+The original 23-check `tests/test_gate_results.py` suite passed. The following
+inputs and transitions nevertheless accepted invalid release evidence:
+
+| Contract | Observed original behavior | Repair and check owner |
+| --- | --- | --- |
+| Required evidence | `{ "model": "M/a", "coherence": [] }` passed the actual gate entry point with exit 0; absent, null, or empty probe groups bypassed their bars. | Require nonempty, correctly shaped coherence, fibonacci, tool-call, and TPS groups. `EvidenceContracts.test_every_required_probe_must_supply_evidence` and `ArtifactContracts.test_cli_blocks_a_partial_artifact`. |
+| Status identity | `FAIL (expected PASS)` counted as coherence success; `FAIL (expected N/A)` waived tool checks. | Read the leading status, preserving the suite's `PASS (plain-text)` and `N/A (parser not supported)` forms. `test_status_reason_cannot_masquerade_as_a_pass_or_waiver`. |
+| Numerical evidence | NaN/Inf TPS escaped comparisons. Invalid samples could disappear beside a valid sample; booleans counted as numbers. | Require every sample and the mean to be finite numeric values; reject unrepresentable integers. `test_invalid_tps_cannot_hide_alongside_a_valid_sample`. |
+| Baseline integrity | Invalid baseline values or malformed baseline JSON silently disabled the regression bar. | Keep absent baselines distinct from present invalid ones; report `tps(invalid-baseline)`. `test_existing_invalid_baseline_cannot_disable_the_regression_bar` and `test_malformed_baseline_is_present_but_invalid`. |
+| Model identity | An artifact naming `M/wrong-checkpoint` verified a roster entry naming `M/expected`. | Match the artifact's model to the manifest, reporting `model-mismatch`. `test_manifest_model_must_match_the_observed_result`. |
+| Baseline refresh | A correctness-failing or wrong-model artifact could overwrite the blessed throughput baseline. | Require correctness, finite positive throughput, and roster identity before writing. `test_baseline_update_requires_all_correctness_bars_and_identity`; every rejected row starts with and preserves a distinct 50 TPS baseline. |
+| New run, failed boot | Publishing a new manifest left the prior run's planned JSON files in place. A model that never booted could inherit old passing evidence. | Validate all labels, then remove only planned per-model results before any boot attempt. `OrchestratorEvidence.test_new_manifest_invalidates_planned_results_before_any_boot`; an unplanned artifact must remain unchanged. |
+| Output-less suite | A subprocess exiting successfully without writing JSON reused the old result file. | Remove the specific prior output before launching the suite. `test_success_without_output_cannot_reuse_a_previous_result`. |
+| Failing suite | `wait_and_read` ignored the subprocess exit code, including a process that wrote valid JSON before exiting 7. | On nonzero exit, remove that output and return no result, so the independent gate also rejects it. `test_failed_subprocess_cannot_leave_a_gateable_result`. |
+
+The subprocess checks call the real `run_suite` and `wait_and_read` functions
+with a tiny local Python program in place of `single_gpu_suite.py`. They launch
+real child processes. A successful child writes 63 TPS instead of the old
+42 TPS, and both the returned artifact and the independent gate must observe
+the new evidence. No HTTP endpoint or Docker command is called.
+
+Cleanup validates the whole roster before touching any artifact, rejecting path
+separators, empty labels, and reserved aggregate/manifest names. It deletes only
+generated planned result JSON, not logs or unplanned results. Archive completed
+run artifacts before starting another campaign in the same checkout.
+
+## Functional connection and reachability
+
+Static trace: `single_gpu_suite.py` emits the probe groups and model argument;
+`run_all_models.py::main` publishes the planned roster before starting model
+rounds; both single-GPU and multi-rank rounds call `run_suite` / `wait_and_read`.
+The documented release procedure then executes `tests/gate_results.py`, whose
+`main` consumes the roster, per-model artifacts, and committed baselines.
+
+Observed: host fixture files reach `gate_manifest`, `verdict`, baseline updates,
+and the actual gate CLI; subprocess fixtures reach both orchestrator helpers.
+The previously unregistered Python checks now have a GPU-free CI job,
+`serve-matrix-gate`, running this exact command:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_gate_results*.py' -v
+```
+
+The existing gate source was byte-identical on Avarok
+revision `567b5ebe7` and the initially examined Atlas-Inf revision `6c5f17dab` (SHA256
+`9ff13894aa88633cad00394a281c360a394091df790719d17f6908d615e155a5`). These repairs
+therefore address a surviving harness gap rather than assuming old audit work
+was absent based on commit subjects.
+
+## Defect sensitivity
+
+Each mutation below was applied independently in an isolated copy of the
+actual Python modules. The original 23 checks passed under every mutation.
+The repaired checks rejected each mutation through the named assertions;
+there were no import, syntax, or unrelated runtime errors in the reported
+mutation runs. All mutation copies were outside the repository worktree.
+
+| Mutant | Repaired observation |
+| --- | --- |
+| Remove the missing-probe failure append. | 12 absent/empty/null partitions and the partial-artifact CLI fail; the CLI wrongly exits 0 again. |
+| Restore status substring matching. | Four failure/waiver classification partitions fail. |
+| Allow non-finite floats and remove the finite-mean check. | NaN/Inf TPS, infinite baseline, and non-finite refresh partitions fail. |
+| Bypass the manifest/result model comparison. | Expected `(0, 1, model-mismatch)` becomes `(1, 1, [])`. |
+| Return absent-baseline `None` on malformed JSON. | The malformed-file fixture wrongly verifies instead of reporting invalid baseline. |
+| Remove correctness/identity admission from baseline refresh. | Coherence, fibonacci, tool-call, and wrong-model refresh partitions overwrite the 50 TPS control. |
+| Omit planned-output cleanup when publishing the manifest. | A simulated failed boot verifies the old artifact instead of reporting `no-result`. |
+| Omit cleanup immediately before the suite subprocess. | Exit 0 with no output returns the old 42 TPS artifact instead of `None`. |
+| Ignore the subprocess failure status. | A child writing JSON then exiting 7 returns a gateable result instead of `None`. |
+
+Nearby valid controls remain: the existing two-of-three coherence policy,
+known-gap tool waiver, annotated successful statuses, absent optional baselines,
+45 TPS at a 50 TPS baseline's exact 10% boundary, a successful baseline refresh,
+and a successful child writing new evidence. The threshold values are unchanged.
+
+## Verification and limits
+
+Original audit observations on macOS arm64 with Python 3.14.6, before the
+September 5 Avarok revalidation below:
+
+- Original suite: 23 passed, no skips.
+- New scorer checks before repair: 33 checks ran with 39 failing subtest/assertion
+  cases, including the process-level false green. The additional malformed-shape
+  check was added while implementing input validation.
+- New orchestrator checks before repair: six ran with nine failing assertion
+  cases; the successful child control already passed.
+- Final registered command: 40 passed, no skips. Nine distinct known-bad
+  production mutations survived the old suite and failed the repaired checks.
+- Python syntax compilation, workflow YAML parsing, `git diff --check`,
+  `cargo fmt --all -- --check`, and the repository SPDX check passed.
+- Workspace Clippy was attempted with `ATLAS_SKIP_BUILD=1`,
+  `CUDARC_CUDA_VERSION=13000`, two build jobs, and an isolated Cargo target.
+  It exited 101 because `spark-storage`'s `streaming_attention_e2e` target
+  references Linux-only `IoUringBackend` on macOS.
+  Rust workspace tests and rustdoc were not run after that build prerequisite
+  failed. The Ubuntu CI Rust jobs remain the required owners of that evidence.
+
+### September 5 Avarok revalidation
+
+The complete 40-check suite was first run against unchanged Avarok production
+code at `567b5ebe7`: it reported 54 failing assertions/subtests and 13 errors
+from malformed probe shapes and an unrepresentable integer. With the repairs,
+all 40 checks pass with zero skips. Avarok's existing case-insensitive readiness
+marker and log matching are preserved. The CI job is added to Avarok's current
+workflow; its other jobs and gating remain unchanged.
+
+Python syntax, workspace Rust formatting, scoped typos, whitespace, and
+actionlint workflow validation pass. Shellcheck additionally reports the same
+three SC2016 findings in unchanged existing workflow code on both base and
+patch. No changed file falls under the repository's SPDX source-header scope.
+The Avarok workspace Clippy attempt stops in unchanged `spark-storage` code
+using Linux-only `libc` constants (`O_DIRECT` and `POSIX_FADV_DONTNEED`) on
+macOS. Ubuntu Rust CI remains pending; no local Rust test pass is claimed.
+
+This does not establish CUDA execution, live-model coherence, numerical model
+parity, throughput, multi-rank behavior, Docker image correctness, or the actual
+checkpoint served. The result's `model` is an argument copied by the suite,
+not independent confirmation of loaded weights.
+
+The remaining highest-value experiment is a fresh image serve-matrix run with
+image digest, source commit, checkpoint revision, and hardware/environment
+recorded alongside the artifacts. Run one orchestrator per results directory:
+this repair closes sequential stale-result reuse, not concurrent-writer races.
+The manifest/result schema still lacks a run identity and cryptographic
+provenance; manually supplied or copied artifacts can bypass the orchestrator's
+freshness discipline. The gate also retains its aggregate coherence and TPS
+policy and does not certify every individual prompt or complete probe cardinality.
+
+The bounded host audit stops after closing these demonstrated release-evidence
+gaps and registering their checks. Fresh GPU evidence remains a separate campaign.

--- a/tests/gate_results.py
+++ b/tests/gate_results.py
@@ -32,14 +32,16 @@ Design (see .claude/skills/atlas-release/references/verify-matrix.md §Gate):
     A missing manifest is a hard FAIL unless coverage is explicitly waived.
   * SSOT — the roster lives in run_all_models.py (the manifest); this gate
     derives from it and never re-lists models.
-A model "verifies" iff it is in the manifest AND its results file exists (it
-booted past the /v1/models health check — single_gpu_suite exits before writing
-if the server is unreachable) AND it clears every bar below.
+A model "verifies" iff its artifact matches the manifest's model and supplies
+every required probe group with valid evidence clearing the bars below.
+This checks artifact content, not freshness or the server's actual checkpoint:
+use a fresh results directory for each image run and retain its provenance.
 """
 
 import argparse
 import glob
 import json
+import math
 import os
 import sys
 
@@ -67,21 +69,53 @@ TPS_TOLERANCE = 0.10     # tps regression bar. A committed tests/baselines/<labe
 # is a regression.
 
 
+def _status_is(s, status):
+    # The suite appends parenthesized details (e.g. PASS (plain-text)).
+    # Words in a failure reason must not change the row's classification.
+    return isinstance(s, str) and (s == status or s.startswith(status + " ("))
+
+
 def _status_pass(s):
-    return "PASS" in (s or "")
+    return _status_is(s, "PASS")
 
 
 def _status_na(s):
-    return "N/A" in (s or "")
+    return _status_is(s, "N/A")
+
+
+def _finite_number(value):
+    try:
+        return type(value) in (int, float) and math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _valid_baseline(baseline):
+    return (isinstance(baseline, dict) and _finite_number(baseline.get("tps"))
+            and baseline["tps"] > 0)
 
 
 def _avg_tps(model_result):
-    """Mean measured tokens/sec across the tps probes, or None if none numeric."""
-    vals = [r.get("tps") for r in (model_result.get("tps", []) or [])
-            if isinstance(r.get("tps"), (int, float))]
-    if not vals:
+    """Mean across every TPS probe, or None for missing/invalid evidence."""
+    rows = model_result.get("tps")
+    if not isinstance(rows, list) or not rows:
         return None
-    return sum(vals) / len(vals)
+    vals = [r.get("tps") if isinstance(r, dict) else None for r in rows]
+    if not all(_finite_number(v) for v in vals):
+        return None
+    avg = sum(vals) / len(vals)
+    return avg if math.isfinite(avg) else None
+
+
+def _probe_rows(model_result, key, fails):
+    rows = model_result.get(key)
+    if rows is None or rows == []:
+        fails.append(f"{key}(no-evidence)")
+        return []
+    if not isinstance(rows, list) or not all(isinstance(r, dict) for r in rows):
+        fails.append(f"{key}(invalid)")
+        return []
+    return rows
 
 
 def verdict(model_result, baseline=None, require_baseline=False):
@@ -94,28 +128,33 @@ def verdict(model_result, baseline=None, require_baseline=False):
     """
     fails = []
 
-    coh = model_result.get("coherence", []) or []
+    coh = _probe_rows(model_result, "coherence", fails)
     coh_pass = sum(1 for r in coh if _status_pass(r.get("status")))
     if coh and coh_pass < COHERENCE_MIN_PASS:
         fails.append(f"coherence({coh_pass}/{len(coh)})")
 
-    fib = model_result.get("fibonacci", []) or []
+    fib = _probe_rows(model_result, "fibonacci", fails)
     fib_pass = sum(1 for r in fib if _status_pass(r.get("status")))
     if fib and fib_pass < FIB_MIN_PASS:
         fails.append("fibonacci")
 
-    tc = model_result.get("tool_calls", []) or []
+    tc = _probe_rows(model_result, "tool_calls", fails)
     if tc:
         any_pass = any(_status_pass(r.get("status")) for r in tc)
         all_na = all(_status_na(r.get("status")) for r in tc)
         if not any_pass and not all_na:
             fails.append("tool_calls")
 
-    avg = _avg_tps(model_result)
-    if avg is not None:
-        if avg <= 0:
+    tps = _probe_rows(model_result, "tps", fails)
+    if tps:
+        avg = _avg_tps(model_result)
+        if avg is None:
+            fails.append("tps(invalid)")
+        elif avg <= 0:
             fails.append("tps(0)")
-        elif baseline and isinstance(baseline.get("tps"), (int, float)) and baseline["tps"] > 0:
+        elif baseline is not None and not _valid_baseline(baseline):
+            fails.append("tps(invalid-baseline)")
+        elif baseline is not None:
             floor = baseline["tps"] * (1 - TPS_TOLERANCE)
             if avg < floor:
                 fails.append(f"tps({avg:.1f}<{floor:.1f})")
@@ -151,15 +190,18 @@ def load_result_file(path):
 
 
 def load_baseline(label, baseline_dir):
-    """Return the {"tps": ...} baseline for a label, or None if not committed."""
+    """Return a baseline, None if absent, or an invalid dict for unreadable data."""
     path = os.path.join(baseline_dir, f"{label}.json")
     if not os.path.isfile(path):
         return None
     try:
         with open(path) as f:
-            return json.load(f)
+            baseline = json.load(f)
+        return baseline if isinstance(baseline, dict) else {}
     except (json.JSONDecodeError, OSError):
-        return None
+        # A present but unreadable baseline must not become the deliberately
+        # allowed "no baseline" liveness-only mode.
+        return {}
 
 
 def write_baseline(label, data, baseline_dir):
@@ -183,7 +225,7 @@ def _score_one(label, name, result, baseline_dir, require_baseline):
     bars = verdict(result, baseline=baseline, require_baseline=require_baseline)
     note = ""
     avg = _avg_tps(result)
-    if avg and avg > 0 and not (baseline and isinstance(baseline.get("tps"), (int, float))) \
+    if avg and avg > 0 and baseline is None \
             and not require_baseline:
         note = "  (no tps baseline — liveness only; run --update-baselines)"
     return bars, note
@@ -230,6 +272,10 @@ def gate_manifest(results_dir, roster, baseline_dir=BASELINE_DIR, require_baseli
             print(f"  [FAIL] {name}  <- unreadable: {err}")
             failures.append((name, [f"unreadable: {err}"]))
             continue
+        if result.get("model") != model:
+            print(f"  [FAIL] {name}  <- result model is {result.get('model')!r}")
+            failures.append((name, ["model-mismatch"]))
+            continue
         bars, note = _score_one(label, name, result, baseline_dir, require_baseline)
         mark = "PASS" if not bars else "FAIL"
         print(f"  [{mark}] {name}" + ("" if not bars else f"  <- {', '.join(bars)}") + note)
@@ -271,7 +317,8 @@ def update_baselines(results_dir, roster, baseline_dir):
     """Write tests/baselines/<label>.json = {"tps": <avg>} from present results.
 
     Roster (label, model) list if a manifest exists, else every present result
-    file. Only positive tps is recorded. Returns [(label, avg)] written.
+    file. Only results clearing the correctness/liveness bars and matching
+    the planned model are eligible. Returns [(label, avg)] written.
     """
     if roster is None:
         items = [(os.path.splitext(os.path.basename(p))[0], None)
@@ -280,12 +327,14 @@ def update_baselines(results_dir, roster, baseline_dir):
     else:
         items = roster
     written = []
-    for label, _ in items:
+    for label, model in items:
         path = os.path.join(results_dir, f"{label}.json")
         if not os.path.isfile(path):
             continue
         result, _err = load_result_file(path)
         if result is None:
+            continue
+        if (model is not None and result.get("model") != model) or verdict(result):
             continue
         avg = _avg_tps(result)
         if avg is None or avg <= 0:

--- a/tests/run_all_models.py
+++ b/tests/run_all_models.py
@@ -416,13 +416,31 @@ def settle() -> None:
     time.sleep(INTER_ROUND_SETTLE_SECONDS)
 
 
+def result_path(label: str) -> str:
+    """Keep generated result cleanup inside this run's results directory."""
+    if (not isinstance(label, str) or not label or "/" in label or "\\" in label
+            or label in (".", "..", "_manifest", "_partial", "all_results")):
+        raise ValueError(f"invalid result label: {label!r}")
+    return os.path.join(RESULTS_DIR, f"{label}.json")
+
+
+def remove_result(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
 def run_suite(host: str, spec: TestSpec, port: int) -> dict:
     """Run single_gpu_suite.py against the given server, return parsed JSON."""
     if host == "head":
         base_url = f"http://localhost:{port}/v1"
     else:
         base_url = f"http://{WORKER_IP}:{port}/v1"
-    out_json = os.path.join(RESULTS_DIR, f"{spec.label}.json")
+    out_json = result_path(spec.label)
+    # A failed or output-less subprocess must not inherit a prior result,
+    # including when run_suite is invoked independently of main's manifest.
+    remove_result(out_json)
     log_path = os.path.join(RESULTS_DIR, f"{spec.label}.log")
     cmd = [
         "python3", SUITE,
@@ -441,7 +459,13 @@ def run_suite(host: str, spec: TestSpec, port: int) -> dict:
 
 def wait_and_read(job: dict) -> Optional[dict]:
     proc = job["proc"]
-    proc.wait()
+    code = proc.wait()
+    if code != 0:
+        # The release gate reads these files independently of this return
+        # value. Discard even valid JSON written by a failed suite process.
+        remove_result(job["out_json"])
+        print(f"    [warn] suite exited {code}; rejected {job['out_json']}")
+        return None
     try:
         with open(job["out_json"]) as f:
             return json.load(f)
@@ -813,6 +837,13 @@ def load_roster(path):
 
 def write_manifest(**flags):
     planned = planned_specs(**flags)
+    # Invalidate previous evidence before any container starts, including
+    # models that will fail at boot and never reach run_suite. Validate the
+    # whole roster before deleting anything. This directory has one writer;
+    # concurrent campaigns must use separate checkouts/results directories.
+    paths = [result_path(label) for label, _model in planned]
+    for path in paths:
+        remove_result(path)
     manifest = {
         "generated_by": "tests/run_all_models.py",
         "labels": [{"label": label, "model": model} for label, model in planned],

--- a/tests/test_gate_results.py
+++ b/tests/test_gate_results.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Self-test for tests/gate_results.py — the serve-matrix release gate.
 
-Pure stdlib (unittest); no server, no GPU. Validates the two properties that
-matter: the per-model bars, and — the reason this gate exists — that a planned
-model which never produced a result FAILS coverage instead of being invisible.
+Pure stdlib (unittest); no server, no GPU. Checks the per-model bars, missing
+and invalid evidence, declared checkpoint identity, baseline eligibility, and
+the process exit status that the release workflow consumes.
 
     python3 -m unittest tests.test_gate_results        # from repo root
     python3 tests/test_gate_results.py                 # direct
 """
 
+import contextlib
+import io
 import json
 import os
 import sys
@@ -201,6 +203,127 @@ class MainExit(unittest.TestCase):
         with open(os.path.join(self.tmp, "a.json"), "w") as f:
             json.dump(_model_result("M/a"), f)
         self.assertEqual(self._run(), 0)
+
+
+class EvidenceContracts(unittest.TestCase):
+    """Reject missing or misleading evidence, not just explicit FAIL rows."""
+
+    def test_every_required_probe_must_supply_evidence(self):
+        for key in ("coherence", "fibonacci", "tool_calls", "tps"):
+            for kind in ("absent", "empty", "null"):
+                with self.subTest(probe=key, evidence=kind):
+                    result = _model_result("m")
+                    if kind == "absent":
+                        del result[key]
+                    else:
+                        result[key] = [] if kind == "empty" else None
+                    self.assertEqual(G.verdict(result), [f"{key}(no-evidence)"])
+
+    def test_status_reason_cannot_masquerade_as_a_pass_or_waiver(self):
+        cases = (
+            ("coherence", "FAIL (expected PASS)", ["coherence(0/3)"]),
+            ("fibonacci", "BYPASS", ["fibonacci"]),
+            ("tool_calls", "FAIL (expected N/A)", ["tool_calls"]),
+            ("tool_calls", "NOT PASS", ["tool_calls"]),
+        )
+        for key, status, expected in cases:
+            with self.subTest(probe=key, status=status):
+                result = _model_result("m")
+                for row in result[key]:
+                    row["status"] = status
+                self.assertEqual(G.verdict(result), expected)
+
+    def test_malformed_probe_collections_are_rejected_by_name(self):
+        for key in ("coherence", "fibonacci", "tool_calls", "tps"):
+            for rows in ({}, "PASS", [None], ["PASS"]):
+                with self.subTest(probe=key, rows=rows):
+                    result = _model_result("m")
+                    result[key] = rows
+                    self.assertEqual(G.verdict(result), [f"{key}(invalid)"])
+
+    def test_status_annotations_emitted_by_the_suite_remain_valid(self):
+        self.assertEqual(G.verdict(_model_result(
+            "m", fib=("PASS (plain-text)",),
+            tools=("N/A (parser not supported)",))), [])
+
+    def test_invalid_tps_cannot_hide_alongside_a_valid_sample(self):
+        for value in (float("nan"), float("inf"), -float("inf"), True, "42", None,
+                      10 ** 400):
+            with self.subTest(value=value):
+                self.assertEqual(G.verdict(_model_result("m", tps=(42.0, value))),
+                                 ["tps(invalid)"])
+
+    def test_existing_invalid_baseline_cannot_disable_the_regression_bar(self):
+        for baseline in ({}, [], {"tps": 0}, {"tps": -1}, {"tps": True},
+                         {"tps": float("nan")}, {"tps": float("inf")}, {"tps": "50"}):
+            with self.subTest(baseline=baseline):
+                self.assertEqual(G.verdict(_model_result("m"), baseline=baseline),
+                                 ["tps(invalid-baseline)"])
+
+    def test_tps_tolerance_boundary_is_inclusive(self):
+        self.assertEqual(G.verdict(_model_result("m", tps=(45.0,)),
+                                   baseline={"tps": 50.0}), [])
+        self.assertEqual(G.verdict(_model_result("m", tps=(44.0,)),
+                                   baseline={"tps": 50.0}), ["tps(44.0<45.0)"])
+
+
+class ArtifactContracts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.bdir = os.path.join(self.tmp.name, "baselines")
+
+    def _write(self, result):
+        with open(os.path.join(self.tmp.name, "a.json"), "w") as f:
+            json.dump(result, f)
+
+    def test_manifest_model_must_match_the_observed_result(self):
+        self._write(_model_result("M/wrong-checkpoint"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            got = G.gate_manifest(self.tmp.name, [("a", "M/expected")], self.bdir)
+        self.assertEqual(got, (0, 1, [("M/expected", ["model-mismatch"])]))
+
+    def test_baseline_update_requires_all_correctness_bars_and_identity(self):
+        cases = (
+            _model_result("M/a", coh=("FAIL",)),
+            _model_result("M/a", fib=("FAIL",)),
+            _model_result("M/a", tools=("FAIL",)),
+            _model_result("M/a", tps=(float("nan"),)),
+            _model_result("M/a", tps=(float("inf"),)),
+            _model_result("M/wrong-checkpoint"),
+        )
+        for result in cases:
+            with self.subTest(result=result):
+                G.write_baseline("a", {"tps": 50.0}, self.bdir)
+                self._write(result)
+                self.assertEqual(G.update_baselines(
+                    self.tmp.name, [("a", "M/a")], self.bdir), [])
+                self.assertEqual(G.load_baseline("a", self.bdir), {"tps": 50.0})
+
+    def test_malformed_baseline_is_present_but_invalid(self):
+        os.makedirs(self.bdir)
+        self._write(_model_result("M/a"))
+        for content in ("{broken json", "null", "[]"):
+            with self.subTest(content=content):
+                with open(os.path.join(self.bdir, "a.json"), "w") as f:
+                    f.write(content)
+                with contextlib.redirect_stdout(io.StringIO()):
+                    got = G.gate_manifest(self.tmp.name, [("a", "M/a")], self.bdir)
+                self.assertEqual(got, (0, 1, [("M/a", ["tps(invalid-baseline)"])]))
+
+    def test_cli_blocks_a_partial_artifact(self):
+        with open(os.path.join(self.tmp.name, G.MANIFEST_NAME), "w") as f:
+            json.dump({"labels": [{"label": "a", "model": "M/a"}]}, f)
+        self._write({"model": "M/a", "coherence": []})
+        # Use the actual entry point: a gate that only prints FAIL is unsafe
+        # for the documented release command sequence.
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, G.__file__, "--results-dir", self.tmp.name,
+             "--baseline-dir", self.bdir], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        for bar in ("coherence", "fibonacci", "tool_calls", "tps"):
+            self.assertIn(f"{bar}(no-evidence)", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_gate_results_orchestrator.py
+++ b/tests/test_gate_results_orchestrator.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Host-only subprocess checks for serve-matrix artifact freshness.
+
+The real orchestrator launches a tiny Python fixture instead of a model suite.
+No container, server, network request, checkpoint, or GPU is used.
+"""
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gate_results as G
+import run_all_models as M
+from test_gate_results import _model_result
+
+
+class OrchestratorEvidence(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.output = self.root / "a.json"
+        self.suite = self.root / "fixture_suite.py"
+        self.spec = M.TestSpec("a", "M/a")
+        self.roster = [("a", "M/a")]
+        for name, value in (
+            ("RESULTS_DIR", self.tmp.name),
+            ("MANIFEST_PATH", str(self.root / G.MANIFEST_NAME)),
+            ("SUITE", str(self.suite)),
+            ("ROUNDS", [[("head", self.spec)]]),
+        ):
+            patcher = patch.object(M, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _write_old_result(self):
+        self.output.write_text(json.dumps(_model_result("M/a", tps=(42.0,))))
+
+    def _launch(self, *, exit_code, write_output):
+        # The fixture understands the same process arguments as the real
+        # single_gpu_suite. Keep a distinct TPS value so reuse is observable.
+        fresh = _model_result("M/a", tps=(63.0,))
+        self.suite.write_text(
+            "import argparse, json, pathlib, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--base-url')\n"
+            "p.add_argument('--model')\n"
+            "p.add_argument('--output')\n"
+            "a = p.parse_args()\n"
+            "assert a.model == 'M/a'\n"
+            + (f"pathlib.Path(a.output).write_text({json.dumps(fresh)!r})\n"
+               if write_output else "")
+            + f"sys.exit({exit_code})\n"
+        )
+        job = M.run_suite("head", self.spec, 8888)
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = M.wait_and_read(job)
+        return result, fresh
+
+    def _gate(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            return G.gate_manifest(self.tmp.name, self.roster,
+                                   str(self.root / "baselines"))
+
+    def _write_manifest(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            M.write_manifest(run_singlegpu=True, skip=set(), only_round=None,
+                             run_ep2=False, run_tp2=False, run_tpep=False, run_ep4=False)
+
+    def test_new_manifest_invalidates_planned_results_before_any_boot(self):
+        self._write_old_result()
+        unrelated = self.root / "unplanned.json"
+        unrelated.write_text("preserve unrelated run artifact")
+        self._write_manifest()
+        self.assertEqual(G.load_manifest(self.tmp.name, None), self.roster)
+        self.assertEqual(self._gate(), (0, 1, [("M/a", ["no-result"])]))
+        self.assertEqual(unrelated.read_text(), "preserve unrelated run artifact")
+
+    def test_failed_subprocess_cannot_reuse_a_previous_result(self):
+        self._write_old_result()
+        result, _ = self._launch(exit_code=7, write_output=False)
+        self.assertIsNone(result)
+        self.assertEqual(self._gate(), (0, 1, [("M/a", ["no-result"])]))
+
+    def test_failed_subprocess_cannot_leave_a_gateable_result(self):
+        result, _ = self._launch(exit_code=7, write_output=True)
+        self.assertIsNone(result)
+        self.assertEqual(self._gate(), (0, 1, [("M/a", ["no-result"])]))
+
+    def test_success_without_output_cannot_reuse_a_previous_result(self):
+        self._write_old_result()
+        result, _ = self._launch(exit_code=0, write_output=False)
+        self.assertIsNone(result)
+        self.assertEqual(self._gate(), (0, 1, [("M/a", ["no-result"])]))
+
+    def test_successful_subprocess_supplies_fresh_passing_evidence(self):
+        self._write_old_result()
+        result, fresh = self._launch(exit_code=0, write_output=True)
+        self.assertEqual(result, fresh)
+        self.assertEqual(self._gate(), (1, 1, []))
+
+    def test_all_labels_are_validated_before_cleanup(self):
+        for label in ("../outside", "nested/label", "nested\\label", "_manifest", ""):
+            with self.subTest(label=label):
+                self._write_old_result()
+                old_bytes = self.output.read_bytes()
+                M.ROUNDS = [[("head", self.spec), ("head", M.TestSpec(label, "M/b"))]]
+                with self.assertRaisesRegex(ValueError, "invalid result label"):
+                    self._write_manifest()
+                self.assertEqual(self.output.read_bytes(), old_bytes)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The serve-matrix release gate can accept missing probe evidence, misleading status strings, non-finite throughput, and results for the wrong model. Failed boots or suite subprocesses can also leave old JSON that certifies a new campaign. This change rejects invalid evidence and clears stale per-model output before boot and suite execution.

The scorer validates required probe groups, numeric throughput and baselines, manifest model identity, and baseline-refresh eligibility. The orchestrator validates labels before cleanup and discards JSON from failed subprocesses. The existing Avarok readiness fix is preserved.

Shared CI change: adds one Ubuntu job running the 40 stdlib scorer and subprocess contract checks. Existing workflow jobs and gates remain unchanged. Release instructions and the repository audit describe the evidence and remaining provenance gaps.

Validation against Avarok main `567b5ebe7784ac3657a4ae97940f6783c8414393`: the new suite reports 54 failing assertions/subtests and 13 malformed-input errors before repair; all 40 checks pass after repair, with zero skips. Python syntax, Rust formatting, scoped typos, diff whitespace and actionlint workflow validation pass. The three Shellcheck SC2016 findings are identical on unchanged base and patch. Workspace Clippy stops at existing Linux-only libc constants in spark-storage on macOS; Ubuntu CI is pending. No Rust, kernel, model or benchmark baseline changes, and no live inference or throughput claim.

Audit: `docs/testing/serve-matrix-rst-audit-2026-09-04.md`. The results directory still requires one orchestrator; copied artifacts and concurrent writers need independent run/image/checkpoint provenance.

AI assistance: RST audit, implementation, mutation testing, Avarok revalidation and documentation.
