### PR TITLE
ci: the Metal lane has never tested Metal — build the kernel set, keep the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,24 +374,12 @@ jobs:
     # suppresses the implicit success() on `needs` — so this job RUNS. Written
     # as `== 'false'` it would fail CLOSED and silently un-gate Rust changes.
     if: ${{ !cancelled() && needs.changes.outputs.web_only != 'true' }}
-    # TEMPORARY: routed back to hosted macOS. #901 moved this to the
-    # self-hosted `apple-48gb-metal`, and that runner's job-started hook path
-    # is unquoted -- it contains a space:
-    #
-    #   /bin/bash: /Users/nologik/Library/Application: No such file or directory
-    #   ##[error]Process completed with exit code 1
-    #
-    # The hook is `/Users/nologik/Library/Application Support/MacCIBurst/bin/
-    # pre-job-disk-guard.sh`, so bash splits it at "Application Support" and
-    # the job dies ~2s in, BEFORE checkout -- every job, every PR. This is a
-    # REQUIRED context, so it made the merge queue impassable for any diff that
-    # is not web-only (observed on #905 and #906, 2026-09-05).
-    #
-    # Restore `[self-hosted, macOS, ARM64]` as soon as the runner's
-    # ACTIONS_RUNNER_HOOK_JOB_STARTED value is quoted (or the directory moved
-    # somewhere without a space). The routing itself is fine; only the host's
-    # hook configuration is broken, and that cannot be fixed from this repo.
-    runs-on: macos-14
+    # Self-hosted Apple Silicon. #901 moved this here; #909 briefly routed it
+    # back to hosted macOS because the runner's job-started hook path was
+    # unquoted and every job died ~2s in, before checkout. That hook is now
+    # fixed at the host (the script lives at a space-free path and the runner
+    # service was restarted), and jobs reach the test step again.
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -417,6 +405,19 @@ jobs:
       # run on a developer machine; default `cargo test` skips them.
       - name: cargo test -p spark-runtime --features metal
         env:
+          # The workflow-wide ATLAS_SKIP_BUILD=1 exists so clippy/check can run
+          # on hosts without nvcc. Inherited here it made this job a no-op: the
+          # skip path emits `metallib_modules() -> Vec::new()`, so the parity
+          # tests looked up kernels in an EMPTY registry. On hosted macOS there
+          # is no Metal device, `maybe_backend()` returned None, all 35 tests
+          # returned early and reported ok in 0.07s — green while testing
+          # nothing, for as long as this job has existed. On the self-hosted
+          # box a device DOES exist, so the same tests reached the lookup and
+          # failed with `Metal: unknown module 'noop_smoke'`. That failure is
+          # the runner working correctly: it is the first environment that
+          # could ever have caught this. Overriding to 0 makes ATLAS_TARGET_HW
+          # below drive the real xcrun -> AIR -> metallib pipeline.
+          ATLAS_SKIP_BUILD: "0"
           ATLAS_TARGET_HW: metal
           ATLAS_TARGET_MODEL: qwen3-5-4b-vlm-mlx-int8
           ATLAS_TARGET_QUANT: mlx_int8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,24 @@ jobs:
     # suppresses the implicit success() on `needs` — so this job RUNS. Written
     # as `== 'false'` it would fail CLOSED and silently un-gate Rust changes.
     if: ${{ !cancelled() && needs.changes.outputs.web_only != 'true' }}
-    runs-on: [self-hosted, macOS, ARM64]
+    # TEMPORARY: routed back to hosted macOS. #901 moved this to the
+    # self-hosted `apple-48gb-metal`, and that runner's job-started hook path
+    # is unquoted -- it contains a space:
+    #
+    #   /bin/bash: /Users/nologik/Library/Application: No such file or directory
+    #   ##[error]Process completed with exit code 1
+    #
+    # The hook is `/Users/nologik/Library/Application Support/MacCIBurst/bin/
+    # pre-job-disk-guard.sh`, so bash splits it at "Application Support" and
+    # the job dies ~2s in, BEFORE checkout -- every job, every PR. This is a
+    # REQUIRED context, so it made the merge queue impassable for any diff that
+    # is not web-only (observed on #905 and #906, 2026-09-05).
+    #
+    # Restore `[self-hosted, macOS, ARM64]` as soon as the runner's
+    # ACTIONS_RUNNER_HOOK_JOB_STARTED value is quoted (or the directory moved
+    # somewhere without a space). The routing itself is fine; only the host's
+    # hook configuration is broken, and that cannot be fixed from this repo.
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable


### PR DESCRIPTION
## Reversing this PR's direction — the hosted-macOS green was measuring nothing

This PR was opened to route the Metal lane back to `macos-14` because the self-hosted runner's job-started hook path was unquoted and every job died ~2 s in, before checkout. **That hook is now fixed at the host** (the guard script lives at a space-free path, `.env` repointed, runner service restarted). Jobs reach the test step again.

And the first thing they did was fail — 35 of 35, in 0.06 s:

```
called `Result::unwrap()` on an `Err` value: Metal: unknown module 'kv_cache_append'
kernel lookup: Metal: unknown module 'noop_smoke'
test result: FAILED. 0 passed; 35 failed; 5 ignored; 0 measured; 270 filtered out; finished in 0.06s
```

**That failure is the runner working correctly.** It is the first environment that could ever have caught this, and merging this PR as originally written would have buried it again.

### What the two lanes actually do

| | hosted `macos-14` | self-hosted `apple-48gb-metal` |
|---|---|---|
| Metal device present | no | **yes** |
| `maybe_backend()` | `Err` → `None` | `Ok` → `Some` |
| Every test body | `let Some(backend) = … else { return }` → **returns immediately** | reaches the kernel lookup |
| Result | `35 passed` in **0.07 s** | `35 failed` in 0.06 s |

The hosted lane has reported green for as long as this job has existed, having executed no Metal work at all. This is the same class [#908](https://github.com/Avarok-Cybersecurity/atlas/pull/908) exists to eliminate — a check that reports success without checking.

### Root cause, end to end

1. `ci.yml` sets `ATLAS_SKIP_BUILD: "1"` **workflow-wide** so clippy/check can run on hosts without nvcc.
2. `crates/atlas-kernels/build.rs:172` short-circuits on that and writes a stub — `pub fn metallib_modules() -> Vec<(&'static str, &'static [u8])> { Vec::new() }`.
3. `ATLAS_TARGET_HW: metal` on the test step does **not** override the skip, so the parity tests look up kernels in an empty registry.
4. On a runner with no device that is invisible; on one with a device it is fatal.

The step's own comment already claimed it would *"Build the metal kernel set"*. The inherited env defeated it — the prose and the behaviour had drifted apart.

### The fix pushed here

- `runs-on:` restored to `[self-hosted, macOS, ARM64]`.
- `ATLAS_SKIP_BUILD: "0"` on the metal test step, so `ATLAS_TARGET_HW` drives the real `xcrun → AIR → metallib` pipeline. That path is implemented (`build_target.rs`, `HARDWARE.toml` `vendor = "apple"`, `arch = "metal3.1"`) and 43 `.metal` sources under `kernels/metal/` feed it.

### Deliberately not fixed here

`maybe_backend()` returning `None` is still a silent pass, so a runner that loses its device would go quietly green again. Closing that hole edits `crates/`, a `PERF_PATH` owing a ~5 GPU-hour campaign — it is queued for the next stack rather than spending a campaign on a one-line guard.

### One correction to my earlier comment on this PR

I previously wrote that the Apple build path was unimplemented, citing a stale `build.rs` comment. That was wrong and I retracted it. I re-checked before writing this one: `metallib_modules()` **is** emitted for real by `build_codegen.rs:103` on the non-skip path. `ATLAS_SKIP_BUILD` is the whole cause.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
