### PR TITLE
ci: build the metal kernel set in the metal test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,14 @@ jobs:
       # run on a developer machine; default `cargo test` skips them.
       - name: cargo test -p spark-runtime --features metal
         env:
+          # The workflow-wide ATLAS_SKIP_BUILD=1 stubs atlas-kernels' build
+          # script, so `metallib_modules()` is EMPTY and every parity test
+          # fails with `Metal: unknown module '...'`. That never showed on
+          # GitHub-hosted macOS runners because MTLCreateSystemDefaultDevice
+          # returns null there and the tests skip themselves; on a real Mac
+          # (the self-hosted M5) they run and go red. This step is the one
+          # place the metal kernel set must actually be built.
+          ATLAS_SKIP_BUILD: "0"
           ATLAS_TARGET_HW: metal
           ATLAS_TARGET_MODEL: qwen3-5-4b-vlm-mlx-int8
           ATLAS_TARGET_QUANT: mlx_int8


### PR DESCRIPTION
`cargo test --features metal (macOS aarch64)` is red on `main` (run 33974555722) and on #895 with `Metal: unknown module 'rms_norm'` (and every other module) across the `metal_backend` parity tests.

**Cause:** the workflow-wide `ATLAS_SKIP_BUILD: "1"` applies to the metal test step too, so `atlas-kernels`' build script emits its stub and `metallib_modules()` returns an empty list. The lane has looked green because GitHub-hosted macOS runners return null from `MTLCreateSystemDefaultDevice` and `maybe_backend()` skips every test. Today the job ran on a real Mac (self-hosted `Toms-M5-Max-Avarok`), the tests executed for the first time, and the empty module set surfaced.

**Fix:** `ATLAS_SKIP_BUILD: "0"` on that one step, with a comment explaining why. Nothing else changes; the CPU-only lanes keep the stub.

**Red first, same machine:**
```
ATLAS_SKIP_BUILD=1 ATLAS_TARGET_HW=metal ATLAS_TARGET_MODEL=qwen3-5-4b-vlm-mlx-int8 ATLAS_TARGET_QUANT=mlx_int8 \
  cargo test -p spark-runtime --no-default-features --features metal --locked metal_backend
  -> Metal: unknown module 'kv_cache_append_turbo4' ... (the CI failure)
ATLAS_SKIP_BUILD=0 ...same...
  -> test result: ok. 35 passed; 0 failed; 5 ignored
```
Full crate with the fixed env: 303 passed, 0 failed.

Not in scope: whether the parity tests should fail loudly instead of skipping when no Metal device exists (a vacuous-green lane is its own problem), and why a `runs-on: macos-14` job was scheduled onto a self-hosted runner.