### PR TITLE
spark-runtime: stop treating host MemAvailable as device free memory on discrete GPUs

### DIFF
--- a/crates/spark-model/src/factory/build.rs
+++ b/crates/spark-model/src/factory/build.rs
@@ -439,11 +439,34 @@ pub fn build_model(
                 gib(used_so_far - ledger_live),
             );
             used_so_far = ledger_live;
-        } else {
+        } else if ledger_live > used_so_far {
+            // Not "the ledger is implausible" — it is the DEVICE figure that
+            // cannot be true. The ledger counts only allocations this backend
+            // made and still holds, so real device usage is always at least
+            // `ledger_live`; `used_so_far` (total − free_memory()) coming out
+            // SMALLER means `free_memory()` over-reported free memory. That is
+            // exactly what a discrete GPU did when `free_memory()` substituted
+            // host MemAvailable: ~990 GB "free" on a 95 GB card → used_so_far
+            // 0 → a KV pool sized as if nothing were allocated → OOM at
+            // cuMemAlloc. Charging the ledger is strictly more conservative
+            // than charging the smaller (impossible) device-derived figure:
+            // it can only shrink the KV budget, never grow it.
             tracing::warn!(
-                "KV budget ledger implausible (ledger {:.1} GB, used {:.1} \
-                 GB) — using raw used_so_far",
+                "KV budget: free_memory() looks wrong — the alloc ledger holds \
+                 {:.1} GB but the device implies only {:.1} GB used, and real \
+                 device usage can never be below the ledger. Charging the \
+                 ledger's {:.1} GB (the larger, safer figure) instead.",
                 gib(ledger_live),
+                gib(used_so_far),
+                gib(ledger_live),
+            );
+            used_so_far = ledger_live;
+        } else {
+            // ledger_live == 0: nothing ledgered yet (or a backend that does
+            // not ledger). Nothing better to charge than the raw figure.
+            tracing::warn!(
+                "KV budget: alloc ledger reports 0 GB live against {:.1} GB \
+                 used on the device — using raw used_so_far",
                 gib(used_so_far),
             );
         }

--- a/crates/spark-runtime/src/cuda_backend.rs
+++ b/crates/spark-runtime/src/cuda_backend.rs
@@ -285,15 +285,21 @@ impl Drop for AtlasCudaBackend {
 // Background task that polls GPU free memory every `interval` and calls
 // `std::process::exit(1)` if it drops below `threshold_bytes`.
 // On GB10 unified memory, GPU OOM = system OOM = kernel freeze, so
-// killing the process early prevents unrecoverable system hangs.
+// killing the process early prevents unrecoverable system hangs. On a
+// discrete card the process would merely OOM rather than take the machine
+// with it, but the watchdog still has to read a device-free figure that is
+// actually the device's — see `cuda_free_memory_bytes`.
 
 /// Query GPU free memory without requiring a GpuBackend reference.
 /// Safe to call from any thread that shares the CUDA context.
 ///
-/// On unified memory systems (GB10), `cuMemGetInfo` reports Linux's "free" memory
-/// which excludes reclaimable buff/cache. This under-reports available memory by
-/// 30-50%. We take the max of CUDA's report and `/proc/meminfo` MemAvailable
-/// to get the true available memory.
+/// Applies the same rule as `AtlasCudaBackend`'s `free_memory`: host
+/// `MemAvailable` stands in for the driver's figure ONLY on an INTEGRATED
+/// GPU (GB10 and friends), where `cuMemGetInfo` reports Linux MemFree and so
+/// omits reclaimable buff/cache. On a discrete card host RAM is a different
+/// pool and the substitution reports many times the card's capacity — which
+/// pinned the watchdog's reading near total host RAM, so it could never cross
+/// its threshold, and put the same fiction on the TUI's memory gauge.
 pub fn cuda_free_memory_bytes() -> Option<usize> {
     let mut free: usize = 0;
     let mut total: usize = 0;
@@ -301,13 +307,86 @@ pub fn cuda_free_memory_bytes() -> Option<usize> {
     if status != 0 {
         return None;
     }
+    Some(polled_free_bytes(
+        free,
+        system_available_memory_bytes(),
+        current_device_is_integrated(),
+    ))
+}
 
-    // On unified memory, also check MemAvailable from /proc/meminfo.
-    // This includes reclaimable buff/cache that CUDA doesn't account for.
-    if let Some(mem_available) = system_available_memory_bytes() {
-        free = free.max(mem_available);
+/// `CU_DEVICE_ATTRIBUTE_INTEGRATED` on the current context's device: true
+/// when the GPU shares the host's physical memory (GB10), false on a discrete
+/// card. Cheap enough to query per call — it is a driver-side table lookup,
+/// and free-memory queries are not on any hot path.
+///
+/// The caller must already have a current context, which every caller does:
+/// `cuMemGetInfo_v2` needs one too.
+///
+/// Fails loudly rather than guessing, like `sm_count_cu`: a wrong answer here
+/// mis-sizes the KV pool by hundreds of gigabytes in either direction. Only
+/// the poll path, which has no way to report an error, degrades to a guess —
+/// see `current_device_is_integrated`.
+///
+/// Measured 2026-09-04: attribute 18 reads 1 on NVIDIA GB10 and 0 on RTX PRO
+/// 6000 Blackwell (and 0 on every discrete datacenter part).
+/// `CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS` (99) reads 1 on BOTH, so it
+/// does NOT discriminate and must not be used here.
+pub(crate) fn device_is_integrated() -> Result<bool> {
+    const CU_DEVICE_ATTRIBUTE_INTEGRATED: u32 = 18;
+    let mut dev: i32 = 0;
+    let status = unsafe { cuCtxGetDevice(&mut dev) };
+    if status != 0 {
+        bail!("cuCtxGetDevice failed: status {status}");
     }
-    Some(free)
+    let mut integrated: i32 = 0;
+    let status =
+        unsafe { cuDeviceGetAttribute(&mut integrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, dev) };
+    if status != 0 {
+        bail!("cuDeviceGetAttribute(INTEGRATED) failed: status {status}");
+    }
+    Ok(integrated != 0)
+}
+
+/// [`device_is_integrated`] in the `Option` style `cuda_free_memory_bytes`
+/// uses: `None` when the driver would not answer. This path cannot `bail!`
+/// like `free_memory` does — its whole contract is `Option<usize>`, and the
+/// watchdog polls it in a loop where a hard error has nowhere to go.
+fn current_device_is_integrated() -> Option<bool> {
+    device_is_integrated().ok()
+}
+
+/// Free device memory to report from a poll, where the integrated/discrete
+/// answer may be missing.
+///
+/// `None` is treated as NOT integrated: substituting host RAM on a discrete
+/// card inflates the reading by orders of magnitude and disarms the watchdog,
+/// while declining to substitute on an integrated one merely under-reports by
+/// the reclaimable buff/cache — an early exit is recoverable, a watchdog that
+/// never fires is not. Never inflate device free memory on a guess.
+pub(crate) fn polled_free_bytes(
+    cu_free: usize,
+    mem_available: Option<usize>,
+    integrated: Option<bool>,
+) -> usize {
+    effective_free_bytes(cu_free, mem_available, integrated.unwrap_or(false))
+}
+
+/// Free device memory to report, given the driver's figure, host
+/// `MemAvailable`, and whether the device is integrated.
+///
+/// Host memory may stand in for device memory on an INTEGRATED GPU ONLY,
+/// where the two are one physical pool. On a discrete GPU they are unrelated,
+/// and substituting host RAM reports a free figure many times the card's
+/// capacity. Pure so the rule is testable without a GPU.
+pub(crate) fn effective_free_bytes(
+    cu_free: usize,
+    mem_available: Option<usize>,
+    integrated: bool,
+) -> usize {
+    match mem_available {
+        Some(avail) if integrated => cu_free.max(avail),
+        _ => cu_free,
+    }
 }
 
 /// Read MemAvailable from /proc/meminfo (Linux only).

--- a/crates/spark-runtime/src/cuda_backend/gpu_impl_graph.rs
+++ b/crates/spark-runtime/src/cuda_backend/gpu_impl_graph.rs
@@ -184,40 +184,13 @@ impl AtlasCudaBackend {
         // pool was sized as if nothing had been allocated — the load then died
         // in `cuMemAlloc_v2` with 4280.2 MB actually free.
         //
-        // `CU_DEVICE_ATTRIBUTE_INTEGRATED` (18) is the discriminator, measured
-        // 2026-09-04: 1 on NVIDIA GB10, 0 on RTX PRO 6000 Blackwell (and 0 on
-        // every discrete datacenter part).
-        // `CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS` (99) reads 1 on BOTH,
-        // so it does NOT discriminate and must not be used here.
-        Ok(effective_free_bytes(
+        // `super::device_is_integrated` documents the discriminator and the
+        // attribute that looks like it would work but does not.
+        Ok(super::effective_free_bytes(
             free,
             super::system_available_memory_bytes(),
-            self.device_is_integrated_cu()?,
+            super::device_is_integrated()?,
         ))
-    }
-
-    /// `CU_DEVICE_ATTRIBUTE_INTEGRATED` on the current context's device: true
-    /// when the GPU shares the host's physical memory (GB10), false on a
-    /// discrete card. Cheap enough to query per call — it is a driver-side
-    /// table lookup, and `free_memory` is not on any hot path.
-    ///
-    /// Fails loudly rather than guessing, like `sm_count_cu`: a wrong answer
-    /// here mis-sizes the KV pool by hundreds of gigabytes in either
-    /// direction.
-    pub(super) fn device_is_integrated_cu(&self) -> Result<bool> {
-        const CU_DEVICE_ATTRIBUTE_INTEGRATED: u32 = 18;
-        let mut dev: i32 = 0;
-        let status = unsafe { cuCtxGetDevice(&mut dev) };
-        if status != 0 {
-            bail!("cuCtxGetDevice failed: status {status}");
-        }
-        let mut integrated: i32 = 0;
-        let status =
-            unsafe { cuDeviceGetAttribute(&mut integrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, dev) };
-        if status != 0 {
-            bail!("cuDeviceGetAttribute(INTEGRATED) failed: status {status}");
-        }
-        Ok(integrated != 0)
     }
 
     pub(super) fn create_stream_cu(&self) -> Result<u64> {
@@ -328,69 +301,5 @@ impl AtlasCudaBackend {
             }
         }
         Ok(())
-    }
-}
-
-/// Free device memory to report, given the driver's figure, host
-/// `MemAvailable`, and whether the device is integrated.
-///
-/// Host memory may stand in for device memory on an INTEGRATED GPU ONLY,
-/// where the two are one physical pool. On a discrete GPU they are unrelated,
-/// and substituting host RAM reports a free figure many times the card's
-/// capacity. Pure so the rule is testable without a GPU.
-pub(super) fn effective_free_bytes(
-    cu_free: usize,
-    mem_available: Option<usize>,
-    integrated: bool,
-) -> usize {
-    match mem_available {
-        Some(avail) if integrated => cu_free.max(avail),
-        _ => cu_free,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::effective_free_bytes;
-
-    const GIB: usize = 1024 * 1024 * 1024;
-
-    #[test]
-    fn discrete_device_ignores_host_mem_available() {
-        // Reproduces the RTX PRO 6000 failure: 95 GiB card, 4.2 GiB actually
-        // free, host MemAvailable 1,038,438,936 kB (~990 GiB). Host RAM is a
-        // different pool; substituting it made free_memory() report ~990 GB
-        // and the KV pool was sized as if nothing had been allocated.
-        let cu_free = 4 * GIB + 280 * 1024 * 1024;
-        let mem_available = Some(1_038_438_936usize * 1024);
-        assert_eq!(
-            effective_free_bytes(cu_free, mem_available, false),
-            cu_free,
-            "a discrete GPU must report the driver's device-free figure verbatim"
-        );
-    }
-
-    #[test]
-    fn integrated_device_takes_the_max() {
-        // GB10 (DGX Spark): device and host share one LPDDR5X pool, and
-        // cuMemGetInfo reports MemFree, which excludes reclaimable buff/cache.
-        let cu_free = 20 * GIB;
-        let mem_available = Some(90 * GIB);
-        assert_eq!(effective_free_bytes(cu_free, mem_available, true), 90 * GIB);
-    }
-
-    #[test]
-    fn integrated_device_without_meminfo_uses_driver_figure() {
-        // /proc/meminfo missing or unparseable (non-Linux, container).
-        let cu_free = 20 * GIB;
-        assert_eq!(effective_free_bytes(cu_free, None, true), cu_free);
-    }
-
-    #[test]
-    fn integrated_device_keeps_driver_figure_when_it_is_larger() {
-        // MemAvailable can be the smaller of the two; `max` must not shrink
-        // the driver's figure.
-        let cu_free = 60 * GIB;
-        assert_eq!(effective_free_bytes(cu_free, Some(10 * GIB), true), cu_free);
     }
 }

--- a/crates/spark-runtime/src/cuda_backend/gpu_impl_graph.rs
+++ b/crates/spark-runtime/src/cuda_backend/gpu_impl_graph.rs
@@ -169,12 +169,55 @@ impl AtlasCudaBackend {
         if status != 0 {
             bail!("cuMemGetInfo_v2 failed: status {status}");
         }
-        // On unified memory (GB10), cuMemGetInfo reports Linux "free" memory
-        // which excludes reclaimable buff/cache. Use MemAvailable instead.
-        if let Some(mem_available) = super::system_available_memory_bytes() {
-            free = free.max(mem_available);
+        // RULE: host `MemAvailable` substitutes for the driver's device-free
+        // figure ONLY on an integrated GPU.
+        //
+        // On integrated memory (GB10 / DGX Spark, unified LPDDR5X) device and
+        // host share one physical pool and `cuMemGetInfo` reports Linux
+        // MemFree, which excludes reclaimable buff/cache — MemAvailable is the
+        // truer number, so taking the max is right there.
+        //
+        // On a DISCRETE GPU host RAM is a different pool entirely and the max
+        // is nonsense: on a 3x RTX PRO 6000 Blackwell box (95 GiB per card,
+        // 1 TB host RAM) MemAvailable read 1,038,438,936 kB, so this returned
+        // ~990 GB free for a 95 GB card, `used_so_far` came out 0, and the KV
+        // pool was sized as if nothing had been allocated — the load then died
+        // in `cuMemAlloc_v2` with 4280.2 MB actually free.
+        //
+        // `CU_DEVICE_ATTRIBUTE_INTEGRATED` (18) is the discriminator, measured
+        // 2026-09-04: 1 on NVIDIA GB10, 0 on RTX PRO 6000 Blackwell (and 0 on
+        // every discrete datacenter part).
+        // `CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS` (99) reads 1 on BOTH,
+        // so it does NOT discriminate and must not be used here.
+        Ok(effective_free_bytes(
+            free,
+            super::system_available_memory_bytes(),
+            self.device_is_integrated_cu()?,
+        ))
+    }
+
+    /// `CU_DEVICE_ATTRIBUTE_INTEGRATED` on the current context's device: true
+    /// when the GPU shares the host's physical memory (GB10), false on a
+    /// discrete card. Cheap enough to query per call — it is a driver-side
+    /// table lookup, and `free_memory` is not on any hot path.
+    ///
+    /// Fails loudly rather than guessing, like `sm_count_cu`: a wrong answer
+    /// here mis-sizes the KV pool by hundreds of gigabytes in either
+    /// direction.
+    pub(super) fn device_is_integrated_cu(&self) -> Result<bool> {
+        const CU_DEVICE_ATTRIBUTE_INTEGRATED: u32 = 18;
+        let mut dev: i32 = 0;
+        let status = unsafe { cuCtxGetDevice(&mut dev) };
+        if status != 0 {
+            bail!("cuCtxGetDevice failed: status {status}");
         }
-        Ok(free)
+        let mut integrated: i32 = 0;
+        let status =
+            unsafe { cuDeviceGetAttribute(&mut integrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, dev) };
+        if status != 0 {
+            bail!("cuDeviceGetAttribute(INTEGRATED) failed: status {status}");
+        }
+        Ok(integrated != 0)
     }
 
     pub(super) fn create_stream_cu(&self) -> Result<u64> {
@@ -285,5 +328,69 @@ impl AtlasCudaBackend {
             }
         }
         Ok(())
+    }
+}
+
+/// Free device memory to report, given the driver's figure, host
+/// `MemAvailable`, and whether the device is integrated.
+///
+/// Host memory may stand in for device memory on an INTEGRATED GPU ONLY,
+/// where the two are one physical pool. On a discrete GPU they are unrelated,
+/// and substituting host RAM reports a free figure many times the card's
+/// capacity. Pure so the rule is testable without a GPU.
+pub(super) fn effective_free_bytes(
+    cu_free: usize,
+    mem_available: Option<usize>,
+    integrated: bool,
+) -> usize {
+    match mem_available {
+        Some(avail) if integrated => cu_free.max(avail),
+        _ => cu_free,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_free_bytes;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn discrete_device_ignores_host_mem_available() {
+        // Reproduces the RTX PRO 6000 failure: 95 GiB card, 4.2 GiB actually
+        // free, host MemAvailable 1,038,438,936 kB (~990 GiB). Host RAM is a
+        // different pool; substituting it made free_memory() report ~990 GB
+        // and the KV pool was sized as if nothing had been allocated.
+        let cu_free = 4 * GIB + 280 * 1024 * 1024;
+        let mem_available = Some(1_038_438_936usize * 1024);
+        assert_eq!(
+            effective_free_bytes(cu_free, mem_available, false),
+            cu_free,
+            "a discrete GPU must report the driver's device-free figure verbatim"
+        );
+    }
+
+    #[test]
+    fn integrated_device_takes_the_max() {
+        // GB10 (DGX Spark): device and host share one LPDDR5X pool, and
+        // cuMemGetInfo reports MemFree, which excludes reclaimable buff/cache.
+        let cu_free = 20 * GIB;
+        let mem_available = Some(90 * GIB);
+        assert_eq!(effective_free_bytes(cu_free, mem_available, true), 90 * GIB);
+    }
+
+    #[test]
+    fn integrated_device_without_meminfo_uses_driver_figure() {
+        // /proc/meminfo missing or unparseable (non-Linux, container).
+        let cu_free = 20 * GIB;
+        assert_eq!(effective_free_bytes(cu_free, None, true), cu_free);
+    }
+
+    #[test]
+    fn integrated_device_keeps_driver_figure_when_it_is_larger() {
+        // MemAvailable can be the smaller of the two; `max` must not shrink
+        // the driver's figure.
+        let cu_free = 60 * GIB;
+        assert_eq!(effective_free_bytes(cu_free, Some(10 * GIB), true), cu_free);
     }
 }

--- a/crates/spark-runtime/src/cuda_backend/tests.rs
+++ b/crates/spark-runtime/src/cuda_backend/tests.rs
@@ -7,6 +7,7 @@ use std::ffi::c_void;
 
 use atlas_core::registry::RawCudaFunc;
 
+use super::{effective_free_bytes, polled_free_bytes};
 use crate::gpu::{DevicePtr, KernelHandle};
 
 #[test]
@@ -25,4 +26,87 @@ fn null_free_is_noop() {
     // Can't call without GPU, but verify the DevicePtr::is_null logic.
     assert!(DevicePtr::NULL.is_null());
     assert!(!DevicePtr(0x1000).is_null());
+}
+
+// ── free-memory reporting rule ──────────────────────────────────────
+//
+// `effective_free_bytes` and `polled_free_bytes` are pure, so the rule that
+// decides whether host `MemAvailable` may stand in for device free memory is
+// tested here without a GPU or a CUDA context.
+
+const GIB: usize = 1024 * 1024 * 1024;
+
+/// The RTX PRO 6000 numbers this bug was found on: a 95 GiB card with 4.2 GiB
+/// actually free, on a host reporting MemAvailable 1,038,438,936 kB (~990 GiB).
+const DISCRETE_CU_FREE: usize = 4 * GIB + 280 * 1024 * 1024;
+const HUGE_HOST_MEM_AVAILABLE: usize = 1_038_438_936 * 1024;
+
+#[test]
+fn discrete_device_ignores_host_mem_available() {
+    // Host RAM is a different pool; substituting it made free_memory() report
+    // ~990 GB and the KV pool was sized as if nothing had been allocated.
+    assert_eq!(
+        effective_free_bytes(DISCRETE_CU_FREE, Some(HUGE_HOST_MEM_AVAILABLE), false),
+        DISCRETE_CU_FREE,
+        "a discrete GPU must report the driver's device-free figure verbatim"
+    );
+}
+
+#[test]
+fn integrated_device_takes_the_max() {
+    // GB10 (DGX Spark): device and host share one LPDDR5X pool, and
+    // cuMemGetInfo reports MemFree, which excludes reclaimable buff/cache.
+    assert_eq!(
+        effective_free_bytes(20 * GIB, Some(90 * GIB), true),
+        90 * GIB
+    );
+}
+
+#[test]
+fn integrated_device_without_meminfo_uses_driver_figure() {
+    // /proc/meminfo missing or unparseable (non-Linux, container).
+    assert_eq!(effective_free_bytes(20 * GIB, None, true), 20 * GIB);
+}
+
+#[test]
+fn integrated_device_keeps_driver_figure_when_it_is_larger() {
+    // MemAvailable can be the smaller of the two; `max` must not shrink the
+    // driver's figure.
+    assert_eq!(
+        effective_free_bytes(60 * GIB, Some(10 * GIB), true),
+        60 * GIB
+    );
+}
+
+#[test]
+fn watchdog_poll_on_a_discrete_device_reports_device_memory() {
+    // What the OOM watchdog and the TUI gauge see. Before the integrated-only
+    // rule reached this path, the poll returned ~990 GB on a 95 GB card, so
+    // `free < threshold_bytes` was false forever and the watchdog could not
+    // fire however close the device came to OOM.
+    assert_eq!(
+        polled_free_bytes(DISCRETE_CU_FREE, Some(HUGE_HOST_MEM_AVAILABLE), Some(false)),
+        DISCRETE_CU_FREE
+    );
+}
+
+#[test]
+fn watchdog_poll_with_unknown_integration_is_treated_as_discrete() {
+    // `None` = the driver would not say (cuCtxGetDevice or cuDeviceGetAttribute
+    // failed). Guessing "integrated" would inflate the reading and disarm the
+    // watchdog; guessing "discrete" only under-reports by the reclaimable
+    // buff/cache on a machine where the max would have been right.
+    assert_eq!(
+        polled_free_bytes(DISCRETE_CU_FREE, Some(HUGE_HOST_MEM_AVAILABLE), None),
+        DISCRETE_CU_FREE,
+        "an unknown integrated/discrete answer must never inflate device free memory"
+    );
+}
+
+#[test]
+fn watchdog_poll_on_an_integrated_device_still_takes_the_max() {
+    assert_eq!(
+        polled_free_bytes(20 * GIB, Some(90 * GIB), Some(true)),
+        90 * GIB
+    );
 }


### PR DESCRIPTION
## Bug

`free_memory_cu()` (backend) and `cuda_free_memory_bytes()` (OOM watchdog and TUI gauge) both computed device free memory as `max(cuMemGetInfo free, host /proc/meminfo MemAvailable)`. That is right on GB10, where GPU memory *is* host memory and `cuMemGetInfo` under-reports reclaimable cache. On any discrete GPU it is wrong: host RAM is unrelated to the card.

Reproduced on an x86_64 box with 3× RTX PRO 6000 Blackwell (95 GiB each), 1 TB host RAM, driver 595.71, CUDA 13.0, serving Nemotron-3-Nano NVFP4 with default flags:

```
KV budget ledger implausible (ledger 35.8 GB, used 0.0 GB) — using raw used_so_far
KV cache: 95.0 GB total × 90% util = 85.5 GB budget; 0.0 GB pre-KV + 4.6 GB reserve → 80.8 GB for KV
Error: Failed to build model
Caused by: cuMemAlloc_v2 failed: status 2, requested 4683632640 bytes (device reports 4280.2 MB free / 95.0 GB total)
```

`free_memory()` returned ~990 GB for a 95 GB card, so `used_so_far = total − free` was 0, the ledger sanity gate rejected the correct 35.8 GB, and the KV pool was sized as if no weights were resident. Same failure at `--gpu-memory-utilization 0.6`. Every H100/H200/B200 deployment would hit this. The watchdog half means the OOM watchdog can never trip on a discrete GPU, and the TUI memory gauge shows host RAM.

## Fix

Substitute MemAvailable only when the device reports `CU_DEVICE_ATTRIBUTE_INTEGRATED` (18) = 1. Measured: **1 on GB10** (DGX Spark), **0 on RTX PRO 6000**. (`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS` is 1 on both, so it is not a usable discriminator.)

- Commit 1: pure `effective_free_bytes(cu_free, mem_available, integrated)` used by `free_memory_cu()`; `device_is_integrated()` via `cuCtxGetDevice` + `cuDeviceGetAttribute`, failing loudly on driver error. The `build.rs` KV-budget ledger gate now distinguishes "ledger larger than device-implied usage" (which means `free_memory()` lied; charge the ledger, the safer figure) from "ledger empty", and says which.
- Commit 2: the watchdog poll uses the same helper through `polled_free_bytes`, where an unanswerable integrated query (`None`) is treated as **discrete**: an early watchdog exit is recoverable, a watchdog that never fires is not. Doc comments rewritten to state the rule.

Red-first unit tests for both (discrete ignores host memory; integrated takes the max; `None` never inflates). Verified on the card after the fix, default flags:

```
KV budget self-relative (ledger): Atlas-own 35.8 GB live in the alloc ledger; 20.0 GB of co-tenant/page-cache use excluded
KV cache: 95.0 GB total × 90% util = 85.5 GB budget; 35.8 GB pre-KV + 4.6 GB reserve → 34.4 GB for KV
kernel check PASSED for (nemotron-3-nano-30b-a3b, sm_120, nvfp4): 156 lookups, 9 expected-absent
```

## Gates

`cargo test -p spark-runtime -p spark-model -p spark-server` (GPU-free, `ATLAS_SKIP_BUILD=1 CUDARC_CUDA_VERSION=13000`): spark-runtime 284/284, spark-model all pass, spark-server lib 104/104; `--bin spark` has 3 failures (`bench_selfstart` pin test, two `tui::bench_variants` tests) that reproduce identically on unmodified `main`, so they are pre-existing and unrelated. clippy `-D warnings`, fmt, rustdoc `-D warnings`, typos all clean. Files stay under the 500-line cap.

Not GB10-visible: on GB10 `INTEGRATED` is 1, so both code paths behave exactly as before. The same first commit is also on #895 (c4c1b562) and will drop out of that branch on rebase once this merges.