### PR TITLE
fix(bfcl): pin soundfile — the scorer could not import from a clean provision

### DIFF
--- a/crates/atlas-plugin/assets/bfcl/requirements.txt
+++ b/crates/atlas-plugin/assets/bfcl/requirements.txt
@@ -7,3 +7,13 @@
 #
 # bfcl-eval carries both the AST checker and the BFCL v4 data files.
 bfcl-eval==2026.3.23
+#
+# soundfile is a TRANSITIVE import that bfcl-eval does not declare:
+# bfcl-eval -> qwen_agent, and qwen_agent/utils/utils.py does a bare
+# `import soundfile as sf` at module scope. Without it the venv provisions
+# "successfully" and the SCORER then fails to import -- which, from a clean
+# provision, made the BFCL gate unrunnable. Observed 2026-09-05 on gb10:
+#   ModuleNotFoundError: No module named 'soundfile'
+# Pinned like everything else here: a scorer dependency that floats can move
+# the score between runs and silently invalidate stored baselines.
+soundfile==0.14.0


### PR DESCRIPTION
## What broke

`bfcl-eval` pulls `qwen_agent`, whose `utils/utils.py` does a bare module-scope `import soundfile as sf`. Neither package declares `soundfile`, so the venv provisions **"successfully"** and the scorer then fails:

```
ModuleNotFoundError: No module named 'soundfile'
```

**From a clean provision the BFCL gate was unrunnable.** Hit live on gb10 while certifying `stack/certified-2026-09-04` (PR #877).

## What worked

#777's *"prove the scorer imports before generating 995 responses"* caught this **at provisioning** rather than after ~1.6 GPU-hours of generation, and its error names the remedy. That fix did its job in production today; this PR removes the cause it detected.

## Verification

```
$ venv/bin/python score.py --selftest          # before
ModuleNotFoundError: No module named 'soundfile'

$ venv/bin/pip install soundfile
$ venv/bin/python score.py --selftest          # after
rc=0
```

Pinned (`soundfile==0.14.0`) rather than floated, consistent with the rest of the file: a scorer dependency that moves can move the score with it and silently invalidate every stored baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
