### PR TITLE
stack/nightly-honesty: 10 fixes where the system was more confident than its evidence

### DIFF
--- a/.github/scripts/assert-gates-are-wired.py
+++ b/.github/scripts/assert-gates-are-wired.py
@@ -60,7 +60,172 @@ GATES = [
     },
 ]
 
+# ---------------------------------------------------------------------------
+# Every required context on `main`, and the job that produces it.
+# ---------------------------------------------------------------------------
+# Pulled from
+#   gh api repos/.../branches/main/protection --jq '.required_status_checks.contexts[]'
+# Branch protection names a STRING. Nothing in the tree makes that string
+# resolve to a job, so a rename, a delete or a move retires a required check
+# silently -- the job keeps passing under its new name and protection keeps
+# waiting for the old one, or (worse) an admin removes the stale entry and the
+# gate is simply gone. Listing them here turns each into a tree-checkable fact.
+#
+# `nested` names a reusable-workflow job: the context is then
+# "<caller job name> / <called job name>", and BOTH halves have to hold.
+REQUIRED_CONTEXTS = [
+    ("cargo fmt --check", "ci.yml", "fmt", None),
+    ("cargo clippy --tests", "ci.yml", "clippy", None),
+    ("cargo test --workspace", "ci.yml", "test", None),
+    ("typos", "ci.yml", "typos", None),
+    ("SPDX license headers", "ci.yml", "license-headers", None),
+    ("kernel shadow structure", "ci.yml", "kernel-structure", None),
+    ("cargo test --features metal (macOS aarch64)", "ci.yml", "test-macos-metal", None),
+    ("PR benchmark gate", "ci.yml", "pr-benchmark-gate-alias", None),
+    ("release matrix / dry-run summary", "ci.yml", "release-matrix",
+     ("release-build.yml", "dry-run-summary")),
+    ("Enforce \u2264500 LoC per source file", "file-size-cap.yml", "check-file-sizes", None),
+    ("cargo deny", "security.yml", "cargo-deny", None),
+    ("cargo llvm-cov --workspace", "coverage.yml", "coverage", None),
+    ("Build mdBook + rustdoc", "docs.yml", "build", None),
+    ("nvcc -> PTX (all gb10 targets)", "kernel-compile.yml", "compile", None),
+    ("Verify committed GDN binaries match PINS.sha256", "gdn-so-pin.yml", "verify-gdn-so-pins", None),
+    ("No block_on under tui/ or recipe/", "tui-threading.yml", "no-blocking-on-the-render-thread", None),
+    ("Build SvelteKit site", "site.yml", "build", None),
+    ("Site unit tests", "site.yml", "unit", None),
+    ("Merge-ancestry guard self-test", "merge-ancestry.yml", "self-test", None),
+    ("CLAAssistant", "cla.yml", "CLAAssistant", None),
+]
+
+# An `if:` that names one of these suppresses the implicit `success()` that
+# `needs:` otherwise carries, so the job still RUNS when a dependency failed.
+STATUS_FUNCTIONS = ("always()", "cancelled()", "failure()", "success()")
+
 problems: list[str] = []
+
+
+def _doc(workflow: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / workflow).read_text())
+
+
+def check_required_context(entry: tuple) -> None:
+    """A required context must be PRODUCIBLE and must not be skippable by a
+    dependency's failure.
+
+    Two distinct ways a required check reaches a verdict that is not about the
+    thing it claims to test:
+
+      * it is gone or renamed -- protection waits on a string no job emits, and
+        the PR hangs on "Expected" forever;
+
+      * it carries `needs:` without a status function in its `if:`, so a FAILED
+        dependency skips it -- and branch protection counts a skipped check as
+        satisfied. The gate then reports safety it never measured. ci.yml's
+        clippy/test and coverage.yml spell this correctly and say why in a
+        comment; docs.yml's `build` did not, and a broken classify-diff.sh
+        would have waved every PR past the docs gate.
+    """
+    context, workflow, job_id, nested = entry
+    jobs = _doc(workflow).get("jobs") or {}
+    if job_id not in jobs:
+        problems.append(
+            f"{workflow} has no `{job_id}` job, but branch protection requires "
+            f"{context!r}; nothing would ever report it and every PR would hang"
+        )
+        return
+    job = jobs[job_id]
+
+    want = context.split(" / ")[0] if nested else context
+    got = job.get("name") or job_id
+    if got != want:
+        problems.append(
+            f"{workflow} `{job_id}` reports as {got!r}, but branch protection "
+            f"requires {context!r}; a renamed job leaves the required context uncreated"
+        )
+
+    cond = str(job.get("if") or "")
+    if job.get("needs") and not any(f in cond for f in STATUS_FUNCTIONS):
+        problems.append(
+            f"{workflow} `{job_id}` has `needs:` but no status function in its "
+            f"`if:` ({cond or 'no if:'}); a FAILED dependency would skip it, and a "
+            f"skipped required check counts as satisfied -- {context!r} would pass vacuously"
+        )
+
+    if nested:
+        sub_wf, sub_job = nested
+        if str(job.get("uses") or "") != f"./.github/workflows/{sub_wf}":
+            problems.append(
+                f"{workflow} `{job_id}` no longer calls {sub_wf}; the nested required "
+                f"context {context!r} would never be created"
+            )
+        sub_jobs = _doc(sub_wf).get("jobs") or {}
+        if sub_job not in sub_jobs:
+            problems.append(f"{sub_wf} has no `{sub_job}` job; {context!r} cannot be reported")
+            return
+        sub_name = sub_jobs[sub_job].get("name") or sub_job
+        if sub_name != context.split(" / ")[1]:
+            problems.append(
+                f"{sub_wf} `{sub_job}` reports as {sub_name!r}; {context!r} would never be created"
+            )
+
+
+# ---------------------------------------------------------------------------
+# A gate must not disable the thing it is gating.
+# ---------------------------------------------------------------------------
+# `cargo test --features metal (macOS aarch64)` inherited ci.yml's
+# workflow-level `ATLAS_SKIP_BUILD: "1"` -- which exists so the ubuntu jobs can
+# type-check without nvcc. atlas-kernels' build.rs honours it before anything
+# else and emits a stub whose `metallib_modules()` is `Vec::new()`, so
+# `MetalGpuBackend::new` built an EMPTY library cache and all 35 parity tests
+# died with `Metal: unknown module`. The required check was red about the stub,
+# never about the kernels, and the merge queue was impassable for every non-web
+# PR. Neither verdict it could produce was about Metal.
+#
+# The truthiness set is build.rs's own: `Ok("1") | Ok("true")`.
+SKIP_TRUTHY = {"1", "true"}
+STUB_FREE_STEPS = [
+    {
+        "workflow": "ci.yml",
+        "job": "test-macos-metal",
+        "step": "cargo test -p spark-runtime --features metal",
+        "var": "ATLAS_SKIP_BUILD",
+        "also": {"ATLAS_TARGET_HW": "metal"},
+    },
+]
+
+
+def check_stub_free(spec: dict) -> None:
+    doc = _doc(spec["workflow"])
+    job = (doc.get("jobs") or {}).get(spec["job"])
+    if job is None:
+        problems.append(f"{spec['workflow']} has no `{spec['job']}` job to check for a stub build")
+        return
+    steps = [s for s in (job.get("steps") or []) if s.get("name") == spec["step"]]
+    if len(steps) != 1:
+        problems.append(
+            f"{spec['workflow']} `{spec['job']}` has {len(steps)} steps named "
+            f"{spec['step']!r}; this guard is pinned to exactly one"
+        )
+        return
+    # Workflow env -> job env -> step env, in that precedence order.
+    env = {}
+    for scope in (doc.get("env") or {}, job.get("env") or {}, steps[0].get("env") or {}):
+        env.update({k: str(v) for k, v in scope.items()})
+    var = spec["var"]
+    if env.get(var) in SKIP_TRUTHY:
+        problems.append(
+            f"{spec['workflow']} `{spec['job']}` runs {spec['step']!r} with {var}="
+            f"{env[var]!r}, so atlas-kernels emits a stub and `metallib_modules()` is "
+            f"empty; the suite can only report `Metal: unknown module` and its verdict "
+            f"is about the stub, not the kernels"
+        )
+    for k, v in spec["also"].items():
+        if env.get(k) != v:
+            problems.append(
+                f"{spec['workflow']} `{spec['job']}` runs {spec['step']!r} with "
+                f"{k}={env.get(k)!r}, want {v!r}; without it build.rs takes the macOS "
+                f"auto-skip and embeds no kernels"
+            )
 
 
 def check(gate: dict) -> None:
@@ -107,6 +272,10 @@ def check(gate: dict) -> None:
 def main() -> None:
     for gate in GATES:
         check(gate)
+    for entry in REQUIRED_CONTEXTS:
+        check_required_context(entry)
+    for spec in STUB_FREE_STEPS:
+        check_stub_free(spec)
     if problems:
         for p in problems:
             print(f"REFUSE: {p}", file=sys.stderr)
@@ -114,6 +283,10 @@ def main() -> None:
     for gate in GATES:
         via = f"needed by `{gate['needed_by']}`, " if gate["needed_by"] else ""
         print(f"ok: {gate['reports_as']} ({gate['workflow']}) {via}reports unconditionally in PRs and the queue")
+    print(f"ok: all {len(REQUIRED_CONTEXTS)} required contexts resolve to a live job, "
+          f"and none can be skipped by a dependency's failure")
+    for spec in STUB_FREE_STEPS:
+        print(f"ok: {spec['workflow']} `{spec['job']}` runs {spec['step']!r} against real kernels, not a build stub")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -969,6 +969,91 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# The PR classifier must never run on a diff that could not be computed
+# ---------------------------------------------------------------------------
+# `pr-categorize` builds the model's context from the changed paths, and the
+# ★ note on that step records why: when the paths were computed and never
+# read, "the classifier's entire input was attacker-authored prose -- titling
+# a decode-kernel PR 'docs: tidy a comment' was a complete bypass".
+#
+# The collection step reopened that bypass from the other end. `git diff ... >
+# changed.txt || true` truncates the file BEFORE git runs, so a failed diff
+# leaves it empty and the prompt reads "Changed paths (0 total)" -- a PR that
+# changes nothing, classified from its title and body, with the model's answer
+# appended to the journey ledger as evidence. The deterministic fallback
+# abstains too (`all_match` needs total > 0), so nothing catches it.
+echo "== the pr classifier refuses an uncomputable diff =="
+python3 - > "$TMP/diffstep.sh" <<'DFPY'
+import yaml, pathlib
+d = yaml.safe_load(pathlib.Path(".github/workflows/ci.yml").read_text())
+for st in d["jobs"]["pr-categorize"]["steps"]:
+    if st.get("name") == "Collect the changed paths":
+        print(st["run"]); break
+DFPY
+if [ -s "$TMP/diffstep.sh" ]; then
+  mkdir -p "$TMP/gbin" "$TMP/grun"
+  cat > "$TMP/gbin/git" <<'GITSTUB'
+#!/usr/bin/env bash
+# `diff` answers per GIT_STUB_MODE; anything else is not this step's business.
+case "$1" in
+  diff)
+    case "${GIT_STUB_MODE:-ok}" in
+      # The real failure: a base sha that is no longer reachable. git writes
+      # nothing to stdout, so the redirect leaves an empty file behind.
+      fail) echo "fatal: bad object $2" >&2; exit 128 ;;
+      *)    printf 'kernels/gb10/x.cu\ncrates/spark-server/src/lib.rs\n' ;;
+    esac ;;
+  *) exit 0 ;;
+esac
+GITSTUB
+  chmod +x "$TMP/gbin/git"
+  df_run() {  # $1 = step script, $2 = stub mode -> rc; step outputs in $TMP/gout
+    : > "$TMP/gout"
+    ( cd "$TMP/grun" && rm -f changed.txt histogram.txt sorted.txt paths.txt
+      PATH="$TMP/gbin:$PATH" GITHUB_OUTPUT="$TMP/gout" GIT_STUB_MODE="$2" \
+        BASE_SHA=aaaaaaa HEAD_SHA=bbbbbbb bash "$1" >"$TMP/gerr" 2>&1 )
+  }
+  df_run "$TMP/diffstep.sh" ok
+  if [ $? -eq 0 ] && grep -q '^count=2$' "$TMP/gout"; then
+    ok "a diff that CAN be computed is emitted with its real count"
+  else
+    bad "the step no longer works on a readable diff"
+    sed 's/^/       /' "$TMP/gerr" | head -3
+  fi
+  df_run "$TMP/diffstep.sh" fail
+  drc=$?
+  if [ "$drc" -ne 0 ]; then
+    ok "a diff that cannot be computed fails the step"
+  else
+    bad "a failed git diff was recorded as a PR that changes nothing ($(grep -m1 '^count=' "$TMP/gout"))"
+  fi
+  # The reason has to reach the run, not just the exit code: this job is
+  # advisory, so a bare non-zero with no annotation is a red X nobody can act
+  # on -- which is how it gets rerun-until-green instead of fixed.
+  if grep -q '::error title=Changed paths unavailable' "$TMP/gerr"; then
+    ok "the failure names itself in the run's annotations"
+  else
+    bad "the step failed silently; no annotation says why"
+  fi
+  # CONTROL: put the `|| true` back and watch the failure become "0 paths".
+  sed 's|^\( *\)if ! git diff --name-only "\$BASE_SHA" "\$HEAD_SHA" > changed.txt; then|\1git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed.txt \|\| true\n\1if false; then|' \
+    "$TMP/diffstep.sh" > "$TMP/diffstep-bad.sh"
+  if cmp -s "$TMP/diffstep.sh" "$TMP/diffstep-bad.sh"; then
+    bad "control: the sabotage did not change the step -- it would measure nothing"
+  else
+    df_run "$TMP/diffstep-bad.sh" fail
+    if [ $? -eq 0 ] && grep -q '^count=0$' "$TMP/gout"; then
+      ok "control: with '|| true' restored, a failed diff emits count=0"
+    else
+      bad "control: the sabotage did not reproduce the fail-open defect"
+      sed 's/^/       /' "$TMP/gerr" | head -3
+    fi
+  fi
+else
+  bad "could not extract the changed-paths step"
+fi
+
+# ---------------------------------------------------------------------------
 # nginx add_header does not accumulate across contexts
 # ---------------------------------------------------------------------------
 # Three vhosts, one rule, three separate incidents -- each found by hand after

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -1054,6 +1054,103 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# The unsigned-record guard must not pass on a diff it could not read
+# ---------------------------------------------------------------------------
+# "One PR, one commit, one signer" is the check that stops a PR adding an
+# UNSIGNED benchmark record -- the ci.yml comment beside it records the
+# experiment: an unsigned record dated 1700000000 claiming 999 tok/s passes
+# the Rust gate, so this shell step is the thing standing in its way.
+#
+# Its entire input was `mapfile -t added < <(git diff ... | grep ...)`, and a
+# process substitution's exit status is invisible to `set -euo pipefail`. A
+# failed enumeration therefore produced an empty array, and empty is the one
+# value this guard reads as "nothing to check": it printed "this PR adds no
+# records" and exited 0, waving through every unsigned record, every
+# cross-commit set and every second signer at once.
+echo "== the unsigned-record guard reads its own input =="
+python3 - > "$TMP/signer.sh" <<'SGPY'
+import yaml, pathlib
+d = yaml.safe_load(pathlib.Path(".github/workflows/ci.yml").read_text())
+for st in d["jobs"]["pr-benchmark-gate"]["steps"]:
+    if st.get("name") == "One PR, one commit, one signer":
+        print(st["run"]); break
+SGPY
+if [ -s "$TMP/signer.sh" ]; then
+  mkdir -p "$TMP/sgbin" "$TMP/sgrun/.benchmarks/x"
+  # An added record with NO .json.sig beside it -- the case the guard exists
+  # for. It must be caught when the diff works, and must NOT be silently
+  # excused when the diff does not.
+  echo '{"git_sha":"abc1234567"}' > "$TMP/sgrun/.benchmarks/x/2026-01-01-abc1234567.json"
+  cat > "$TMP/sgbin/git" <<'SGSTUB'
+#!/usr/bin/env bash
+case "$1" in
+  merge-base) echo base0000000 ;;
+  diff)
+    case "${GIT_STUB_MODE:-ok}" in
+      fail) echo "fatal: bad revision" >&2; exit 128 ;;
+      *)    echo ".benchmarks/x/2026-01-01-abc1234567.json" ;;
+    esac ;;
+  *) exit 0 ;;
+esac
+SGSTUB
+  chmod +x "$TMP/sgbin/git"
+  sg_run() {  # $1 = step script, $2 = stub mode -> rc, output in $TMP/sgout
+    ( cd "$TMP/sgrun" && rm -f added_all.txt
+      PATH="$TMP/sgbin:$PATH" GIT_STUB_MODE="$2" BASE=deadbeef \
+        bash "$1" >"$TMP/sgout" 2>&1 )
+  }
+  sg_run "$TMP/signer.sh" ok
+  if [ $? -ne 0 ] && grep -q 'Unsigned record added' "$TMP/sgout"; then
+    ok "an added record with no sidecar is refused"
+  else
+    bad "the guard stopped catching an unsigned record"
+    sed 's/^/       /' "$TMP/sgout" | head -3
+  fi
+  sg_run "$TMP/signer.sh" fail
+  sgrc=$?
+  if [ "$sgrc" -ne 0 ] && ! grep -q 'adds no records' "$TMP/sgout"; then
+    ok "an unreadable diff fails the guard instead of clearing the PR"
+  else
+    bad "a failed enumeration was reported as a PR that adds no records"
+    sed 's/^/       /' "$TMP/sgout" | head -3
+  fi
+  if grep -q 'It is NOT reporting that the PR adds none' "$TMP/sgout"; then
+    ok "the annotation distinguishes 'could not look' from 'found nothing'"
+  else
+    bad "the guard failed without saying it had been blinded"
+  fi
+  # CONTROL: the pre-fix single line, restored. The unsigned record must go
+  # through, which is the defect this guard is here to make impossible.
+  python3 - "$TMP/signer.sh" "$TMP/signer-bad.sh" <<'SGSAB'
+import pathlib, sys, re
+t = pathlib.Path(sys.argv[1]).read_text()
+new = re.sub(
+    r'if ! git diff --name-only --diff-filter=AM "\$base"\.\.\.HEAD -- \.benchmarks \\\n'
+    r' *> added_all\.txt; then\n.*?\n *exit 1\n *fi\n',
+    '', t, count=1, flags=re.S)
+new = new.replace(
+    "mapfile -t added < <(grep '\\.json$' added_all.txt || true)",
+    "mapfile -t added < <(git diff --name-only --diff-filter=AM \"$base\"...HEAD "
+    "-- .benchmarks | grep '\\.json$' || true)", 1)
+assert new != t, "sabotage did not change the step -- it would measure nothing"
+pathlib.Path(sys.argv[2]).write_text(new)
+SGSAB
+  if [ -s "$TMP/signer-bad.sh" ]; then
+    sg_run "$TMP/signer-bad.sh" fail
+    if [ $? -eq 0 ] && grep -q 'adds no records' "$TMP/sgout"; then
+      ok "control: the old form clears an unsigned record when the diff fails"
+    else
+      bad "control: the sabotage did not reproduce the fail-open defect"
+      sed 's/^/       /' "$TMP/sgout" | head -3
+    fi
+  else
+    bad "control: could not build the sabotaged step"
+  fi
+else
+  bad "could not extract the one-signer step"
+fi
+
+# ---------------------------------------------------------------------------
 # nginx add_header does not accumulate across contexts
 # ---------------------------------------------------------------------------
 # Three vhosts, one rule, three separate incidents -- each found by hand after

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -747,7 +747,12 @@ cp .github/scripts/assert-gates-are-wired.py "$TMP/sg/scripts/"
 # does not land, and the control then passes against unmodified input -- which
 # is a green light that measured nothing. Caught exactly that way once already.
 sg_sabotage() {
-  for w in site.yml merge-ancestry.yml; do cp ".github/workflows/$w" "$TMP/sg/workflows/$w"; done
+  # EVERY workflow, not just the sabotaged one: the assertions read across
+  # files (ci.yml calls release-build.yml, and the required-context list
+  # spans nine of them). Staging a subset made the script die with
+  # FileNotFoundError -- rc=1 for the wrong reason, which want_rc_msg
+  # catches only because it also pins the message.
+  for w in .github/workflows/*.yml; do cp "$w" "$TMP/sg/workflows/"; done
   python3 - "$TMP/sg/workflows/$1" "$2" <<'PY'
 import pathlib, sys, yaml
 p = pathlib.Path(sys.argv[1]); d = yaml.safe_load(p.read_text())
@@ -787,6 +792,173 @@ want_rc_msg 1 "every entry would deadlock" "control: dropping merge_group suppor
 sg_sabotage merge-ancestry.yml 'd["jobs"]["guard"]["name"] = "Ancestry"'
 want_rc_msg 1 "leaves the required context uncreated" "control: renaming a required job is caught" \
   python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# ---------------------------------------------------------------------------
+# A required check whose verdict is not about the thing it claims to test
+# ---------------------------------------------------------------------------
+# `cargo test --features metal (macOS aarch64)` inherited ci.yml's
+# workflow-level ATLAS_SKIP_BUILD=1 (there so the ubuntu jobs type-check
+# without nvcc). atlas-kernels' build.rs honours it first and emits a stub
+# whose `metallib_modules()` is Vec::new(), so MetalGpuBackend loaded ZERO
+# libraries and all 35 parity tests died with `Metal: unknown module`. The
+# check was permanently red about a stub, and the merge queue was impassable
+# for every non-web PR. Same family as a check that passes vacuously: the
+# verdict is not about the capability named on the tin.
+#
+# Staged with the same sg_sabotage helper above -- it copies every workflow,
+# which these assertions need.
+#
+# The metal step's env, addressed by name so a sabotage that does not land is
+# an AssertionError rather than a control that silently measured nothing.
+rc_metal_env='
+steps = [s for s in d["jobs"]["test-macos-metal"]["steps"] if s.get("name","").startswith("cargo test -p spark-runtime")]
+assert len(steps) == 1, f"sabotage would not land: {len(steps)} metal test steps"
+env = steps[0]["env"]
+'
+
+want_rc 0 "every required context resolves to a live job that a failed dependency cannot skip" \
+  python3 .github/scripts/assert-gates-are-wired.py
+
+# The regression itself: put the stub env back on the metal test step.
+sg_sabotage ci.yml "$rc_metal_env"'env["ATLAS_SKIP_BUILD"] = "1"'
+want_rc_msg 1 "is about the stub, not the kernels" \
+  "control: running the metal suite against a kernel-build stub is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# Inheritance, not just the step: deleting the step override lets ci.yml's
+# workflow-level ATLAS_SKIP_BUILD=1 reach the job again. A guard that only
+# looked at the step's own env would pass here.
+sg_sabotage ci.yml "$rc_metal_env"'env.pop("ATLAS_SKIP_BUILD")'
+want_rc_msg 1 "is about the stub, not the kernels" \
+  "control: dropping the override so the workflow-level stub env is inherited is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# Without ATLAS_TARGET_HW, build.rs takes its macOS auto-skip and embeds
+# nothing even with ATLAS_SKIP_BUILD=0 -- the same empty set by another route.
+sg_sabotage ci.yml "$rc_metal_env"'env.pop("ATLAS_TARGET_HW")'
+want_rc_msg 1 "build.rs takes the macOS auto-skip" \
+  "control: dropping ATLAS_TARGET_HW from the metal suite is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# The other half of the family: a required job that a FAILED dependency
+# silently skips. Branch protection counts a skipped check as satisfied, so
+# the gate reports safety it never measured. This is the exact pre-fix state
+# of docs.yml `build` -- `needs: [changes]` with no `if:` at all.
+sg_sabotage docs.yml 'd["jobs"]["build"].pop("if")'
+want_rc_msg 1 "would pass vacuously" \
+  "control: a required job a failed dependency can skip is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# Renames and deletes across the whole required list, not just the two GATES.
+sg_sabotage security.yml 'd["jobs"]["cargo-deny"]["name"] = "deny"'
+want_rc_msg 1 "a renamed job leaves the required context uncreated" \
+  "control: renaming cargo deny is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+sg_sabotage gdn-so-pin.yml 'd["jobs"].pop("verify-gdn-so-pins")'
+want_rc_msg 1 "every PR would hang" \
+  "control: deleting the GDN pin job is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# The nested reusable-workflow context. `release matrix / dry-run summary` is
+# TWO names -- the caller's and the callee's -- and renaming either one leaves
+# protection waiting on a string nothing emits.
+sg_sabotage release-build.yml 'd["jobs"]["dry-run-summary"]["name"] = "summary"'
+want_rc_msg 1 "would never be created" \
+  "control: renaming the nested dry-run summary job is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+sg_sabotage ci.yml 'd["jobs"]["release-matrix"]["uses"] = "./.github/workflows/release.yml"'
+want_rc_msg 1 "no longer calls release-build.yml" \
+  "control: repointing the release-matrix caller is caught" \
+  python3 "$TMP/sg/scripts/assert-gates-are-wired.py"
+
+# ---------------------------------------------------------------------------
+# A grep-based gate that scanned nothing and said OK
+# ---------------------------------------------------------------------------
+# `No block_on under tui/ or recipe/` is a required context implemented as
+# `if hits=$(grep -r ... dirs 2>/dev/null); then fail; fi`. On a MISSING
+# directory grep exits 2, the redirect hides the reason, and the `if` reads any
+# non-zero as "no hits" -- so the check printed OK and exited 0 against a tree
+# with no tui/ at all. Verified in an empty directory before the fix. A rename
+# of either tree would have retired the rule while the check stayed green.
+#
+# Run the step's REAL shell, extracted from the workflow, so the control cannot
+# drift from what CI executes.
+mkdir -p "$TMP/bo"
+python3 - "$TMP/bo/step.sh" "$TMP/bo/scan_dirs" <<'PY'
+import pathlib, sys, yaml
+d = yaml.safe_load(pathlib.Path(".github/workflows/tui-threading.yml").read_text())
+job = d["jobs"]["no-blocking-on-the-render-thread"]
+steps = [s for s in job["steps"] if s.get("name", "").startswith("Check the render thread")]
+assert len(steps) == 1, f"expected one render-thread step, found {len(steps)}"
+pathlib.Path(sys.argv[1]).write_text(steps[0]["run"])
+pathlib.Path(sys.argv[2]).write_text(steps[0]["env"]["SCAN_DIRS"])
+PY
+BO_DIRS=$(cat "$TMP/bo/scan_dirs")
+
+want_rc 0 "the render-thread gate passes on the real tree" \
+  env SCAN_DIRS="$BO_DIRS" bash "$TMP/bo/step.sh"
+
+# A tree where one scanned directory does not exist. Pre-fix this printed
+# "OK: no block_on/block_in_place under tui/ or recipe/" and exited 0.
+mkdir -p "$TMP/bo/moved/crates/spark-server/src/recipe"
+want_rc_msg 1 "does not exist, so this check scanned nothing" \
+  "control: the render-thread gate refuses a tree it cannot scan" \
+  env -C "$TMP/bo/moved" SCAN_DIRS="$BO_DIRS" bash "$TMP/bo/step.sh"
+
+# ...and the existence assertion did not neuter the rule it guards: a real
+# block_on in a present tree is still caught.
+mkdir -p "$TMP/bo/dirty/crates/spark-server/src/tui" "$TMP/bo/dirty/crates/spark-server/src/recipe"
+printf 'fn f() { handle.block_on(fut); }\n' > "$TMP/bo/dirty/crates/spark-server/src/tui/draw.rs"
+want_rc_msg 1 "must never poll a future" \
+  "control: the render-thread gate still catches a real block_on" \
+  env -C "$TMP/bo/dirty" SCAN_DIRS="$BO_DIRS" bash "$TMP/bo/step.sh"
+
+# The same defect twice more, in the two other gates that decide by scanning a
+# tree. Both were verified passing on a tree they could not see.
+#
+# `Enforce <=500 LoC per source file`: `find crates ...` on a missing directory
+# feeds the loop nothing, `violations` stays 0, and the step printed its tick
+# and exited 0 -- the cap unenforced repo-wide. `set -euo pipefail` does not
+# catch it: the find lives in a process substitution whose status is not the
+# command's.
+mkdir -p "$TMP/fs"
+python3 - "$TMP/fs/step.sh" <<'PY'
+import pathlib, sys, yaml
+d = yaml.safe_load(pathlib.Path(".github/workflows/file-size-cap.yml").read_text())
+steps = [s for s in d["jobs"]["check-file-sizes"]["steps"]
+         if s.get("name", "").startswith("Check no .rs file")]
+assert len(steps) == 1, f"expected one file-size step, found {len(steps)}"
+pathlib.Path(sys.argv[1]).write_text(steps[0]["run"])
+PY
+want_rc 0 "the 500-LoC cap passes on the real tree" bash "$TMP/fs/step.sh"
+
+mkdir -p "$TMP/fs/nocrates"
+want_rc_msg 1 "the 500-line cap scanned nothing" \
+  "control: the 500-LoC cap refuses a tree with no crates/ to scan" \
+  env -C "$TMP/fs/nocrates" bash "$TMP/fs/step.sh"
+
+# `kernel shadow structure`: the scan loop skipped any hardware tree that was
+# not present, so an empty (or renamed) kernels/ printed
+# "kernel shadow structure: OK" and exited 0. HW_SOURCE_EXT is the list of
+# trees the check CLAIMS to cover; every one of them must be there.
+want_rc 0 "the kernel-shadow check passes on the real kernels/ tree" \
+  python3 scripts/check_kernel_shadows.py
+
+mkdir -p "$TMP/ks/kernels"
+want_rc_msg 1 "is missing hardware tree(s)" \
+  "control: the kernel-shadow check refuses a kernels/ tree it cannot scan" \
+  python3 scripts/check_kernel_shadows.py "$TMP/ks/kernels"
+
+# ...and it still catches the violation it exists for: a shadow byte-identical
+# to the common file it overrides is a dead override.
+mkdir -p "$TMP/ks/live/gb10/common" "$TMP/ks/live/gb10/m1/q" \
+         "$TMP/ks/live/metal" "$TMP/ks/live/strix" "$TMP/ks/live/strix-hip"
+printf '__global__ void k() {}\n' > "$TMP/ks/live/gb10/common/k.cu"
+cp "$TMP/ks/live/gb10/common/k.cu" "$TMP/ks/live/gb10/m1/q/k.cu"
+want_rc_msg 1 "RULE1" "control: the kernel-shadow check still catches a dead override" \
+  python3 scripts/check_kernel_shadows.py "$TMP/ks/live"
 
 # ---------------------------------------------------------------------------
 # A write whose failure is swallowed, and no probe behind it

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -891,6 +891,84 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# PR telemetry must not record an unreadable diff as an empty one
+# ---------------------------------------------------------------------------
+# The collector calls `pulls/N/files` once per PR, and that call can fail. It
+# used to fall through to `paths='[]'` with no warning, and every consumer of
+# the record reads an empty path list as a MEASUREMENT: no targets, no owners,
+# no promotion debt, no collisions -- the most reassuring record this view can
+# emit, manufactured out of an API error and posted to the tracking issue.
+#
+# The Rust half (gate/telemetry.rs) has tests for how the marker is HONOURED.
+# Nothing tested that the shell half still EMITS it, and the shell half is the
+# one with no other coverage, so this runs the real step against a gh stub.
+echo "== pr telemetry marks an unreadable diff =="
+python3 - > "$TMP/collect.sh" <<'TELPY'
+import yaml, pathlib
+d = yaml.safe_load(pathlib.Path(".github/workflows/pr-telemetry.yml").read_text())
+for st in d["jobs"]["render"]["steps"]:
+    if st.get("name", "").startswith("Collect open PRs"):
+        print(st["run"]); break
+TELPY
+if [ -s "$TMP/collect.sh" ]; then
+  mkdir -p "$TMP/tbin" "$TMP/trun"
+  # #1's files come back; #2's call fails the way a 404 does -- non-zero exit
+  # AND an error body on stdout, so a length check would read that body as a
+  # filename. That shape is why the collector guards on the exit status.
+  cat > "$TMP/tbin/gh" <<'TELSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"pulls?state=all"*)
+    echo '[{"number":1,"title":"one","author":"a","draft":false,"merged":false},{"number":2,"title":"two","author":"b","draft":false,"merged":false}]' ;;
+  *"pulls/1/files"*) printf 'kernels/gb10/x.cu\n' ;;
+  *"pulls/2/files"*) echo '{"message":"Not Found","status":"404"}'; exit 1 ;;
+  *) exit 1 ;;
+esac
+TELSTUB
+  chmod +x "$TMP/tbin/gh"
+  tel_run() {  # $1 = step script -> facts.json on stdout
+    ( cd "$TMP/trun" && rm -f facts.json prs.json prs.ndjson enriched.ndjson
+      PATH="$TMP/tbin:$PATH" GH_TOKEN=x REPO=o/r bash "$1" >/dev/null 2>&1 )
+    jq -c '.' "$TMP/trun/facts.json" 2>/dev/null
+  }
+  tel_run "$TMP/collect.sh" > "$TMP/facts.txt"
+  if jq -e 'any(.[]; .number == 2 and .paths_unknown == true)' "$TMP/facts.txt" >/dev/null 2>&1; then
+    ok "a PR whose files could not be read is recorded as paths_unknown"
+  else
+    bad "an API failure was recorded as a PR that changes nothing"
+    sed 's/^/       /' "$TMP/facts.txt" | head -2
+  fi
+  # The marker must DISCRIMINATE. A collector that stamped every record
+  # `paths_unknown: true` would pass the check above and make the view useless,
+  # so the readable PR must come back marked known, with its path.
+  if jq -e 'any(.[]; .number == 1 and .paths_unknown == false and (.changed_paths | length) == 1)' \
+       "$TMP/facts.txt" >/dev/null 2>&1; then
+    ok "a PR whose files WERE read is recorded as known"
+  else
+    bad "the marker does not discriminate: a readable diff came back unknown"
+    sed 's/^/       /' "$TMP/facts.txt" | head -2
+  fi
+  # CONTROL: the pre-fix behaviour, reconstructed by flipping the one flag.
+  # It must turn the first check red and leave the second green, which is what
+  # proves the check measures the failure path and not the happy one.
+  sed 's/^\( *\)unknown=true$/\1unknown=false/' "$TMP/collect.sh" > "$TMP/collect-bad.sh"
+  if cmp -s "$TMP/collect.sh" "$TMP/collect-bad.sh"; then
+    bad "control: the sabotage did not change the step -- it would measure nothing"
+  else
+    tel_run "$TMP/collect-bad.sh" > "$TMP/facts-bad.txt"
+    if jq -e 'any(.[]; .number == 2 and .paths_unknown == false)' "$TMP/facts-bad.txt" >/dev/null 2>&1 \
+       && jq -e 'any(.[]; .number == 1 and .paths_unknown == false)' "$TMP/facts-bad.txt" >/dev/null 2>&1; then
+      ok "control: dropping the marker is caught (#2 renders as changing nothing)"
+    else
+      bad "control: the sabotaged collector did not reproduce the defect"
+      sed 's/^/       /' "$TMP/facts-bad.txt" | head -2
+    fi
+  fi
+else
+  bad "could not extract the telemetry collect step"
+fi
+
+# ---------------------------------------------------------------------------
 # nginx add_header does not accumulate across contexts
 # ---------------------------------------------------------------------------
 # Three vhosts, one rule, three separate incidents -- each found by hand after

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1136,8 +1136,27 @@ jobs:
         run: |
           set -euo pipefail
           base=$(git merge-base "$BASE" HEAD)
+          # ★ The enumeration is checked SEPARATELY from the filter.
+          #
+          # `mapfile -t added < <(git diff ... | grep ...)` reports the status
+          # of `mapfile`, never of the pipeline inside the process
+          # substitution -- `set -euo pipefail` does not reach in there. So a
+          # failed `git diff` produced an EMPTY list, and an empty list is the
+          # one input this guard reads as "nothing to check": it printed "this
+          # PR adds no records" and exited 0, waving through every unsigned
+          # record, every cross-commit record set, and every second signer it
+          # exists to stop. A guard that cannot see its input must not report
+          # that the input was clean.
+          #
+          # `|| true` stays on the GREP, where it means what it says: no match
+          # is grep's normal "nothing found", not a failure to look.
+          if ! git diff --name-only --diff-filter=AM "$base"...HEAD -- .benchmarks \
+               > added_all.txt; then
+            echo "::error title=Cannot enumerate added records::git diff $base...HEAD failed, so this step could not see which records the PR adds. It is NOT reporting that the PR adds none."
+            exit 1
+          fi
           # `.json$` also drops the `.json.sig` sidecars, which are read below.
-          mapfile -t added < <(git diff --name-only --diff-filter=AM "$base"...HEAD -- .benchmarks | grep '\.json$' || true)
+          mapfile -t added < <(grep '\.json$' added_all.txt || true)
           if [ "${#added[@]}" -eq 0 ]; then
             echo "this PR adds no records — nothing to agree on."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,28 @@ jobs:
               printf '%s\n' "$d"
             } >> "$GITHUB_OUTPUT"
           }
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed.txt || true
+          # ★ NO `|| true` HERE. The redirect truncates `changed.txt` before
+          # git runs, so a failed diff leaves it EMPTY -- and empty is not a
+          # value this step is allowed to emit. Every consumer reads it as a
+          # measurement: `count=0`, an empty histogram, an empty path list,
+          # and a classifier prompt that says "Changed paths (0 total)". That
+          # is the classifier running on the PR's TITLE AND BODY ALONE, which
+          # is exactly the bypass the ★ note on the classify step says was
+          # closed -- reopened by a transient git failure, silently, and with
+          # the model's confident answer appended to the journey ledger as
+          # evidence. The deterministic fallback cannot save it either: its
+          # `all_match` requires `total > 0`, so it abstains too.
+          #
+          # `base.sha` can genuinely be unreachable (force-pushed away from the
+          # base branch and garbage-collected) even under `fetch-depth: 0`. That
+          # is a real condition, and the honest response is to fail this job --
+          # it is advisory and nothing `needs:` it, so red here blocks no merge
+          # and buys a cause one click away, the same trade `implied_benches`
+          # below already makes.
+          if ! git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed.txt; then
+            echo "::error title=Changed paths unavailable::git diff $BASE_SHA..$HEAD_SHA failed. Refusing to classify from the title and body alone -- an empty path list would read as a PR that changes nothing."
+            exit 1
+          fi
           total=$(wc -l < changed.txt)
           echo "count=$total" >> "$GITHUB_OUTPUT"
           # TWO views of the same diff, complementary by construction:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,33 @@ jobs:
       # run on a developer machine; default `cargo test` skips them.
       - name: cargo test -p spark-runtime --features metal
         env:
+          # ★ ATLAS_SKIP_BUILD=0, overriding the workflow-level "1".
+          #
+          # This job used to inherit `ATLAS_SKIP_BUILD: "1"` from the top of
+          # this file, which exists so the ubuntu jobs can type-check without
+          # nvcc. atlas-kernels' build.rs honours it FIRST -- before the
+          # macOS/ATLAS_TARGET_HW logic -- and emits a stub whose
+          # `metallib_modules()` returns `Vec::new()`. `MetalGpuBackend::new`
+          # then builds an EMPTY library cache (an empty module slice is not an
+          # error to it) and every pipeline lookup dies with
+          # `Metal: unknown module '<name>'`, so all 35 parity tests failed
+          # instantly and this required context was red on every non-web PR --
+          # red about the stub, never about the kernels.
+          #
+          # The Metal compile path is implemented, not stubbed:
+          # build_target.rs `AppleTarget` (xcrun -sdk macosx metal -> AIR ->
+          # metallib), reached from `resolve_compute_target("apple")`, over the
+          # 43 `.metal` sources under kernels/metal/ whose HARDWARE.toml
+          # declares `vendor = "apple"`. So the fix is to let it run, not to
+          # skip the suite: a suite told not to build the thing it tests can
+          # neither fail for a real defect nor pass meaningfully, and a skip
+          # that survived Phase 2 would be the same bug wearing green.
+          #
+          # `.github/scripts/assert-gates-are-wired.py` pins this statically and
+          # `metal_backend::tests::embedded_kernels` refuses at RUNTIME if the
+          # embedded metallib set is ever empty again, so the stub cannot come
+          # back quietly by either route.
+          ATLAS_SKIP_BUILD: "0"
           ATLAS_TARGET_HW: metal
           ATLAS_TARGET_MODEL: qwen3-5-4b-vlm-mlx-int8
           ATLAS_TARGET_QUANT: mlx_int8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,6 +80,19 @@ jobs:
     # This job must RUN on a web-only diff: its mdBook half IS the gate for
     # `book/`, and it is a required context. Only the rustdoc half is skipped,
     # at STEP level — see the steps below.
+    #
+    # ★ `!cancelled()` is what makes that true even when `changes` FAILS.
+    # Default `needs:` semantics carry an implicit `success()`, so a broken
+    # classify-diff.sh SKIPPED this job — and a skipped required context is
+    # counted as satisfied by branch protection and the merge queue. The docs
+    # gate would then have waved a PR through while reporting nothing, which is
+    # the same defect class as a check that tests a stub. Naming a status
+    # function suppresses the implicit success(); `web_only` then resolves to
+    # the empty string, the step-level `!= 'true'` guards are true, and the
+    # rustdoc half runs. Fails OPEN, exactly as ci.yml's clippy/test and
+    # coverage.yml already do — this job was the one that did not.
+    # Pinned by .github/scripts/assert-gates-are-wired.py.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/file-size-cap.yml
+++ b/.github/workflows/file-size-cap.yml
@@ -458,6 +458,31 @@ jobs:
             "crates/spark-model/src/layers/qwen3_attention/prefill/paged_qkv.rs"
           )
 
+          # ★ The scanned tree must EXIST and must contain Rust. `find crates`
+          # on a missing directory writes to stderr and yields nothing; the
+          # loop below then runs zero times, `violations` stays 0, and this
+          # required check prints its tick and exits 0 -- the cap silently
+          # unenforced for the whole repo. `set -euo pipefail` does not help:
+          # the failure is inside a process substitution, whose status is not
+          # the command's. Same shape as the render-thread gate's missing-tree
+          # bug. Assert the input before trusting an empty result.
+          # Counted inside the `-d` guard on purpose: under `set -euo pipefail`
+          # a bare `find crates | wc -l` on a missing directory kills the step
+          # at the assignment, which is a non-zero exit with no explanation of
+          # why -- right verdict, useless log.
+          scanned=0
+          if [[ -d crates ]]; then
+            scanned=$(find crates -name '*.rs' -not -name '*.bak' -not -path '*/target/*' | wc -l)
+          fi
+          if [[ $scanned -eq 0 ]]; then
+            echo "::error::found no .rs files under crates/, so the 500-line cap scanned nothing."
+            echo "Either crates/ moved or the find expression stopped matching. An unscanned"
+            echo "tree is an unenforced cap, and this check would have gone green without"
+            echo "this line."
+            exit 1
+          fi
+          echo "scanning $scanned Rust source file(s) under crates/"
+
           violations=0
           while IFS= read -r -d '' file; do
             lines=$(wc -l < "$file")

--- a/.github/workflows/pr-telemetry.yml
+++ b/.github/workflows/pr-telemetry.yml
@@ -94,10 +94,29 @@ jobs:
                        --paginate --jq '.[].filename' 2>/dev/null); then
               paths=$(printf '%s' "$raw" \
                       | jq -R -s -c 'split("\n") | map(select(length > 0))')
+              unknown=false
             else
+              # ★ A failed files call is NOT "this PR changes nothing". It used
+              # to fall through to a bare `paths='[]'`, and every consumer reads
+              # an empty list as a measurement: no targets, no owners, no
+              # promotion debt, no collisions. That is this view understating a
+              # blast radius all the way to zero — the one direction the comment
+              # above says it must never fail in — and it did it silently, from
+              # a transient API error, into a record posted to the tracking
+              # issue and parsed by gate/telemetry.rs.
+              #
+              # The record is kept and MARKED rather than dropped: dropping it
+              # makes the PR absent from the comment, and absent reads as "no
+              # such PR" — the same understatement, and it also removes the PR
+              # from the collision table and the merge order it should be
+              # blocking. Marked, the renderer counts it at maximum radius and
+              # labels every row it contributes as assumed.
+              echo "::warning::PR #$number: changed files unreadable; recorded as paths_unknown, counted at maximum blast radius." >&2
               paths='[]'
+              unknown=true
             fi
-            jq -c --argjson p "$paths" '. + {changed_paths: $p}' <<<"$pr" >> enriched.ndjson
+            jq -c --argjson p "$paths" --argjson u "$unknown" \
+              '. + {changed_paths: $p, paths_unknown: $u}' <<<"$pr" >> enriched.ndjson
           done < prs.ndjson
           jq -s '.' enriched.ndjson > facts.json
 

--- a/.github/workflows/tui-threading.yml
+++ b/.github/workflows/tui-threading.yml
@@ -56,6 +56,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check the render thread never blocks on a future
         shell: bash
+        env:
+          # SSOT for the trees this rule covers: the existence assertion and
+          # the grep must never be able to disagree about which they are.
+          SCAN_DIRS: "crates/spark-server/src/tui/ crates/spark-server/src/recipe/"
         run: |
           set -euo pipefail
           # Only real call syntax counts -- comments explaining the rule are
@@ -75,10 +79,27 @@ jobs:
           # production code is ever put in a file named that way, this check
           # will not see it -- that is the cost, and it is smaller than the
           # alternative.
+          # ★ The scanned trees must EXIST. `grep -r` on a missing directory
+          # exits 2, the `2>/dev/null` hides the reason, and `if hits=$(...)`
+          # reads any non-zero as "no hits" -- so this required check printed
+          # OK and exited 0 against a tree with no `tui/` at all. Verified:
+          # running the block below in an empty directory passes. A rename or a
+          # move of either tree would silently retire the rule while the check
+          # stayed green, which is the failure mode this whole gate exists to
+          # prevent. Assert the inputs before trusting the absence of output.
+          for d in $SCAN_DIRS; do
+            [ -d "$d" ] || {
+              echo "::error::$d does not exist, so this check scanned nothing."
+              echo "The render-thread rule is pinned to these trees. If one moved,"
+              echo "update SCAN_DIRS in this workflow in the same commit -- an"
+              echo "unscanned tree is an unenforced rule, and it would have gone"
+              echo "green without this line."
+              exit 1
+            }
+          done
           if hits=$(grep -rnE '\.(block_on|block_in_place)\(' \
                       --include='*.rs' --exclude='*_tests.rs' \
-                      crates/spark-server/src/tui/ \
-                      crates/spark-server/src/recipe/ 2>/dev/null); then
+                      $SCAN_DIRS 2>/dev/null); then
             echo "::error::The TUI render thread must never poll a future."
             echo "$hits"
             echo

--- a/crates/atlas-plugin/src/benchmarks/ssm_poison/report.rs
+++ b/crates/atlas-plugin/src/benchmarks/ssm_poison/report.rs
@@ -116,21 +116,34 @@ pub(super) fn summary(s: &Score) -> Vec<Stat> {
 /// missing key and a zero must stay distinguishable to whatever compares
 /// records later.
 pub(super) fn metrics(s: &Score) -> BTreeMap<String, f64> {
-    [
+    let mut m: BTreeMap<String, f64> = [
         ("rounds", s.rounds),
         ("invariant", s.invariant),
         ("jittered", s.jittered),
         ("collapsed", s.collapsed),
         ("unmeasured", s.unmeasured),
-        // The vacuity attestation, floored in BENCH.toml. A run that never
-        // engaged the prefix cache records 0 here and fails at the record
-        // level too — before this metric existed, such a run was a green
-        // PASS that had measured nothing.
-        ("min_cached_prompt_tokens", s.min_turn1_cached.unwrap_or(0)),
     ]
     .into_iter()
     .map(|(k, v)| (k.to_string(), v as f64))
-    .collect()
+    .collect();
+    // The vacuity attestation, floored in BENCH.toml at `min = 1.0`. A run
+    // that engaged the prefix cache and got NOTHING back records 0 here and
+    // fails at the record level too — before this metric existed, such a run
+    // was a green PASS that had measured nothing.
+    //
+    // ★ But only when a round actually reported a figure. `min_turn1_cached`
+    // is `None` when no replay produced a turn-1 attestation at all, and
+    // `unwrap_or(0)` wrote that absence as the vacuity value — collapsing "the
+    // cache restored nothing" into "nobody looked", which is precisely the
+    // distinction the doc comment above demands and the one a reader of the
+    // failure ("min_cached_prompt_tokens 0 < 1") would get wrong. Both cases
+    // still fail the floor: an absent key is reported as missing from the
+    // record. `concurrency.rs` omits the identically-named key on `None`
+    // already; this makes the two agree.
+    if let Some(min) = s.min_turn1_cached {
+        m.insert("min_cached_prompt_tokens".to_string(), min as f64);
+    }
+    m
 }
 
 #[cfg(test)]

--- a/crates/atlas-plugin/src/benchmarks/ssm_poison/report_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/ssm_poison/report_tests.rs
@@ -254,3 +254,45 @@ fn unmeasured_rows_are_attributed_to_their_actual_round() {
         .expect("unmeasured tile");
     assert_eq!(unmeasured.style, CellStyle::Bad);
 }
+
+/// ★ "The cache gave back nothing" and "no round reported a figure" are
+/// different findings and must not share a value.
+///
+/// `min_turn1_cached` is `None` when not one replay produced a turn-1
+/// attestation — every replay errored, or came back with no turns. Writing 0
+/// for that stamped the record with the VACUITY signature the metric exists to
+/// detect, so the gate's failure line read "min_cached_prompt_tokens 0 < 1" —
+/// "the prefix cache restored nothing" — for a run in which nothing was ever
+/// measured. Both still fail the floor; only one of them is true.
+#[test]
+fn an_unmeasured_cache_is_absent_from_the_record_not_zero() {
+    let replays: Vec<_> = (1..=3)
+        .map(|n| RoundRecord {
+            round: n,
+            verdict: RoundVerdict::Unmeasured {
+                reason: "connection reset".into(),
+            },
+            turn1_cached: None,
+        })
+        .collect();
+    let m = metrics(&score(&replays));
+    assert!(
+        !m.contains_key("min_cached_prompt_tokens"),
+        "an unmeasured cache must not be written as the vacuity value: {m:?}"
+    );
+    // The rest of the record is unaffected — the run still says, loudly, that
+    // three rounds went unmeasured.
+    assert_eq!(m["rounds"], 3.0);
+    assert_eq!(m["unmeasured"], 3.0);
+    // And a REAL zero is still recorded as a zero, so the key still
+    // discriminates. (`a_zero_cache_run_records_a_zero_metric` above pins
+    // that direction; asserted here too so one edit cannot silence both.)
+    let vacuous: Vec<_> = (1..=3)
+        .map(|n| RoundRecord {
+            round: n,
+            verdict: RoundVerdict::Invariant,
+            turn1_cached: Some(0),
+        })
+        .collect();
+    assert_eq!(metrics(&score(&vacuous))["min_cached_prompt_tokens"], 0.0);
+}

--- a/crates/atlas-plugin/src/bin/pr_telemetry.rs
+++ b/crates/atlas-plugin/src/bin/pr_telemetry.rs
@@ -24,7 +24,13 @@ fn main() -> anyhow::Result<()> {
 
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
-    let prs: Vec<PrFacts> = serde_json::from_str(input.trim()).unwrap_or_default();
+    // ★ Never `unwrap_or_default()` here. A malformed or truncated feed would
+    // become an empty Vec, `render` would emit "_No open pull requests._", and
+    // the workflow would post that to the tracking issue as the state of the
+    // repository — a parse failure published as a measurement of zero. Failing
+    // the step leaves the previous comment standing, which is stale but true.
+    let prs: Vec<PrFacts> = serde_json::from_str(input.trim())
+        .map_err(|e| anyhow::anyhow!("the PR feed on stdin is not a JSON array of PrFacts: {e}"))?;
 
     print!("{}", render(&root, &prs));
     Ok(())

--- a/crates/atlas-plugin/src/gate/telemetry.rs
+++ b/crates/atlas-plugin/src/gate/telemetry.rs
@@ -60,8 +60,28 @@ pub struct PrFacts {
     #[serde(default)]
     pub merged: bool,
     /// Repo-relative paths this PR changes.
+    ///
+    /// Only meaningful when [`Self::paths_unknown`] is false. When the list
+    /// could not be read it is empty, and empty-because-unknown is NOT the
+    /// same fact as empty-because-nothing-changed.
     #[serde(default)]
     pub changed_paths: Vec<String>,
+    /// True when the collector could not read this PR's file list at all.
+    ///
+    /// ★ The whole point of this view is blast radius, and understating it is
+    /// the one direction it must not fail in. A failed `pulls/N/files` call
+    /// used to fall through to `changed_paths: []`, which every consumer here
+    /// reads as *this PR touches nothing*: no targets, no owners, no promotion
+    /// debt, no collisions — a maximally reassuring record produced by an API
+    /// error. This flag makes the absence of the input a first-class fact so
+    /// the renderer can say "unknown" instead of "none".
+    ///
+    /// The marker is kept rather than dropping the record: a dropped PR is
+    /// simply absent from the comment, and absent reads as *no such PR* — the
+    /// same understatement by a different route, and one that also removes it
+    /// from the collision table and the merge order it should be blocking.
+    #[serde(default)]
+    pub paths_unknown: bool,
 }
 
 /// One PR's derived position in the taxonomy.
@@ -98,7 +118,11 @@ pub fn views(root: &Path, prs: &[PrFacts]) -> Vec<PrView> {
                 .filter(|p| taxon::hardware_of(p).is_some())
                 .cloned()
                 .collect();
-            let whole_repo = facts.changed_paths.len() > kernel_paths.len();
+            // ★ Unknown paths are the MAXIMUM blast radius, never the empty
+            // one. `whole_repo` is what makes a PR re-open every target and
+            // contend with every other PR, so routing the unknown case through
+            // it gives the conservative answer everywhere at once.
+            let whole_repo = facts.paths_unknown || facts.changed_paths.len() > kernel_paths.len();
             PrView {
                 hardware: taxon::hardware_span(&kernel_paths),
                 models: taxon::model_span(&kernel_paths),
@@ -109,9 +133,17 @@ pub fn views(root: &Path, prs: &[PrFacts]) -> Vec<PrView> {
                 },
                 owners: codeowners::owners_for_paths(&rules, &facts.changed_paths),
                 whole_repo,
-                promotion_debt: coverage::promotion_debt(
-                    facts.changed_paths.iter().map(String::as_str),
-                ),
+                // Same rule for debt: with no paths there is no join to
+                // perform, so the answer is every candidate, and the renderer
+                // labels the row as assumed rather than measured.
+                promotion_debt: if facts.paths_unknown {
+                    coverage::PROMOTION_CANDIDATES
+                        .iter()
+                        .map(|gate| gate.id)
+                        .collect()
+                } else {
+                    coverage::promotion_debt(facts.changed_paths.iter().map(String::as_str))
+                },
                 facts: facts.clone(),
             }
         })
@@ -167,6 +199,29 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
         "\nAdvisory. Nothing here blocks a merge — the blocking checks live on each PR.\n",
     );
 
+    // ── The one thing this view cannot be quiet about ──
+    //
+    // A PR whose file list the collector could not read is shown at MAXIMUM
+    // blast radius below, not zero. Saying so out loud is the difference
+    // between a conservative estimate and a fabricated measurement: every
+    // "ALL" and every debt row those PRs contribute is an assumption, and a
+    // reader who cannot tell which rows are assumed will quote them as facts.
+    let blind: Vec<u64> = views
+        .iter()
+        .filter(|v| v.facts.paths_unknown)
+        .map(|v| v.facts.number)
+        .collect();
+    if !blind.is_empty() {
+        out.push_str(&format!(
+            "\n> ⚠ **Changed files unavailable for {}.** The API call for their diffs \
+             failed on this run, so nothing below measures them. They are counted at \
+             MAXIMUM blast radius — every target, every promotion candidate — because \
+             an unknown diff must never render as an empty one. Re-run this workflow \
+             before using any row they appear in.\n",
+            order::cap_prs(&blind)
+        ));
+    }
+
     out.push_str(&order::render_next_steps(&views));
 
     // ── PRs, grouped by the hardware they touch ──
@@ -198,14 +253,20 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
     }
     for (category, group) in &grouped {
         for view in group {
-            let targets = if view.whole_repo {
+            let targets = if view.facts.paths_unknown {
+                "ALL — **assumed**, changed files unreadable".to_string()
+            } else if view.whole_repo {
                 "ALL (diff reaches outside kernels/)".to_string()
             } else if view.targets.is_empty() {
                 "none".to_string()
             } else {
                 format!("{}", view.targets.len())
             };
-            let owners = if view.owners.is_empty() {
+            // "—" means CODEOWNERS matched nobody. With no paths there was
+            // nothing to match, which is a different sentence.
+            let owners = if view.facts.paths_unknown {
+                "unknown".to_string()
+            } else if view.owners.is_empty() {
                 "—".to_string()
             } else {
                 view.owners.join(" ")
@@ -259,7 +320,14 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
                 // those two different rows instead of one undifferentiated list.
                 if v.facts.merged { "**yes**" } else { "not yet" },
                 escape(&v.facts.title),
-                v.promotion_debt.join(", ")
+                if v.facts.paths_unknown {
+                    format!(
+                        "{} — **assumed** (paths unreadable)",
+                        v.promotion_debt.join(", ")
+                    )
+                } else {
+                    v.promotion_debt.join(", ")
+                }
             ));
         }
     }
@@ -315,3 +383,7 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
 #[cfg(test)]
 #[path = "telemetry_tests.rs"]
 mod telemetry_tests;
+
+#[cfg(test)]
+#[path = "telemetry_unknown_tests.rs"]
+mod telemetry_unknown_tests;

--- a/crates/atlas-plugin/src/gate/telemetry.rs
+++ b/crates/atlas-plugin/src/gate/telemetry.rs
@@ -240,7 +240,13 @@ pub fn render(root: &Path, prs: &[PrFacts]) -> String {
     out.push_str("|---|---|---|---|\n");
     let mut grouped: BTreeMap<String, Vec<&PrView>> = BTreeMap::new();
     for view in views.iter().filter(|v| !v.facts.merged) {
-        let key = if view.hardware.is_empty() {
+        // "host / non-kernel" is a CLAIM about the diff — the hardware span
+        // is empty because no changed path named a kernel. With no changed
+        // paths at all there is nothing to have named one, so grouping a blind
+        // PR under it asserts something this run cannot know.
+        let key = if view.facts.paths_unknown {
+            "unknown (changed files unreadable)".to_string()
+        } else if view.hardware.is_empty() {
             "host / non-kernel".to_string()
         } else {
             view.hardware

--- a/crates/atlas-plugin/src/gate/telemetry_order.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_order.rs
@@ -52,13 +52,21 @@ fn contend(a: &PrView, b: &PrView) -> bool {
     !a.targets.is_disjoint(&b.targets)
 }
 
-/// The PRs a merge order can contain: open and non-draft. A merged PR has
-/// already landed; a draft cannot land. The old order ranked both, which made
-/// the suggestion wrong on its face whenever the feed carried merged PRs.
+/// The PRs a merge order can contain: open, non-draft, and with a diff this
+/// run could actually read. A merged PR has already landed; a draft cannot
+/// land. The old order ranked both, which made the suggestion wrong on its
+/// face whenever the feed carried merged PRs.
+///
+/// ★ A PR whose changed files came back unreadable is NOT ranked. Ranking is
+/// entirely a function of what a diff touches, so ordering one we cannot see
+/// would be a recommendation with no input behind it — and with an empty path
+/// list it would sort to the FRONT (zero partners, zero targets, zero files)
+/// and be published as "merge next". [`super::render_next_steps`] names them
+/// instead, so they are excluded loudly rather than silently.
 fn orderable(views: &[PrView]) -> Vec<&PrView> {
     views
         .iter()
-        .filter(|v| !v.facts.merged && !v.facts.draft)
+        .filter(|v| !v.facts.merged && !v.facts.draft && !v.facts.paths_unknown)
         .collect()
 }
 
@@ -143,6 +151,17 @@ pub fn render_order_chart(views: &[PrView]) -> String {
     if order.is_empty() {
         // No fence at all: an empty gitGraph (a mainline with no branches)
         // renders as a lone dot, which reads as a broken chart.
+        //
+        // "nothing to order" and "everything was unreadable" are different
+        // facts and must not share a sentence.
+        if views
+            .iter()
+            .any(|v| !v.facts.merged && v.facts.paths_unknown)
+        {
+            return "_Nothing could be ordered: the changed files of the open PR(s) came \
+                    back unreadable on this run._\n"
+                .to_string();
+        }
         return "_No open, non-draft PRs to order._\n".to_string();
     }
     let shown = order.len().min(CHART_PR_BOUND);
@@ -184,6 +203,15 @@ pub fn render_next_steps(views: &[PrView]) -> String {
     let mut out = String::from("\n### Recommended next steps\n\n");
     let order = merge_order(views);
     match order.first() {
+        None if views
+            .iter()
+            .any(|v| !v.facts.merged && v.facts.paths_unknown) =>
+        {
+            out.push_str(
+                "- **No recommendation.** Every rankable PR's changed files came \
+                       back unreadable on this run.\n",
+            )
+        }
         None => out.push_str("- Nothing to merge: no open, non-draft PRs.\n"),
         Some(head) => {
             let v = views.iter().find(|v| v.facts.number == *head).unwrap();
@@ -193,6 +221,21 @@ pub fn render_next_steps(views: &[PrView]) -> String {
                 super::escape(&v.facts.title)
             ));
         }
+    }
+
+    // Unrankable, and said so where the reader is deciding what to merge.
+    let blind: Vec<u64> = views
+        .iter()
+        .filter(|v| !v.facts.merged && v.facts.paths_unknown)
+        .map(|v| v.facts.number)
+        .collect();
+    if !blind.is_empty() {
+        out.push_str(&format!(
+            "- **Cannot rank {}:** their changed files came back unreadable, so this \
+             run has no input to order them by. They are counted as touching \
+             everything elsewhere in this comment; re-run before trusting the order.\n",
+            cap_prs(&blind)
+        ));
     }
 
     // Baselines already moved: open PRs whose targets a merged PR re-opened.

--- a/crates/atlas-plugin/src/gate/telemetry_order_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_order_tests.rs
@@ -18,6 +18,7 @@ fn pr(number: u64, paths: &[&str]) -> PrFacts {
         author: "someone".into(),
         draft: false,
         merged: false,
+        paths_unknown: false,
         changed_paths: paths.iter().map(|s| s.to_string()).collect(),
     }
 }

--- a/crates/atlas-plugin/src/gate/telemetry_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_tests.rs
@@ -17,6 +17,7 @@ fn pr(number: u64, paths: &[&str]) -> PrFacts {
         author: "someone".into(),
         draft: false,
         merged: false,
+        paths_unknown: false,
         changed_paths: paths.iter().map(|s| s.to_string()).collect(),
     }
 }
@@ -254,6 +255,7 @@ fn pr_titles_cannot_break_the_table() {
         author: "x".into(),
         draft: false,
         merged: false,
+        paths_unknown: false,
         changed_paths: vec![FLAGSHIP.to_string()],
     };
     let body = render(&root, &[hostile]);
@@ -301,6 +303,7 @@ fn the_promotion_debt_section_is_always_rendered() {
         author: "someone".into(),
         draft: false,
         merged: false,
+        paths_unknown: false,
         changed_paths: vec!["crates/spark-server/src/scheduler/mod.rs".into()],
     }];
     let body = super::render(&root, &prs);
@@ -329,6 +332,7 @@ fn debt_is_derived_from_the_prs_own_paths() {
             author: "a".into(),
             draft: false,
             merged: false,
+            paths_unknown: false,
             changed_paths: vec!["docs/adr/README.md".into()],
         },
         super::PrFacts {
@@ -337,6 +341,7 @@ fn debt_is_derived_from_the_prs_own_paths() {
             author: "b".into(),
             draft: false,
             merged: false,
+            paths_unknown: false,
             changed_paths: vec!["crates/spark-server/src/scheduler/mod.rs".into()],
         },
     ];
@@ -365,6 +370,7 @@ fn the_debt_table_distinguishes_merged_from_open() {
             author: "a".into(),
             draft: false,
             merged: false,
+            paths_unknown: false,
             changed_paths: vec!["crates/spark-server/src/scheduler/mod.rs".into()],
         },
         super::PrFacts {
@@ -373,6 +379,7 @@ fn the_debt_table_distinguishes_merged_from_open() {
             author: "b".into(),
             draft: false,
             merged: true,
+            paths_unknown: false,
             changed_paths: vec!["crates/spark-server/src/scheduler/mod.rs".into()],
         },
     ];

--- a/crates/atlas-plugin/src/gate/telemetry_unknown_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_unknown_tests.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! A PR whose changed files could not be read must never render as a PR that
+//! changes nothing.
+//!
+//! The collector calls `pulls/N/files` once per PR. That call can fail — a
+//! 404 on a PR that vanished mid-run, a 502, a token that lost a scope — and
+//! it used to fall through to `changed_paths: []` with no warning. Everything
+//! downstream reads an empty list as a measurement: zero targets, zero owners,
+//! zero promotion debt, zero collisions, and first place in the merge order
+//! (fewest partners, fewest targets, smallest diff). An API error therefore
+//! published the single most reassuring record this view can produce, and did
+//! it into a comment on the tracking issue.
+//!
+//! These tests pin the opposite: unknown is maximal, and every row it produces
+//! says it is assumed.
+
+use super::*;
+
+fn repo_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace layout")
+        .to_path_buf()
+}
+
+fn blind(number: u64) -> PrFacts {
+    PrFacts {
+        number,
+        title: format!("pr {number}"),
+        author: "someone".into(),
+        draft: false,
+        merged: false,
+        // Exactly the shape the failure path produces: empty, but flagged.
+        changed_paths: Vec::new(),
+        paths_unknown: true,
+    }
+}
+
+fn known(number: u64, paths: &[&str]) -> PrFacts {
+    PrFacts {
+        number,
+        title: format!("pr {number}"),
+        author: "someone".into(),
+        draft: false,
+        merged: false,
+        changed_paths: paths.iter().map(|s| s.to_string()).collect(),
+        paths_unknown: false,
+    }
+}
+
+const FLAGSHIP: &str = "kernels/gb10/qwen3.6-27b/nvfp4/w4a4_gemm.cu";
+
+/// The load-bearing assertion: unknown paths are the MAXIMUM blast radius.
+/// Before the fix this view had `targets == {}` and `whole_repo == false`.
+#[test]
+fn an_unreadable_diff_re_opens_every_target_not_none() {
+    let root = repo_root();
+    let v = &views(&root, &[blind(1)])[0];
+    assert!(v.whole_repo, "unknown paths must be treated as whole-repo");
+    assert_eq!(
+        v.targets,
+        taxon::walk(&root).into_iter().collect::<BTreeSet<_>>(),
+        "an unreadable diff must re-open every target, not zero"
+    );
+    // An empty path list joins against no coverage table, so the debt is the
+    // whole candidate list, not the empty one an absent join would yield.
+    assert_eq!(
+        v.promotion_debt,
+        coverage::PROMOTION_CANDIDATES
+            .iter()
+            .map(|g| g.id)
+            .collect::<Vec<_>>(),
+        "unknown paths owe every promotion candidate"
+    );
+    // And a PR with genuinely no matching paths still owes nothing — the two
+    // cases must not have collapsed into one.
+    let clean = &views(&root, &[known(2, &["docs/adr/README.md"])])[0];
+    assert_eq!(clean.promotion_debt, Vec::<&str>::new());
+}
+
+/// Maximal radius is only honest if the reader can tell it is assumed. Every
+/// surface the unknown PR reaches must say so.
+#[test]
+fn the_comment_labels_every_assumed_row_as_assumed() {
+    let root = repo_root();
+    let body = render(&root, &[blind(7), known(8, &[FLAGSHIP])]);
+    assert!(
+        body.contains("⚠ **Changed files unavailable for #7.**"),
+        "the banner must name the affected PRs: {body}"
+    );
+    let row = body
+        .lines()
+        .find(|l| l.starts_with("| #7"))
+        .expect("the blind PR still has a row");
+    assert!(
+        row.contains("ALL — **assumed**, changed files unreadable"),
+        "the targets cell must not read as a measurement: {row}"
+    );
+    assert!(
+        row.contains("| unknown |"),
+        "no matched owner and no paths to match are different cells: {row}"
+    );
+    let debt = body
+        .lines()
+        .find(|l| l.starts_with("| #7 |"))
+        .expect("the blind PR appears in the debt table");
+    assert!(
+        debt.contains("**assumed** (paths unreadable)"),
+        "assumed debt must not be quoted as owed: {debt}"
+    );
+    // The readable PR's rows stay unqualified — the labelling is targeted, not
+    // a blanket disclaimer that would make every row equally unbelievable.
+    let good = body
+        .lines()
+        .find(|l| l.starts_with("| #8"))
+        .expect("the readable PR has a row");
+    assert!(!good.contains("assumed"), "{good}");
+}
+
+/// The worst single consequence of the old behaviour: an empty diff sorts to
+/// the FRONT of the merge order, so an API error published "merge next: #7".
+#[test]
+fn an_unreadable_diff_is_never_recommended_as_merge_next() {
+    let root = repo_root();
+    let vs = views(&root, &[blind(7), known(8, &[FLAGSHIP])]);
+    assert_eq!(
+        order::merge_order(&vs),
+        vec![8],
+        "an unrankable PR must not be ranked at all, least of all first"
+    );
+    let body = render(&root, &[blind(7), known(8, &[FLAGSHIP])]);
+    assert!(body.contains("**Merge next: #8**"), "{body}");
+    assert!(
+        body.contains("**Cannot rank #7:**"),
+        "exclusion from the order must be stated, not silent: {body}"
+    );
+}
+
+/// Dropping the record was the other candidate fix. It is not what we do, and
+/// the reason is testable: a blind PR must still appear in the collision table
+/// it may well be colliding with.
+#[test]
+fn a_blind_pr_still_collides_with_everything() {
+    let root = repo_root();
+    let vs = views(&root, &[blind(7), known(8, &[FLAGSHIP])]);
+    let c = collisions(&vs);
+    assert!(
+        !c.is_empty(),
+        "a maximal-radius PR contends with every gated PR"
+    );
+    for (target, prs) in &c {
+        assert!(prs.contains(&7), "#7 missing from `{target}`: {prs:?}");
+    }
+}
+
+/// When the ONLY open PR is blind, "nothing to order" would be false. The two
+/// empty-order cases must read differently.
+#[test]
+fn an_all_blind_run_does_not_claim_there_is_nothing_to_merge() {
+    let root = repo_root();
+    let body = render(&root, &[blind(7)]);
+    assert!(
+        !body.contains("Nothing to merge: no open, non-draft PRs."),
+        "there IS an open PR; the run just cannot see it: {body}"
+    );
+    assert!(body.contains("**No recommendation.**"), "{body}");
+    assert!(body.contains("came back unreadable"), "{body}");
+}
+
+/// The field is `#[serde(default)]`, so the collector's older records still
+/// parse — but a record that carries the flag must not lose it in transit.
+#[test]
+fn the_marker_survives_the_json_the_workflow_actually_writes() {
+    let facts: Vec<PrFacts> = serde_json::from_str(
+        r#"[{"number":7,"title":"t","author":"a","draft":false,"merged":false,
+             "changed_paths":[],"paths_unknown":true},
+            {"number":8,"title":"t","author":"a","draft":false,"merged":false,
+             "changed_paths":[]}]"#,
+    )
+    .expect("the workflow's shape parses");
+    assert!(facts[0].paths_unknown, "the flag must round-trip");
+    assert!(
+        !facts[1].paths_unknown,
+        "absent means known-and-empty, which is what pre-fix records mean"
+    );
+}

--- a/crates/atlas-plugin/src/gate/telemetry_unknown_tests.rs
+++ b/crates/atlas-plugin/src/gate/telemetry_unknown_tests.rs
@@ -102,6 +102,10 @@ fn the_comment_labels_every_assumed_row_as_assumed() {
         row.contains("| unknown |"),
         "no matched owner and no paths to match are different cells: {row}"
     );
+    assert!(
+        row.contains("unknown (changed files unreadable)"),
+        "\"host / non-kernel\" is a claim about a diff nobody read: {row}"
+    );
     let debt = body
         .lines()
         .find(|l| l.starts_with("| #7 |"))

--- a/crates/atlas-plugin/src/hardware/policy.rs
+++ b/crates/atlas-plugin/src/hardware/policy.rs
@@ -278,10 +278,18 @@ pub fn postcheck(
 ) -> Postcheck {
     let mut concerns = Vec::new();
     if let Some(f) = delta.thermal_throttle_fraction().filter(|f| *f > 0.0) {
-        concerns.push(format!(
-            "thermally throttled for {:.2}% of the run",
-            f * 100.0
-        ));
+        // A partial sum is a floor, never a figure. Printing it bare would put
+        // an understated percentage into the record, where it is quoted as the
+        // reason a speed number was accepted.
+        concerns.push(if delta.thermal_counters_complete() {
+            format!("thermally throttled for {:.2}% of the run", f * 100.0)
+        } else {
+            format!(
+                "thermally throttled for AT LEAST {:.2}% of the run — one or more throttle \
+                 counters were unreadable, so the true figure can only be higher",
+                f * 100.0
+            )
+        });
     }
     if let Some(d) = delta.hottest_chassis_delta_c {
         concerns.push(format!("hottest chassis zone moved {d:+.0} °C"));
@@ -295,12 +303,19 @@ pub fn postcheck(
     }
     let validity = match delta.thermal_throttle_advanced() {
         Some(true) => {
+            // ★ `unwrap_or(0)` here wrote "sw 0 µs" for a counter that was
+            // never read. This line lands in the record and is the text a
+            // human quotes when deciding how bad a throttle was; a counter
+            // nobody could read must not appear in it as a measured zero.
+            fn counter(v: Option<u64>) -> String {
+                v.map_or_else(|| "unreadable".to_string(), |us| format!("{us} µs"))
+            }
             concerns.push(format!(
-                "a thermal throttle counter advanced during the run (sw {} µs, hw {} µs, \
-                 brake {} µs) — this speed number is not comparable",
-                delta.sw_thermal_us.unwrap_or(0),
-                delta.hw_thermal_us.unwrap_or(0),
-                delta.hw_power_brake_us.unwrap_or(0),
+                "a thermal throttle counter advanced during the run (sw {}, hw {}, \
+                 brake {}) — this speed number is not comparable",
+                counter(delta.sw_thermal_us),
+                counter(delta.hw_thermal_us),
+                counter(delta.hw_power_brake_us),
             ));
             Validity::Invalid
         }

--- a/crates/atlas-plugin/src/hardware/policy_tests.rs
+++ b/crates/atlas-plugin/src/hardware/policy_tests.rs
@@ -384,3 +384,48 @@ fn the_registry_classifies_every_benchmark_the_incident_named() {
         let _: Sensitivity = d.sensitivity;
     }
 }
+
+/// ★ The record must not quote an understated throttle as a figure.
+///
+/// `hardware_state.postcheck.concerns` is persisted with the gate record and is
+/// the text a human reads when deciding whether a speed number is comparable.
+/// With one counter unreadable the percentage is a floor, and the counter list
+/// used to print `sw 0 µs` for a counter that was never read — a measured zero
+/// invented out of an absent reading, in the one paragraph whose job is to say
+/// how bad the throttle was.
+#[test]
+fn an_unreadable_counter_is_never_printed_as_a_measured_zero() {
+    let p = postcheck(
+        Sensitivity::Speed,
+        &delta(None, Some(12_000_000)),
+        options(),
+    );
+    assert_eq!(p.validity, Validity::Invalid);
+    let joined = p.concerns.join("\n");
+    assert!(
+        joined.contains("sw unreadable"),
+        "an unread counter must say so: {joined}"
+    );
+    assert!(
+        !joined.contains("sw 0 µs"),
+        "a never-read counter was recorded as a measured zero: {joined}"
+    );
+    assert!(
+        joined.contains("AT LEAST 1.73%"),
+        "a partial sum is a floor, not a figure: {joined}"
+    );
+    // The complete case keeps the plain wording, so the hedge is information
+    // rather than boilerplate on every record.
+    let full = postcheck(
+        Sensitivity::Speed,
+        &delta(Some(0), Some(12_000_000)),
+        options(),
+    );
+    let full = full.concerns.join("\n");
+    assert!(full.contains("throttled for 1.73% of the run"), "{full}");
+    assert!(!full.contains("AT LEAST"), "{full}");
+    assert!(
+        full.contains("sw 0 µs"),
+        "a real zero still reads as zero: {full}"
+    );
+}

--- a/crates/atlas-plugin/src/hardware/state.rs
+++ b/crates/atlas-plugin/src/hardware/state.rs
@@ -357,12 +357,42 @@ impl HardwareStateDelta {
             .then_some(false)
     }
 
+    /// True when every counter [`Self::thermal_throttle_fraction`] sums was
+    /// readable on BOTH captures.
+    ///
+    /// When false the fraction is a lower bound, and the caller must say so:
+    /// an unreadable counter contributes nothing to the sum, which moves the
+    /// answer in the reassuring direction.
+    pub fn thermal_counters_complete(&self) -> bool {
+        self.sw_thermal_us.is_some()
+            && self.hw_thermal_us.is_some()
+            && self.hw_power_brake_us.is_some()
+    }
+
     /// The throttled fraction of the run, for the record's summary line.
+    ///
+    /// `None` when the run has no measured duration, or when NOT ONE thermal
+    /// counter was readable across both captures. A LOWER BOUND when only some
+    /// were — see [`Self::thermal_counters_complete`].
+    ///
+    /// ★ This used to be `unwrap_or(0)` over all three counters, which is the
+    /// same mistake [`Self::thermal_throttle_advanced`] exists to avoid one
+    /// method up: an unreadable counter became a measured zero. With nothing
+    /// readable it returned `Some(0.0)` — "this run did not throttle" — from a
+    /// box that reported nothing at all, and that sentence is persisted in the
+    /// record's `hardware_state.postcheck.concerns` and quoted later as
+    /// evidence that a speed number is comparable.
     pub fn thermal_throttle_fraction(&self) -> Option<f64> {
         let secs = self.elapsed_s.filter(|s| *s > 0)? as f64;
-        let us = self.sw_thermal_us.unwrap_or(0)
-            + self.hw_thermal_us.unwrap_or(0)
-            + self.hw_power_brake_us.unwrap_or(0);
+        let counters = [
+            self.sw_thermal_us,
+            self.hw_thermal_us,
+            self.hw_power_brake_us,
+        ];
+        if counters.iter().all(Option::is_none) {
+            return None;
+        }
+        let us: u64 = counters.into_iter().flatten().sum();
         Some(us as f64 / 1e6 / secs)
     }
 }

--- a/crates/atlas-plugin/src/hardware/state_tests.rs
+++ b/crates/atlas-plugin/src/hardware/state_tests.rs
@@ -252,3 +252,52 @@ fn one_line_names_the_box_and_says_when_something_is_unknown() {
     let blind = HardwareState::default().one_line();
     assert!(blind.contains("foreign gpu proc unknown"), "{blind}");
 }
+
+/// ★ A sum over three unreadable counters is not zero throttling.
+///
+/// The fraction used to be `unwrap_or(0)` across all three, so a box that
+/// reported no counter at all produced `Some(0.0)` — the same number a
+/// genuinely cool run produces, and the number the postcheck's summary line is
+/// built from. Compare `thermal_throttle_advanced` directly above it, which
+/// has always answered `None` for exactly this input.
+#[test]
+fn a_fraction_over_no_readable_counter_is_unknown_not_zero() {
+    let d = HardwareStateDelta {
+        elapsed_s: Some(692),
+        sw_thermal_us: None,
+        hw_thermal_us: None,
+        hw_power_brake_us: None,
+        ..HardwareStateDelta::default()
+    };
+    assert_eq!(d.thermal_throttle_advanced(), None);
+    assert_eq!(d.thermal_throttle_fraction(), None);
+    assert!(!d.thermal_counters_complete());
+}
+
+/// A PARTIAL sum is still worth reporting — it is a floor — but it must be
+/// flagged as one, because every unreadable counter moves it downwards.
+#[test]
+fn a_partial_sum_is_a_floor_and_says_so() {
+    let d = HardwareStateDelta {
+        elapsed_s: Some(692),
+        sw_thermal_us: None,
+        hw_thermal_us: Some(12_000_000),
+        hw_power_brake_us: Some(0),
+        ..HardwareStateDelta::default()
+    };
+    let f = d
+        .thermal_throttle_fraction()
+        .expect("one counter was readable");
+    assert!(
+        (f - 12.0 / 692.0).abs() < 1e-9,
+        "the readable counter counts"
+    );
+    assert!(
+        !d.thermal_counters_complete(),
+        "an unreadable counter must not pass as a complete sum"
+    );
+    // And the fully-readable case is NOT flagged, so the label discriminates.
+    let mut full = d.clone();
+    full.sw_thermal_us = Some(0);
+    assert!(full.thermal_counters_complete());
+}

--- a/crates/spark-runtime/src/metal_backend/tests.rs
+++ b/crates/spark-runtime/src/metal_backend/tests.rs
@@ -8,6 +8,11 @@
 
 mod helpers;
 
+// Runs before any parity module can matter: it refuses a build that
+// embedded no metallibs at all, which is the state every one of them
+// silently reports `Metal: unknown module` from.
+mod embedded_kernels;
+
 mod parity_asym;
 mod parity_attention;
 mod parity_attention_full;

--- a/crates/spark-runtime/src/metal_backend/tests/embedded_kernels.rs
+++ b/crates/spark-runtime/src/metal_backend/tests/embedded_kernels.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! The anti-vacuity guard for the whole `metal_backend` parity suite.
+//!
+//! Every other test in this suite calls `helpers::maybe_backend()`, which
+//! hands `atlas_kernels::metallib_modules()` to `MetalGpuBackend::new`. That
+//! constructor loads one `MTLLibrary` per entry -- and an EMPTY slice is not
+//! an error to it: it succeeds with a zero-entry library cache, and the
+//! failure only surfaces later, once per test, as
+//! `Metal: unknown module '<name>'`.
+//!
+//! That is exactly what shipped. atlas-kernels' `build.rs` honours
+//! `ATLAS_SKIP_BUILD` before anything else and emits a stub whose
+//! `metallib_modules()` is `Vec::new()`; `ci.yml` sets `ATLAS_SKIP_BUILD: "1"`
+//! at WORKFLOW level so the ubuntu jobs can type-check without nvcc, and the
+//! macOS job inherited it. The required context
+//! `cargo test --features metal (macOS aarch64)` was therefore red on every
+//! non-web PR, reporting on the stub rather than on the kernels -- a verdict
+//! that was not about the thing it claimed to test.
+//!
+//! This test states the suite's precondition as a first-class assertion, so
+//! the answer to "did the kernels get built?" is ONE named failure instead of
+//! 35 lookup failures, and so the suite can never again be run against a build
+//! that embedded nothing. It deliberately has no skip path: a skip here would
+//! reintroduce the hole it exists to close.
+
+/// The parity suite is meaningless without embedded metallibs. Refuse.
+#[test]
+fn embedded_metallib_set_is_not_empty() {
+    let modules = atlas_kernels::metallib_modules();
+    assert!(
+        !modules.is_empty(),
+        "atlas_kernels::metallib_modules() is empty -- no Metal kernels were \
+         compiled into this binary, so every parity test below would fail with \
+         `Metal: unknown module`, and a suite that cannot reach a kernel cannot \
+         report on one.\n\
+         \n\
+         Cause: atlas-kernels/build.rs took its skip branch. Either \
+         ATLAS_SKIP_BUILD is set to 1/true, or the build is on macOS with no \
+         ATLAS_TARGET_HW set (the auto-skip).\n\
+         \n\
+         Build the kernels instead of skipping them:\n\
+         \x20 ATLAS_SKIP_BUILD=0 ATLAS_TARGET_HW=metal \\\n\
+         \x20 ATLAS_TARGET_MODEL=qwen3-5-4b-vlm-mlx-int8 ATLAS_TARGET_QUANT=mlx_int8 \\\n\
+         \x20 cargo test -p spark-runtime --no-default-features --features metal metal_backend"
+    );
+}

--- a/crates/spark-server/src/api/compact.rs
+++ b/crates/spark-server/src/api/compact.rs
@@ -171,6 +171,21 @@ pub fn compact_messages(
     result
 }
 
+/// The SSE `data:` payload for a mid-stream error on the legacy
+/// `/v1/completions` stream.
+///
+/// Built with `serde_json`, NOT `format!`: `message` is an arbitrary
+/// runtime string — an anyhow `{e:#}` chain, a tokenizer or CUDA
+/// diagnostic, a file path — and interpolating one into a JSON literal
+/// emits a MALFORMED frame the moment it contains a `"`, a `\` or a
+/// newline. The client then reports a parse error instead of the reason
+/// its request died, which is strictly worse than the generic error it
+/// replaced. The envelope shape (`{"error": "<text>"}`) is unchanged;
+/// only the encoding is.
+pub(super) fn completion_error_frame(message: &str) -> String {
+    serde_json::json!({ "error": message }).to_string()
+}
+
 pub(super) fn openai_error_response(status: StatusCode, message: String) -> Response {
     openai_error_response_with_param(status, message, None, None)
 }

--- a/crates/spark-server/src/api/completions.rs
+++ b/crates/spark-server/src/api/completions.rs
@@ -465,9 +465,9 @@ pub(super) async fn completions_stream(
                     )]
                 }
             }
-            StreamEvent::Error(msg) => {
-                vec![Ok(Event::default().data(format!(r#"{{"error":"{msg}"}}"#)))]
-            }
+            StreamEvent::Error(msg) => vec![Ok(
+                Event::default().data(super::compact::completion_error_frame(&msg))
+            )],
         };
         futures::stream::iter(events)
     });

--- a/crates/spark-server/src/api/tests/error_frames.rs
+++ b/crates/spark-server/src/api/tests/error_frames.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The mid-stream error frame on the legacy `/v1/completions` SSE stream.
+//!
+//! The frame is the ONLY way a streaming client learns why its request
+//! died: the stream carries HTTP 200, so a malformed frame is not a
+//! degraded error message, it is no error message at all — the client's
+//! JSON parser raises on the frame and the real reason never surfaces.
+
+use crate::api::compact::completion_error_frame;
+
+/// Messages that actually reach this frame: `send_error_to_sink` forwards
+/// anyhow `{e:#}` chains verbatim, and those routinely quote a path, a
+/// token or an inner error.
+const HOSTILE: &[&str] = &[
+    r#"swap-in failed: open "/var/spill/swap_7.bin": No such file"#,
+    "prefill failed: CUDA error\nlaunch failed",
+    r"grammar compile failed near \x00",
+    r#"tool "bash" rejected: unbalanced """#,
+];
+
+#[test]
+fn an_error_message_survives_the_frame_as_parseable_json() {
+    for msg in HOSTILE {
+        let frame = completion_error_frame(msg);
+        let v: serde_json::Value = serde_json::from_str(&frame).unwrap_or_else(|e| {
+            panic!("frame for {msg:?} must be JSON a client can parse, got {frame:?}: {e}")
+        });
+        // Parseable is not enough — the reason has to arrive intact.
+        assert_eq!(
+            v.get("error").and_then(|e| e.as_str()),
+            Some(*msg),
+            "frame must round-trip the reason verbatim: {frame}"
+        );
+    }
+}
+
+#[test]
+fn the_wire_shape_is_unchanged_for_an_ordinary_message() {
+    // Pins the envelope: this fix changes the ENCODING, not the contract
+    // every existing client already parses.
+    assert_eq!(
+        completion_error_frame("Scheduler queue closed"),
+        r#"{"error":"Scheduler queue closed"}"#
+    );
+}

--- a/crates/spark-server/src/api/tests/mod.rs
+++ b/crates/spark-server/src/api/tests/mod.rs
@@ -5,6 +5,7 @@
 //! - `harness`   — whole-stream driver for the content sanitizer
 //! - `sanitizer` — orphan tool-call fragments must not reach the client
 //! - `envelope`  — F73: inner tags inside a sanctioned envelope must
+//! - `error_frames` — a streaming error must reach the client as JSON
 //! - `watchdog`  — repetition guard: fires on real loops, not on prose
 //! - `health_fault` — #429: readiness must fail on a dead CUDA context
 //! - `model_advertise` — /v1/models must report the ceiling admission enforces
@@ -15,6 +16,7 @@
 //! reminders any more.
 
 mod envelope;
+mod error_frames;
 mod harness;
 mod health_fault;
 mod model_advertise;

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -307,22 +307,64 @@ pub fn swap_out_sequence(
     }
 }
 
+/// Refill an already-claimed slot from the swap image on disk.
+///
+/// Split out so the caller has exactly ONE error path to notify the
+/// client on, and so a failure leaves the slot in the caller's hands to
+/// release: `SequenceState`'s guard returns the SSM slot, but the KV
+/// blocks `restore_sequence_state` allocated are the model's and only
+/// `free_sequence` gives them back.
+fn refill_from_image(
+    model: &dyn Model,
+    s: &SwappedSeq,
+    spill: &mut KvSpillManager,
+    seq: &mut SequenceState,
+) -> Result<()> {
+    let mut reader = spill.open_file(s.swap_id)?;
+    model.restore_sequence_state(seq, s.num_blocks, &mut reader)?;
+    drop(reader);
+    spill.remove_file(s.swap_id)?;
+    Ok(())
+}
+
 /// Resume a swapped-out sequence by restoring its state from disk.
 pub fn resume_swapped_seq(
     _think_end_token: Option<u32>,
     _think_start_token: Option<u32>,
     model: &dyn Model,
-    s: SwappedSeq,
+    mut s: SwappedSeq,
     spill: &mut KvSpillManager,
 ) -> Result<ActiveSeq> {
     // Starvation guard: a just-resumed sequence must not be the next KV
     // victim before it makes real progress (see `preempt` module docs).
     let immune_until = s.output_tokens.len() + super::preempt::PREEMPT_IMMUNITY_TOKENS;
-    let mut seq = model.alloc_sequence()?;
-    let mut reader = spill.open_file(s.swap_id)?;
-    model.restore_sequence_state(&mut seq, s.num_blocks, &mut reader)?;
-    drop(reader);
-    spill.remove_file(s.swap_id)?;
+    // Every step of the restore is fallible, and `s.sink` is the ONLY
+    // handle to the request still waiting on it. A bare `?` dropped it:
+    // the caller logged `Swap-in failed: …` and the client's channel just
+    // closed — reported by the API layer as the generic "Inference
+    // cancelled", or, streaming, as a stream that stops mid-response.
+    // The swap-OUT half was already fixed for exactly this; this is the
+    // same contract on the way back in.
+    let restored = model.alloc_sequence().and_then(|mut seq| {
+        match refill_from_image(model, &s, spill, &mut seq) {
+            Ok(()) => Ok(seq),
+            Err(e) => {
+                if let Err(free_err) = model.free_sequence(&mut seq) {
+                    tracing::error!(
+                        "resume_swapped_seq: free after a failed restore: {free_err:#}"
+                    );
+                }
+                Err(e)
+            }
+        }
+    });
+    let mut seq = match restored {
+        Ok(seq) => seq,
+        Err(e) => {
+            send_error_to_sink(&mut s.sink, &format!("swap-in failed: {e:#}"));
+            return Err(e);
+        }
+    };
 
     // Restore CPU-side metadata.
     seq.tokens = s.tokens;

--- a/crates/spark-server/src/scheduler/lifecycle_tests.rs
+++ b/crates/spark-server/src/scheduler/lifecycle_tests.rs
@@ -179,7 +179,13 @@ fn empty_output_edges() {
 /// Minimal `Model`: only the paths `finish_sequence` exercises
 /// (`cache_sequence`, `free_sequence`, `ep_broadcast_cmd_for_seq`
 /// default) are live; everything else is unreachable in these tests.
-struct StubModel;
+#[derive(Default)]
+pub(super) struct StubModel {
+    /// Slots handed to `free_sequence`. Lets a sibling test prove that a
+    /// failing path released what it had already allocated instead of
+    /// leaking it (see `swap_resume_tests`).
+    pub(super) freed: std::sync::Mutex<Vec<usize>>,
+}
 
 impl Model for StubModel {
     fn prefill(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
@@ -305,7 +311,13 @@ impl Model for StubModel {
         anyhow::bail!("unused in lifecycle tests")
     }
     fn cache_sequence(&self, _s: &SequenceState) {}
-    fn free_sequence(&self, _s: &mut SequenceState) -> Result<()> {
+    fn free_sequence(&self, s: &mut SequenceState) -> Result<()> {
+        self.freed.lock().expect("stub freed list").push(s.slot_idx);
+        Ok(())
+    }
+    /// A swap image the spill manager can actually write and re-open.
+    fn save_sequence_state(&self, _s: &SequenceState, w: &mut dyn std::io::Write) -> Result<()> {
+        w.write_all(&[0u8; 8])?;
         Ok(())
     }
     fn compact_sequence(&self, _s: &mut SequenceState, _slot: usize) -> Result<()> {
@@ -417,7 +429,7 @@ fn test_seq(
 }
 
 fn finish_and_recv(mut a: ActiveSeq, mut rx: RespRx) -> InferenceResponse {
-    finish_sequence(&StubModel, &mut a, MAX_SEQ_LEN);
+    finish_sequence(&StubModel::default(), &mut a, MAX_SEQ_LEN);
     rx.try_recv()
         .expect("finish_sequence must send the blocking response")
         .expect("response must be Ok")

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -61,6 +61,8 @@ mod spec_capacity;
 pub mod spec_stats;
 mod spec_step;
 mod ssm_decode_ring;
+#[cfg(test)]
+mod swap_resume_tests;
 mod teardown;
 #[cfg(test)]
 mod test_support;

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -56,6 +56,9 @@ mod repetition;
 mod rollback;
 mod sample_step;
 pub mod sched_ctx;
+mod shutdown_drain;
+#[cfg(test)]
+mod shutdown_drain_tests;
 pub mod snapshot;
 mod spec_capacity;
 pub mod spec_stats;
@@ -1103,22 +1106,13 @@ pub fn run(
     for mut a in active {
         finish_sequence(&*model, &mut a, sched.limits.max_seq_len);
     }
-    if let Some(ref mut spill) = spill_manager {
-        for s in swapped {
-            let _ = spill.remove_file(s.swap_id);
-        }
-    }
-    for mut p in preempted {
-        send_error_to_sink(
-            &mut p.a.sink,
-            "server shutting down before preempted resume",
-        );
-    }
-    for p in prefilling {
-        let mut seq = p.seq;
-        let _ = model.free_sequence(&mut seq);
-        let _ = model.ep_broadcast_cmd_for_seq(seq.slot_idx as u32, 0xFFFFFFF1);
-    }
+    shutdown_drain::abort_in_flight_on_shutdown(
+        &*model,
+        prefilling,
+        swapped,
+        preempted,
+        spill_manager.as_mut(),
+    );
     // Shutdown applies to every slot the worker has; seq_id is ignored.
     let _ = model.ep_broadcast_cmd_for_seq(0, 0xFFFFFFFF);
 

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -52,6 +52,8 @@ mod preempt_tests;
 mod prefill_a_step;
 mod prefill_a_step_params;
 mod prefill_b_step;
+#[cfg(test)]
+mod prefill_fifo_tests;
 mod repetition;
 mod rollback;
 mod sample_step;

--- a/crates/spark-server/src/scheduler/mtp_dcut.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut.rs
@@ -56,6 +56,12 @@ const BUCKETS: [f32; 4] = [0.25, 0.5, 0.75, 1.0];
 // lock-step. 96 -> 160 with the DFlash n=20 × k=8 widening.
 pub(super) const VERIFY_ROW_BUDGET: usize = 160;
 
+/// Widest verify batch in SEQUENCES that the model can accept — the batched
+/// verify's hidden stash slot count, which `can_batch_verify` enforces as
+/// `(2..=VERIFY_WY_TABLE_SEQS).contains(&n)`. Read from the model crate, not
+/// restated, so the chunker tracks the stash if it is ever resized.
+pub(super) const WIDTH_CAP: usize = spark_model::layer::VERIFY_WY_TABLE_SEQS;
+
 /// Widest verify batch (SEQUENCES, not rows) D-Cut may prune —
 /// the D-Cut-at-depth policy. Value-parsed from `ATLAS_MTP_DCUT_MAX_SEQS`
 /// once per process (0 disables pruning entirely; `ATLAS_NO_MTP_DCUT` also
@@ -288,12 +294,27 @@ pub(super) fn plan(
 
 /// Split a batch into verify chunks: `[lo, hi)` index ranges over `ks`.
 ///
-/// ONE cap: the row-buffer bound (`VERIFY_ROW_BUDGET` = 160) — the audited
-/// verify envelope (meta gaps / logits rows / bt staging, sizes.rs). The
-/// sequence-count cap is DERIVED from it per chunk (`budget / widest rows`:
-/// rows=4 → 24 seqs, rows=3 → 32 = the 32:2 shape in one chunk, rows=2 → 48;
-/// `can_batch_verify` separately bounds n at 32 = `VERIFY_WY_TABLE_SEQS`), no
-/// longer a hardcoded 8 for the deep widths. The old 8 was stale from the
+/// TWO caps, because `can_batch_verify` enforces two:
+/// * the row-buffer bound (`VERIFY_ROW_BUDGET` = 160) — the audited verify
+///   envelope (meta gaps / logits rows / bt staging, sizes.rs), from which a
+///   per-chunk sequence cap is DERIVED (`budget / widest rows`: rows=4 → 40
+///   seqs, rows=3 → 53, rows=2 → 80), no longer a hardcoded 8 for the deep
+///   widths;
+/// * the WIDTH bound `VERIFY_WY_TABLE_SEQS` = 32 — the batched verify's
+///   hidden stash has exactly 32 slots, so `can_batch_verify` admits only
+///   `(2..=32).contains(&n)`.
+///
+/// ★ The width bound used to be omitted here, on the reasoning that "n is
+/// separately bounded at 32" by the dispatch cap. It is — by
+/// `speculative::mtp_max_seqs()`, whose DEFAULT is 32 but which is an
+/// operator value (`ATLAS_MTP_MAX_SEQS`), and by nothing else. Raise it and
+/// the row-derived cap lets a chunk reach 40/53/80 sequences; every such
+/// chunk is refused WHOLESALE by the `can_batch_verify` gate in `mtp_step`
+/// and falls to the per-seq verify loop — one weight sweep PER SEQUENCE.
+/// That is the same "stale cap silently serializes the batch" artifact this
+/// function was written to close (the hardcoded 8), closed for ROWS and left
+/// open for WIDTH. Deriving BOTH caps here means a chunk this function emits
+/// is always one the model will actually batch. The old 8 was stale from the
 /// 32-row budget era and SILENTLY SERIALIZED any depth shape above n=8 into
 /// 8-wide verify chunks (double weight reads per step): a 2026-07-30 fixer-r2
 /// leg with `ATLAS_MTP_K_LADDER=..,16:2,..` measured 127-135 tok/s at C=16 vs
@@ -312,8 +333,9 @@ pub(super) fn chunk_ranges(ks: &[usize]) -> Vec<(usize, usize)> {
     let mut lo = 0usize;
     while lo < ks.len() {
         // Derived, not hardcoded: rows <= 4 is ensured by the ladder clamp,
-        // so the division is well-defined and >= 24.
-        let seq_cap = VERIFY_ROW_BUDGET / ks[lo].max(1);
+        // so the division is well-defined and >= 40. Clamped by the verify
+        // stash width so the chunk is one `can_batch_verify` will accept.
+        let seq_cap = (VERIFY_ROW_BUDGET / ks[lo].max(1)).min(WIDTH_CAP);
         let mut hi = lo;
         let mut r = 0usize;
         while hi < ks.len() && hi - lo < seq_cap && r + ks[hi] <= VERIFY_ROW_BUDGET {

--- a/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
+++ b/crates/spark-server/src/scheduler/mtp_dcut_tests.rs
@@ -76,23 +76,30 @@ fn chunk_ranges_reproduce_the_uniform_caps() {
 #[test]
 fn chunk_ranges_seq_cap_derives_from_the_row_budget() {
     // Depth above n=8 (env-ladder / ragged-D-Cut shapes) is no longer
-    // serialized into 8-wide chunks: the row budget is the only bound. The
-    // split points are derived from VERIFY_ROW_BUDGET (160) so this test
-    // states the boundary arithmetic, not a frozen budget value.
-    // rows=3: 160/3 = 53 seqs — everything up to 53 is ONE chunk.
+    // serialized into 8-wide chunks. Two bounds apply, and the chunk is the
+    // MIN of them: the row budget (VERIFY_ROW_BUDGET = 160, giving 53 seqs
+    // at rows=3, 40 at rows=4, 80 at rows=2) and the verify stash width
+    // (VERIFY_WY_TABLE_SEQS = 32). Both are read from their SSOT below, so
+    // this test states the boundary arithmetic and not frozen values.
+    const W: usize = spark_model::layer::VERIFY_WY_TABLE_SEQS; // 32
+    // rows=3: the row budget would allow 53, the stash allows 32.
     assert_eq!(chunk_ranges(&[3; 21]), vec![(0, 21)]);
-    assert_eq!(chunk_ranges(&[3; 33]), vec![(0, 33)]);
-    assert_eq!(chunk_ranges(&[3; 53]), vec![(0, 53)]);
-    assert_eq!(chunk_ranges(&[3; 54]), vec![(0, 53), (53, 54)]);
-    // rows=4: 160/4 = 40 seqs.
+    assert_eq!(chunk_ranges(&[3; W]), vec![(0, W)]);
+    // Past the stash the chunker SPLITS rather than emitting a chunk the
+    // model refuses (it previously returned a single (0,33) / (0,53)).
+    assert_eq!(chunk_ranges(&[3; 33]), vec![(0, W), (W, 33)]);
+    assert_eq!(chunk_ranges(&[3; 53]), vec![(0, W), (W, 53)]);
+    // rows=4: row budget 40, stash 32.
     assert_eq!(chunk_ranges(&[4; 9]), vec![(0, 9)]);
-    assert_eq!(chunk_ranges(&[4; 40]), vec![(0, 40)]);
-    assert_eq!(chunk_ranges(&[4; 41]), vec![(0, 40), (40, 41)]);
-    // rows=2: 160/2 = 80 seqs.
-    assert_eq!(chunk_ranges(&[2; 80]), vec![(0, 80)]);
-    assert_eq!(chunk_ranges(&[2; 81]), vec![(0, 80), (80, 81)]);
+    assert_eq!(chunk_ranges(&[4; 40]), vec![(0, W), (W, 40)]);
+    // rows=2: row budget 80, stash 32.
+    assert_eq!(chunk_ranges(&[2; 80]), vec![(0, W), (W, 64), (64, 80)]);
     // rows=3 with 10 seqs (the old (0,8),(8,10) split): one chunk now.
     assert_eq!(chunk_ranges(&[3; 10]), vec![(0, 10)]);
+    // The row budget still binds where it is TIGHTER than the stash: at
+    // rows=8 (the DFlash uniform K=γ+1 shape) 160/8 = 20 < 32, so 20 wins.
+    assert_eq!(chunk_ranges(&[8; 20]), vec![(0, 20)]);
+    assert_eq!(chunk_ranges(&[8; 21]), vec![(0, 20), (20, 21)]);
 }
 
 #[test]
@@ -250,4 +257,66 @@ fn below_the_gate_the_pairing_is_legacy_but_the_pruning_is_kept() {
     assert_eq!(c_paired, vec![(0, 4), (5, 3)]);
     assert_ne!(c_paired, paired);
     assert_eq!(c_depths.iter().sum::<usize>(), 7);
+}
+
+// ── Width bound: the chunker's OTHER cap ───────────────────────────────────
+//
+// `chunk_ranges` derives its per-chunk sequence cap from the ROW budget
+// alone (`VERIFY_ROW_BUDGET / ks[lo]`), which at the shallow rungs is 40
+// (rows=4), 53 (rows=3) and 80 (rows=2) sequences. But `can_batch_verify`
+// enforces a SECOND, independent bound the chunker never consulted:
+// `(2..=VERIFY_WY_TABLE_SEQS).contains(&n)`, i.e. n <= 32, because the
+// batched verify's hidden stash has exactly 32 slots.
+//
+// A chunk wider than 32 is therefore refused WHOLESALE by the
+// `chunk.len() >= 2 && model.can_batch_verify(chunk_ks)` gate in
+// `mtp_step`, and every sequence in it falls back to the per-seq verify
+// loop — one weight sweep PER SEQUENCE instead of one per chunk. That is
+// the exact "stale cap silently serializes the batch" artifact class the
+// module doc says was closed when the cap stopped being a hardcoded 8; it
+// was closed for ROWS and left open for WIDTH.
+#[test]
+fn chunk_ranges_never_exceed_the_verify_width_bound() {
+    // The hard bound `can_batch_verify` enforces, read from the model crate
+    // rather than restated, so this test tracks the stash if it is resized.
+    const WIDTH_CAP: usize = spark_model::layer::VERIFY_WY_TABLE_SEQS;
+    // Every rung depth, at widths that span the row-derived caps (40/53/80).
+    for rows in 2..=4usize {
+        for n in 2..=96usize {
+            let ks = vec![rows; n];
+            for (lo, hi) in chunk_ranges(&ks) {
+                assert!(
+                    hi - lo <= WIDTH_CAP,
+                    "rows={rows} n={n}: chunk ({lo},{hi}) is {} sequences wide, \
+                     above the {WIDTH_CAP}-slot verify stash — can_batch_verify \
+                     refuses it and the whole chunk serializes",
+                    hi - lo
+                );
+            }
+        }
+    }
+}
+
+// Ragged (D-Cut) shapes must obey the width bound too: the cap is taken
+// from `ks[lo]`, the chunk's DEEPEST row count, so a chunk that starts deep
+// and continues shallow gets the deep cap while admitting shallow rows.
+#[test]
+fn ragged_chunks_also_respect_the_width_bound() {
+    // Deepest-first, as the caller guarantees: 4 deep rows then a long
+    // shallow tail. seq_cap is 160/4 = 40, so the shallow tail is admitted
+    // well past the 32-slot stash.
+    let mut ks = vec![4usize; 4];
+    ks.extend(std::iter::repeat_n(2usize, 60));
+    for (lo, hi) in chunk_ranges(&ks) {
+        assert!(
+            hi - lo <= spark_model::layer::VERIFY_WY_TABLE_SEQS,
+            "ragged chunk ({lo},{hi}) is {} wide",
+            hi - lo
+        );
+        // The row budget must still hold — the width clamp adds a bound, it
+        // does not relax the existing one.
+        let r: usize = ks[lo..hi].iter().sum();
+        assert!(r <= VERIFY_ROW_BUDGET, "rows={r}");
+        assert!(hi > lo, "empty range");
+    }
 }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -29,6 +29,7 @@ mod run_batched_mixed;
 mod run_batched_prefill;
 #[path = "phase_continue_prefills/run_standard.rs"]
 mod run_standard;
+mod spec_mixing;
 
 use std::time::Instant;
 
@@ -42,6 +43,7 @@ use crate::scheduling_policy::{ActiveSeqTiming, SchedulingPolicy};
 use run_batched_mixed::run_batched_mixed_step;
 use run_batched_prefill::run_batched_prefill_step;
 use run_standard::run_standard_chunk_loop;
+use spec_mixing::mixing_blocked_by_spec;
 
 /// Shared per-chunk InnerQ poll used by every prefill path (standard /
 /// batched-prefill / batched-mixed). `maybe_finalize` is idempotent post
@@ -90,12 +92,16 @@ pub(super) fn continue_in_progress_prefills(
         })
         .collect();
 
-    // single_active_with_spec: active.len()==1 AND a speculative path is
-    // active (those step_* paths require active.len()==1 and mixing would
-    // double-decode). Computed early because the always-mixed gate below
-    // needs it too. (Also reused by the Q12 mixed-batch gate further down.)
-    let single_active_with_spec =
-        active.len() == 1 && (use_mtp || use_self_speculative || use_ngram_speculative);
+    // Does an in-flight speculative step forbid fusing a prefill chunk into
+    // decode this tick? ONE home for the rule (`spec_mixing`), which also
+    // records the range over which it disagrees with the scheduler's real
+    // MTP dispatch gate — read that module before touching this.
+    // Computed early because the always-mixed gate below needs it too, and
+    // it is reused by the Q12 mixed-batch gate further down.
+    let single_active_with_spec = mixing_blocked_by_spec(
+        active.len(),
+        use_mtp || use_self_speculative || use_ngram_speculative,
+    );
 
     // ── Step 2 (spec): always-on fused mixed step ──
     //
@@ -184,11 +190,11 @@ pub(super) fn continue_in_progress_prefills(
     // loops); Q12 Phase 2/3 replace with kernel-level batched dispatch.
     //
     // Gates: N≥2 prefilling, no EP (worker opcode pending, Phase 6),
-    // and for mixed-batch only: skip if active.len()==1 AND a speculative
-    // path is active (those step_* paths require active.len()==1 and
-    // mixing would double-decode). Spec is off by construction when
-    // active.len() ≥ 2, so the mixed branch is safe there.
-    // (`single_active_with_spec` computed near the top — reused here.)
+    // and for mixed-batch only: `single_active_with_spec` (computed near the
+    // top from `spec_mixing::mixing_blocked_by_spec`). NOTE: spec is NOT off
+    // by construction at active.len() >= 2 — the MTP dispatch cap is 32, not
+    // 1 — so this branch does run under a live speculative regime; see the
+    // `spec_mixing` module doc for what that costs and why it stands.
     // BISECT: ATLAS_BISECT_Q12_DISABLE=1 forces the per-stream FIFO path
     // (pre-Q12 behavior) so we can isolate whether the chunked-prefill +
     // concurrent-decode crash originates in the Q12 batched-prefill

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -103,19 +103,22 @@ pub(super) fn run_standard_chunk_loop(
         .unwrap_or(false);
     // The spec gate here used to be the process-GLOBAL flags (`!use_mtp && ...`),
     // which meant a `--speculative` serve could NEVER fuse prefill with decode —
-    // at any concurrency. But speculative execution is per-STEP: the scheduler
-    // only runs a spec step when `active.len() == 1` (mod.rs:511/516/520);
-    // at C>=2 every sequence is on plain batched decode anyway, so fusing is
-    // exactly as safe as it is for a non-speculative serve. The correct
-    // predicate is "a spec step would run this tick", i.e. the same
-    // `single_active_with_spec` shape phase_continue_prefills.rs computes.
+    // at any concurrency. Speculative execution is per-STEP, so the predicate
+    // became "a spec step would run this tick".
     //
-    // Without this, one 8K prefill chunk froze every active decoder for the
+    // Without that, one 8K prefill chunk froze every active decoder for the
     // whole chunk (mixed_forward never fired in any --speculative production
     // config) — the single largest scheduler-level concurrency gap found by
     // the 2026-07-25 architecture map.
+    //
+    // ★ The rule now has ONE home, `super::spec_mixing`, because the
+    // justification it used to carry here ("the scheduler only runs a spec
+    // step when active.len() == 1") is STALE: the MTP dispatch cap is 32.
+    // Read that module's doc — it names the width range where this predicate
+    // and the real dispatch gate disagree, and what the disagreement costs —
+    // before changing this line.
     let any_spec = use_mtp || use_self_speculative || use_ngram_speculative;
-    let spec_step_this_tick = active.len() == 1 && any_spec;
+    let spec_step_this_tick = super::spec_mixing::mixing_blocked_by_spec(active.len(), any_spec);
     let can_mix = !no_mix_bisect && !active.is_empty() && !model.is_ep() && !spec_step_this_tick;
 
     if can_mix {

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/spec_mixing.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/spec_mixing.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Whether a speculative step blocks fusing a prefill chunk into decode.
+//!
+//! SSOT for a predicate that had THREE copies (`phase_continue_prefills`'s
+//! `single_active_with_spec`, reused by the always-mixed gate and the Q12
+//! mixed-batch gate, and `run_standard`'s `spec_step_this_tick`), each
+//! carrying the same justification comment.
+//!
+//! # ★ The premise those comments state is no longer true
+//!
+//! All three read, in substance: *"those `step_*` paths require
+//! `active.len() == 1` … spec is off by construction when `active.len() >= 2`,
+//! so the mixed branch is safe there."* That was correct when the MTP
+//! dispatch cap was 1. It is not correct now: the scheduler dispatches MTP
+//! whenever `active.len() <= speculative::mtp_max_seqs()`
+//! (`scheduler/mod.rs`, `spec_width_ok`), and that cap DEFAULTS TO 32
+//! (`speculative/ladder.rs`, raised 1 → 4 → 8 → 16 → 32 across the ladder
+//! campaign). Only the n-gram and self-speculative lanes still require
+//! `active.len() == 1`.
+//!
+//! So over the width range `2..=mtp_max_seqs()` this predicate says "no spec
+//! step this tick" while the dispatcher would in fact have run one. The
+//! mixed branch is then entered, and it:
+//!
+//! * clears `pending_drafts` / `pending_draft_conf` on EVERY active sequence,
+//! * emits one plain token per sequence through `mixed_forward`, and
+//! * sets `did_mixed_step`, which makes `mod.rs` skip `step_mtp` entirely
+//!   for the tick.
+//!
+//! i.e. for the whole duration of a chunked prefill, every concurrent
+//! sequence is demoted from a K-wide verify step to one plain token, and
+//! then pays a re-bootstrap. That is a decode-step deficit concentrated at
+//! low-to-mid concurrency, which is exactly where it is least likely to be
+//! noticed on a wide ladder rung.
+//!
+//! # Why this file does NOT change the value
+//!
+//! Widening the predicate to the real cap is a one-line change, but it is
+//! not obviously the right one: it trades the demotion above for the gap
+//! the C=1 rule was introduced to close — "one 8K prefill chunk froze every
+//! active decoder for the whole chunk … the single largest scheduler-level
+//! concurrency gap" (`run_standard`, 2026-07-25). Which side wins at
+//! C=2..8 is a throughput question, and no measurement of it exists. Under
+//! measurement discipline that A/B is a GPU leg, so this module names the
+//! divergence, gives it one home, and pins its extent in CI instead of
+//! guessing at the flip.
+
+/// Whether an in-flight speculative step forbids fusing a prefill chunk
+/// into this tick's decode.
+///
+/// The C=1 rule, unchanged in value — see the module doc for the range
+/// over which it disagrees with the scheduler's real dispatch gate.
+pub(super) fn mixing_blocked_by_spec(n_active: usize, any_spec: bool) -> bool {
+    any_spec && n_active == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn without_speculation_mixing_is_never_blocked() {
+        for n in 0..40usize {
+            assert!(!mixing_blocked_by_spec(n, false), "n={n}");
+        }
+    }
+
+    #[test]
+    fn the_c1_rule_blocks_exactly_one_active_sequence() {
+        assert!(!mixing_blocked_by_spec(0, true));
+        assert!(mixing_blocked_by_spec(1, true));
+        for n in 2..40usize {
+            assert!(!mixing_blocked_by_spec(n, true), "n={n}");
+        }
+    }
+
+    /// The guard this module exists for: pin the EXTENT of the divergence
+    /// between this predicate and the scheduler's real MTP dispatch width
+    /// gate, so it is a tracked, bounded exposure rather than a stale
+    /// comment. If someone moves the cap, this test reports the new range;
+    /// if the cap ever returns to 1 the divergence is empty and the three
+    /// call sites can go back to being trivially correct.
+    #[test]
+    fn divergence_from_the_real_dispatch_gate_is_exactly_two_through_the_cap() {
+        // CI sets neither override; skip rather than assert a value we do
+        // not control (same discipline as the ladder's default-shape tests).
+        if std::env::var_os("ATLAS_MTP_MAX_SEQS").is_some()
+            || std::env::var_os("ATLAS_NO_MTP_K_LADDER").is_some()
+        {
+            return;
+        }
+        let cap = spark_model::speculative::mtp_max_seqs();
+        // The scheduler dispatches MTP at `active.len() <= cap` (mod.rs).
+        let dispatch_would_run = |n: usize| n >= 1 && n <= cap;
+        let diverges: Vec<usize> = (0..cap + 8)
+            .filter(|&n| dispatch_would_run(n) != mixing_blocked_by_spec(n, true))
+            .collect();
+        let expected: Vec<usize> = (2..=cap).collect();
+        assert_eq!(
+            diverges, expected,
+            "the widths where mixing is allowed but a spec step would have run \
+             are no longer 2..={cap}; re-read this module's doc before changing it"
+        );
+        // And the divergence must be non-empty on the shipped default, or
+        // the module doc is describing a problem that no longer exists.
+        assert!(
+            cap >= 32,
+            "dispatch cap fell to {cap}; divergence range shrank"
+        );
+    }
+}

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -23,10 +23,24 @@ pub(super) fn promote_completed_prefills(
     // needs it for the budget-derived `finish_reason` decision.
     max_seq_len: usize,
 ) {
-    // Process in reverse order so swap_remove indices stay valid.
+    // Process in reverse order so the removal indices stay valid: taking a
+    // higher index out never shifts a lower one.
     completed_indices.sort_unstable_by_key(|x| std::cmp::Reverse(x.0));
     for (idx, maybe_token) in completed_indices {
-        let mut p = prefilling.swap_remove(idx);
+        // `remove`, NOT `swap_remove`. `prefilling` is a FIFO — arrivals are
+        // appended by `phase_start_prefills` and the single-stream path in
+        // `phase_continue_prefills` advances `prefilling[0]` — and
+        // `swap_remove` backfills the hole with the vector's LAST element,
+        // i.e. the NEWEST arrival. Removing the head then served the queue
+        // LIFO: `[A,B,C]` became `[C,B]`, so `B` advanced only if the queue
+        // happened to drain to length 2 at the instant a prefill completed.
+        // Under sustained arrivals it never does, and nothing downstream
+        // restores order (this and the `push` in `phase_start_prefills` are
+        // the only mutations of the vector) or times a waiting prefill out
+        // (the deadline sweep walks `active` only) — an unbounded stall.
+        // The shift is O(concurrent prefills) of a move each, against a
+        // chunk forward pass; see `prefill_fifo_tests`.
+        let mut p = prefilling.remove(idx);
         let Some(first) = maybe_token else {
             // Error path: free the sequence.
             let mut seq = p.seq;

--- a/crates/spark-server/src/scheduler/prefill_fifo_tests.rs
+++ b/crates/spark-server/src/scheduler/prefill_fifo_tests.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Prefill-queue ORDERING tests for the promote/continue pair.
+//!
+//! `prefilling` is a FIFO: `phase_start_prefills` appends arrivals with
+//! `push`, and `continue_in_progress_prefills` advances `prefilling[0]` —
+//! the queue HEAD — one chunk per tick. The only other mutation of that
+//! vector is the removal in `phase_promote_prefills`, so that removal is
+//! what has to keep the FIFO a FIFO.
+//!
+//! It did not. `swap_remove(0)` backfills the head with the vector's LAST
+//! element, i.e. the NEWEST arrival, so `[A,B,C]` becomes `[C,B]` when A
+//! completes: the queue is served LIFO at the head and `B` only ever gets
+//! a chunk if the queue happens to drain to length 2 at the instant a
+//! prefill completes. Under sustained arrivals that never happens and `B`
+//! waits forever — nothing downstream re-sorts `prefilling`, and the
+//! request-deadline sweep in `mod_helpers` only walks `active`, so a
+//! starved prefill is not even timed out.
+//!
+//! Reachability: the single-stream path runs whenever both Q12 batched
+//! branches are ineligible. The case exercised here is the common one —
+//! a `--speculative` serve with one decode active (`single_active_with_spec`),
+//! which disqualifies `can_batch_mixed`, while a non-empty `active`
+//! disqualifies `can_batch_prefill_only`.
+//!
+//! These tests drive the REAL `continue_in_progress_prefills` (admission →
+//! chunk → promote) over many ticks against a scripted `Model` stub; the
+//! ordering assertions are on the production queue itself, not on a model
+//! of it.
+
+use anyhow::Result;
+use spark_model::traits::{Model, SequenceState};
+use spark_runtime::gpu::DevicePtr;
+
+use super::phase_continue_prefills::continue_in_progress_prefills;
+use super::phase_promote_prefills::promote_completed_prefills;
+use super::sched_ctx::SchedCtx;
+use super::test_support::{test_prefill_ident, test_seq};
+use super::types::{ActiveSeq, PrefillInProgress};
+use crate::scheduling_policy::FifoPolicy;
+
+/// The sampled first token. Not an EOS (the fixture's `eos_tokens` is
+/// empty), so promotion pushes onto `active` rather than finishing.
+const FIRST: u32 = 7;
+
+/// One prompt = one chunk = one tick of prefill work.
+const CHUNK: usize = 4;
+
+/// Minimal `Model`: every prefill chunk succeeds and the greedy sampler
+/// (temperature 0.0, no suppressed ids) answers from `argmax_on_device`.
+/// Everything else is unreachable on the single-stream prefill path.
+#[derive(Default)]
+struct PrefillStubModel;
+
+impl Model for PrefillStubModel {
+    fn prefill_chunk(
+        &self,
+        tokens: &[u32],
+        seq: &mut SequenceState,
+        chunk_start: usize,
+        chunk_len: usize,
+        _is_last: bool,
+        _stream: u64,
+    ) -> Result<DevicePtr> {
+        // Mirror the real contract: the chunk's tokens land in the sequence.
+        seq.tokens
+            .extend_from_slice(&tokens[chunk_start..chunk_start + chunk_len]);
+        seq.seq_len = seq.tokens.len();
+        Ok(DevicePtr::NULL)
+    }
+    fn argmax_on_device(&self, _logits_ptr: DevicePtr, _stream: u64) -> Result<u32> {
+        Ok(FIRST)
+    }
+    fn vocab_size(&self) -> usize {
+        32
+    }
+    fn free_sequence(&self, _seq: &mut SequenceState) -> Result<()> {
+        Ok(())
+    }
+    fn cache_sequence(&self, _seq: &SequenceState) {}
+    fn detach_slot_for_reuse(&self, _seq: &mut SequenceState) {}
+    fn has_proposer(&self) -> bool {
+        false
+    }
+    fn has_self_speculative(&self) -> bool {
+        false
+    }
+    fn logits_buffer_ptr(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn hidden_after_norm(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn bind_gpu_to_thread(&self) -> Result<()> {
+        Ok(())
+    }
+    fn alloc_sequence(&self) -> Result<SequenceState> {
+        Ok(SequenceState::host_only(0))
+    }
+    fn copy_logits_to_host(&self, _l: DevicePtr, _dst: &mut [u8]) -> Result<()> {
+        unreachable!("greedy fast path never reads logits back")
+    }
+    fn prefill(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("chunked prefill only")
+    }
+    fn decode(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("decode is driven by mod.rs, not by this harness")
+    }
+    fn decode_batch(
+        &self,
+        _t: &[u32],
+        _s: &mut [&mut SequenceState],
+        _st: u64,
+    ) -> Result<DevicePtr> {
+        unreachable!("decode is driven by mod.rs, not by this harness")
+    }
+    fn decode_draft(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<Vec<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed(
+        &self,
+        _t: &[u32; 2],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 2]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed_k3(
+        &self,
+        _t: &[u32; 3],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 3]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed_k4(
+        &self,
+        _t: &[u32; 4],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 4]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn argmax_batch(&self, _l: DevicePtr, _n: usize, _st: u64) -> Result<Vec<u32>> {
+        unreachable!("batched decode is not driven here")
+    }
+    fn checkpoint_ssm_states(&self, _s: &mut SequenceState) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn rollback_ssm_states(&self, _s: &mut SequenceState, _n: usize) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn compact_sequence(&self, _s: &mut SequenceState, _new_slot: usize) -> Result<()> {
+        unreachable!("no compaction in this harness")
+    }
+    fn save_hidden_for_mtp(&self, _token_idx: usize, _st: u64) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn run_mtp_propose(
+        &self,
+        _t: u32,
+        _p: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<Option<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn run_mtp_propose_multi(
+        &self,
+        _t: u32,
+        _p: usize,
+        _n: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+        _mask: Option<&[i32]>,
+    ) -> Result<Vec<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn trim_proposer_state(&self, _s: &mut SequenceState, _n: usize, _st: u64) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn generate_speculative(
+        &self,
+        _p: &[u32],
+        _params: &spark_runtime::sampler::SamplingParams,
+        _n: usize,
+    ) -> Result<spark_model::engine::GenerateResult> {
+        unreachable!("no speculation in this harness")
+    }
+}
+
+/// What one run of the tick loop observed.
+struct Run {
+    /// `(session_hash, tick)` for every prefill promoted into `active`.
+    promoted: Vec<(u64, usize)>,
+    /// Initially-queued ids that never got a single prefill chunk.
+    stuck: Vec<u64>,
+}
+
+/// Drive the real admit → continue → promote loop for `ticks` ticks.
+///
+/// `seed_depth` requests (ids `1..=seed_depth`) are already queued when the
+/// loop starts, and one NEW request arrives every tick — the sustained-arrival
+/// condition under which head reordering becomes unbounded starvation. Arrival
+/// is applied before the continue phase, the order `mod.rs` uses
+/// (`start_new_requests` then `continue_in_progress_prefills`).
+fn drive(seed_depth: usize, ticks: usize) -> Run {
+    let model = PrefillStubModel;
+    let policy = FifoPolicy;
+    let sched = SchedCtx::for_test();
+
+    // Response receivers, kept alive so no sink observes a closed channel.
+    let mut keep = Vec::new();
+    let mut active: Vec<ActiveSeq> = Vec::new();
+    let mut prefilling: Vec<PrefillInProgress> = Vec::new();
+
+    // One long-lived decode occupant — a `--speculative` serve at C=1. That
+    // is `single_active_with_spec`, which disqualifies the Q12 mixed batch,
+    // and a non-empty `active` disqualifies the Q12 prefill batch, so every
+    // tick takes the single-stream path under test. `session_hash` 0 is
+    // reserved for it; prefill ids start at 1.
+    let (occupant, rx) = test_seq(vec![1], usize::MAX, None, 8);
+    keep.push(rx);
+    active.push(occupant);
+
+    let seeded: Vec<u64> = (1..=seed_depth as u64).collect();
+    for &id in &seeded {
+        let (p, rx) = test_prefill_ident(id, CHUNK);
+        keep.push(rx);
+        prefilling.push(p);
+    }
+
+    let mut next_id = seed_depth as u64 + 1;
+    let mut promoted: Vec<(u64, usize)> = Vec::new();
+
+    for tick in 0..ticks {
+        let (p, rx) = test_prefill_ident(next_id, CHUNK);
+        keep.push(rx);
+        prefilling.push(p);
+        next_id += 1;
+
+        continue_in_progress_prefills(
+            &model,
+            &policy,
+            &mut active,
+            &mut prefilling,
+            CHUNK, // max_prefill_tokens
+            CHUNK, // max_batch_tokens
+            false, // always_mixed
+            0,     // prefill_stream
+            0,     // prefill_event
+            true,  // use_mtp
+            false, // use_self_speculative
+            false, // use_ngram_speculative
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            &sched,
+        );
+
+        // The rest of `mod.rs` decodes and retires. Here every promoted
+        // prefill retires at once, leaving the single decode occupant at
+        // index 0 (promotion appends).
+        for a in active.drain(1..) {
+            promoted.push((a.session_hash, tick));
+        }
+    }
+
+    let stuck = seeded
+        .into_iter()
+        .filter(|id| !promoted.iter().any(|(p, _)| p == id))
+        .collect();
+    Run { promoted, stuck }
+}
+
+/// The starvation test. Every request already in the queue must get its
+/// prefill even though a newer one arrives on every single tick.
+///
+/// Pre-fix (`swap_remove`) this is red from depth 2 upward: the head is
+/// backfilled with the newest arrival, so ids 2..=depth never advance in
+/// 500 ticks. Depth 1 passes either way — the harness discriminates on the
+/// ordering, it does not fail everything.
+#[test]
+fn every_queued_prefill_advances_under_sustained_arrivals() {
+    for depth in 1..=8 {
+        let run = drive(depth, 500);
+        assert!(
+            run.stuck.is_empty(),
+            "queue depth {depth}: request(s) {:?} never got a prefill chunk in 500 ticks",
+            run.stuck,
+        );
+    }
+}
+
+/// The wait is BOUNDED by the queue depth, not merely finite: with one
+/// chunk of work per request the request that is `k`-th in line is served
+/// on tick `k`.
+#[test]
+fn queued_prefills_are_served_in_arrival_order() {
+    for depth in 1..=8 {
+        let run = drive(depth, 500);
+        for (rank, id) in (1..=depth as u64).enumerate() {
+            let tick = run
+                .promoted
+                .iter()
+                .find(|(p, _)| *p == id)
+                .map(|(_, t)| *t)
+                .unwrap_or_else(|| panic!("depth {depth}: request {id} never promoted"));
+            assert_eq!(
+                tick, rank,
+                "depth {depth}: request {id} was {rank} places from the head but ran on tick {tick}",
+            );
+        }
+    }
+}
+
+/// Control: the loop really runs. Every tick admits one request and
+/// completes one prefill, so a 500-tick run promotes 500 of them. This
+/// stays GREEN before the fix — the pre-fix failure above is about WHICH
+/// requests ran, not about a harness that never got off the ground.
+#[test]
+fn the_tick_loop_makes_progress_every_tick() {
+    let run = drive(8, 500);
+    assert_eq!(
+        run.promoted.len(),
+        500,
+        "expected one promotion per tick, got {}",
+        run.promoted.len(),
+    );
+}
+
+/// Unit control on the removal itself: promoting the head must leave the
+/// rest of the queue in arrival order.
+#[test]
+fn promoting_the_head_preserves_the_order_of_the_remainder() {
+    let model = PrefillStubModel;
+    let mut keep = Vec::new();
+    let mut prefilling: Vec<PrefillInProgress> = (1..=4)
+        .map(|id| {
+            let (p, rx) = test_prefill_ident(id, CHUNK);
+            keep.push(rx);
+            p
+        })
+        .collect();
+    let mut active: Vec<ActiveSeq> = Vec::new();
+
+    promote_completed_prefills(
+        &model,
+        &mut prefilling,
+        vec![(0, Some(FIRST))],
+        &mut active,
+        None,
+        None,
+        None,
+        None,
+        4096,
+    );
+
+    let order: Vec<u64> = prefilling.iter().map(|p| p.session_hash).collect();
+    assert_eq!(
+        order,
+        vec![2, 3, 4],
+        "head removal must not reorder the queue"
+    );
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].session_hash, 1);
+}
+
+/// The batched paths hand `promote_completed_prefills` SEVERAL completed
+/// indices at once. Removing them must still leave the survivors in
+/// arrival order — the reverse-index walk is an implementation detail of
+/// keeping the indices valid, not licence to reorder.
+#[test]
+fn promoting_several_at_once_preserves_the_order_of_the_remainder() {
+    let model = PrefillStubModel;
+    let mut keep = Vec::new();
+    let mut prefilling: Vec<PrefillInProgress> = (1..=5)
+        .map(|id| {
+            let (p, rx) = test_prefill_ident(id, CHUNK);
+            keep.push(rx);
+            p
+        })
+        .collect();
+    let mut active: Vec<ActiveSeq> = Vec::new();
+
+    // Indices 0 and 2 complete (ids 1 and 3), in the caller's arrival order.
+    promote_completed_prefills(
+        &model,
+        &mut prefilling,
+        vec![(0, Some(FIRST)), (2, Some(FIRST))],
+        &mut active,
+        None,
+        None,
+        None,
+        None,
+        4096,
+    );
+
+    let order: Vec<u64> = prefilling.iter().map(|p| p.session_hash).collect();
+    assert_eq!(
+        order,
+        vec![2, 4, 5],
+        "multi-removal must not reorder the queue"
+    );
+    let promoted: Vec<u64> = active.iter().map(|a| a.session_hash).collect();
+    assert_eq!(
+        promoted,
+        vec![3, 1],
+        "promotion still walks the indices in reverse"
+    );
+}

--- a/crates/spark-server/src/scheduler/shutdown_drain.rs
+++ b/crates/spark-server/src/scheduler/shutdown_drain.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The last thing the scheduler does: fail what it cannot finish.
+//!
+//! Split from `lifecycle.rs` for the =<500-line cap; the drain is one
+//! self-contained step of shutdown, and its tests live beside it in
+//! `shutdown_drain_tests.rs`.
+
+use super::*;
+
+/// Fail every request the scheduler is abandoning as it exits.
+///
+/// Shutdown reaches the scheduler with work in three parked states, and
+/// only ONE of them used to be told: `preempted` got an error frame,
+/// while `prefilling` was freed and `swapped` had its disk image deleted
+/// with their sinks dropped on the floor. A dropped sink is not a quiet
+/// success — it closes the client's channel, which `chat_blocking` and
+/// `completions_exec` render as the generic "Inference cancelled", and
+/// which a STREAMING client sees as a response that stops mid-token with
+/// no error frame and no finish chunk, under an HTTP 200 that already
+/// promised a complete answer. A `SIGTERM` during a rolling restart hits
+/// exactly these states, so the honest report is the whole point.
+///
+/// Every request gets a reason that names WHICH state it died in: "your
+/// prompt never finished loading" and "you were paged out to disk" are
+/// different things to a client deciding whether to retry.
+pub(super) fn abort_in_flight_on_shutdown(
+    model: &dyn Model,
+    prefilling: Vec<PrefillInProgress>,
+    swapped: Vec<SwappedSeq>,
+    preempted: Vec<PreemptedSeq>,
+    mut spill: Option<&mut KvSpillManager>,
+) {
+    for mut p in preempted {
+        send_error_to_sink(
+            &mut p.a.sink,
+            "server shutting down before preempted resume",
+        );
+    }
+    for mut p in prefilling {
+        send_error_to_sink(&mut p.sink, "server shut down during prefill");
+        let seq = &mut p.seq;
+        let _ = model.free_sequence(seq);
+        let _ = model.ep_broadcast_cmd_for_seq(seq.slot_idx as u32, 0xFFFFFFF1);
+    }
+    for mut s in swapped {
+        send_error_to_sink(
+            &mut s.sink,
+            "server shut down while this request was swapped out to disk",
+        );
+        if let Some(spill) = spill.as_deref_mut() {
+            let _ = spill.remove_file(s.swap_id);
+        }
+    }
+}

--- a/crates/spark-server/src/scheduler/shutdown_drain_tests.rs
+++ b/crates/spark-server/src/scheduler/shutdown_drain_tests.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! What a `SIGTERM` does to requests the scheduler has parked.
+//!
+//! Shutdown finds work in three states — mid-prefill, swapped out to
+//! disk, preempted awaiting resume — and the drain used to tell only the
+//! third. The other two had their sinks dropped, which is not a quiet
+//! failure: a blocking client gets the generic "Inference cancelled" and
+//! a streaming client gets a response that stops mid-token with no error
+//! frame and no finish chunk, under the HTTP 200 the stream already sent.
+//! A rolling restart lands on exactly these states.
+
+use super::lifecycle::swap_out_sequence;
+use super::lifecycle_tests::StubModel;
+use super::shutdown_drain::abort_in_flight_on_shutdown;
+use super::test_support::{RespRx, test_prefill, test_seq};
+use super::types::PreemptedSeq;
+use spark_runtime::kv_spill::KvSpillManager;
+
+fn message(label: &str, mut rx: RespRx) -> String {
+    match rx.try_recv() {
+        Ok(Err(e)) => format!("{e:#}"),
+        Ok(Ok(_)) => panic!("{label}: an abandoned request must not report success"),
+        Err(e) => panic!("{label}: the client was dropped instead of told ({e})"),
+    }
+}
+
+#[test]
+fn shutdown_tells_every_parked_request_which_state_it_died_in() {
+    let model = StubModel::default();
+    let dir = std::env::temp_dir().join(format!("atlas-shutdown-drain-{}", std::process::id()));
+    let mut spill = KvSpillManager::new(dir, 8 * 1024 * 1024).expect("spill manager");
+
+    let (prefill, prefill_rx) = test_prefill(vec![1, 2, 3]);
+
+    let (victim, swapped_rx) = test_seq(vec![4, 5], 6, None, 2);
+    let mut active = vec![victim];
+    let swapped = swap_out_sequence(&model, &mut active, 0, &mut spill).expect("swap-out writes");
+
+    let (parked, preempted_rx) = test_seq(vec![7], 9, None, 1);
+    let preempted = PreemptedSeq {
+        a: parked,
+        tokens: vec![7],
+    };
+
+    abort_in_flight_on_shutdown(
+        &model,
+        vec![prefill],
+        vec![swapped],
+        vec![preempted],
+        Some(&mut spill),
+    );
+
+    // Each reason must name the state, not just "shutting down": a client
+    // deciding whether to retry treats "your prompt never finished
+    // loading" and "you were paged out to disk" differently.
+    let m = message("prefilling", prefill_rx);
+    assert!(m.contains("prefill"), "prefilling: got {m:?}");
+    let m = message("swapped", swapped_rx);
+    assert!(m.contains("swapped out"), "swapped: got {m:?}");
+    let m = message("preempted", preempted_rx);
+    assert!(m.contains("preempted"), "preempted: got {m:?}");
+}

--- a/crates/spark-server/src/scheduler/swap_resume_tests.rs
+++ b/crates/spark-server/src/scheduler/swap_resume_tests.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! A failed swap-IN must reach the client, exactly as a failed swap-OUT
+//! already does.
+//!
+//! `swap_out_sequence` was fixed once for this: "on error the victim is
+//! surfaced to its client and freed here rather than silently dropped
+//! (the old path leaked the GPU blocks AND the client saw only
+//! 'Inference cancelled')". The RESUME half kept the old shape — bare
+//! `?` on `alloc_sequence` / `open_file` / `restore_sequence_state`,
+//! consuming the `SwappedSeq` and with it the only handle to the waiting
+//! request. The scheduler logged `Swap-in failed: …` and moved on; the
+//! client's oneshot closed, which the API layer reports as the generic
+//! "Inference cancelled", and a streaming client got a stream that
+//! simply stopped.
+
+use super::lifecycle::{resume_swapped_seq, swap_out_sequence};
+use super::lifecycle_tests::StubModel;
+use super::test_support::test_seq;
+use spark_runtime::kv_spill::KvSpillManager;
+
+/// Per-test spill root under the process's temp dir; `KvSpillManager::new`
+/// creates it and wipes stale `swap_*` files.
+fn spill(tag: &str) -> KvSpillManager {
+    let dir = std::env::temp_dir().join(format!("atlas-swap-resume-{tag}-{}", std::process::id()));
+    KvSpillManager::new(dir, 8 * 1024 * 1024).expect("spill manager")
+}
+
+#[test]
+fn a_swap_in_that_cannot_read_its_image_tells_the_client() {
+    let model = StubModel::default();
+    let mut spill = spill("lost-image");
+    let (a, mut rx) = test_seq(vec![7, 8, 9], 5, None, 3);
+    let mut active = vec![a];
+    let s = swap_out_sequence(&model, &mut active, 0, &mut spill).expect("swap-out writes");
+
+    // The image disappears between swap-out and resume: an operator
+    // clearing the spill dir, a tmpfs eviction, a disk-full reclaim.
+    // `open_file` then fails and the sequence can never come back.
+    spill.remove_file(s.swap_id).expect("remove the image");
+    let freed_before = model.freed.lock().expect("freed list").len();
+
+    let server_side = match resume_swapped_seq(None, None, &model, s, &mut spill) {
+        Ok(_) => panic!("a swap-in with no image on disk must fail"),
+        Err(e) => e,
+    };
+
+    match rx.try_recv() {
+        Ok(Err(e)) => {
+            let msg = format!("{e:#}");
+            // Naming the phase is the point: "Inference cancelled" is
+            // what the client used to get, and it is indistinguishable
+            // from a client-side abort.
+            assert!(
+                msg.contains("swap-in"),
+                "the error must name what failed, got {msg:?}"
+            );
+        }
+        Ok(Ok(_)) => panic!("a failed swap-in must not report success"),
+        Err(e) => panic!(
+            "the client's sink was dropped instead of told ({e}); \
+             the server-side error was {server_side:#}"
+        ),
+    }
+
+    // The slot claimed by `alloc_sequence` before the failure must go
+    // back, or every failed resume permanently narrows the pool.
+    let freed_after = model.freed.lock().expect("freed list").len();
+    assert_eq!(
+        freed_after,
+        freed_before + 1,
+        "the sequence allocated for the resume must be freed on the error path"
+    );
+}

--- a/crates/spark-server/src/scheduler/test_support.rs
+++ b/crates/spark-server/src/scheduler/test_support.rs
@@ -121,3 +121,49 @@ pub(super) fn test_seq(
     };
     (a, rx)
 }
+
+/// A `PrefillInProgress` with a blocking oneshot sink — the shape the
+/// scheduler is holding when a shutdown lands mid-prefill.
+pub(super) fn test_prefill(prompt: Vec<u32>) -> (super::types::PrefillInProgress, RespRx) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let p = super::types::PrefillInProgress {
+        prompt_tokens: std::sync::Arc::new(prompt),
+        session_hash: 0,
+        seq: SequenceState::host_only(0),
+        chunk_offset: 0,
+        max_tokens: 16,
+        min_tokens: 0,
+        eos_tokens: EOS.to_vec(),
+        sink: ResponseSink::Blocking(Some(tx)),
+        cancel_flag: None,
+        request_start: Instant::now(),
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        top_n_sigma: 0.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        repetition_penalty_window: 256,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        lz_penalty: DEFAULT_LZ_PENALTY,
+        dry_multiplier: 0.0,
+        dry_base: 0.0,
+        dry_allowed_length: 0,
+        dry_sequence_breakers: Vec::new(),
+        logit_bias: Vec::new(),
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: None,
+        spontaneous_think_budget: 0,
+        require_tool_call: false,
+        tools_present: false,
+        suppress_tool_call: false,
+        disable_mtp: false,
+        grammar_state: None,
+        seed: None,
+        top_logprobs: None,
+        timeout_at: None,
+    };
+    (p, rx)
+}

--- a/crates/spark-server/src/scheduler/test_support.rs
+++ b/crates/spark-server/src/scheduler/test_support.rs
@@ -167,3 +167,57 @@ pub(super) fn test_prefill(prompt: Vec<u32>) -> (super::types::PrefillInProgress
     };
     (p, rx)
 }
+
+/// A real `PrefillInProgress` at `chunk_offset == 0`, identified by
+/// `session_hash` so an ordering test can name the request it is tracking.
+///
+/// `eos_tokens` is empty and `temperature` is 0.0 on purpose: that is the
+/// `sample_token` greedy fast path (`argmax_on_device`), which a stub `Model`
+/// can answer without a device logits buffer. `max_tokens` is 8 (> 1) so
+/// promotion pushes onto `active` instead of finishing immediately.
+pub(super) fn test_prefill_ident(
+    id: u64,
+    prompt_len: usize,
+) -> (super::types::PrefillInProgress, RespRx) {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let p = super::types::PrefillInProgress {
+        prompt_tokens: std::sync::Arc::new(vec![1u32; prompt_len]),
+        session_hash: id,
+        seq: SequenceState::host_only(id as usize),
+        chunk_offset: 0,
+        max_tokens: 8,
+        min_tokens: 0,
+        eos_tokens: Vec::new(),
+        sink: ResponseSink::Blocking(Some(tx)),
+        cancel_flag: None,
+        request_start: Instant::now(),
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        top_n_sigma: 0.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        repetition_penalty_window: 256,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        lz_penalty: DEFAULT_LZ_PENALTY,
+        dry_multiplier: 0.0,
+        dry_base: 0.0,
+        dry_allowed_length: 0,
+        dry_sequence_breakers: Vec::new(),
+        logit_bias: Vec::new(),
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: None,
+        spontaneous_think_budget: 0,
+        require_tool_call: false,
+        tools_present: false,
+        suppress_tool_call: false,
+        disable_mtp: false,
+        grammar_state: None,
+        seed: None,
+        top_logprobs: None,
+        timeout_at: None,
+    };
+    (p, rx)
+}

--- a/crates/spark-server/src/scheduling_policy.rs
+++ b/crates/spark-server/src/scheduling_policy.rs
@@ -112,11 +112,43 @@ impl SchedulingPolicy for SlaiPolicy {
         true
     }
 
+    /// Shortest-job-first over ALL pending, with ONE seat reserved for the
+    /// head of the queue.
+    ///
+    /// ★ Why the reservation exists. Pure SJF has no wait-time term, and
+    /// `requests` is rebuilt from the pending queue every tick, so a long
+    /// prompt is re-sorted to the tail on every tick it loses. Under a
+    /// steady arrival of shorter requests — the ordinary shape of a busy
+    /// serve — it is never selected at all. That is an UNBOUNDED wait, not
+    /// a slow one: no amount of elapsed time makes it eligible, because
+    /// nothing in the ranking key ever changes.
+    ///
+    /// The queue is in ARRIVAL order (the scheduler enumerates
+    /// `PendingQueue::requests` directly, and admission re-inserts its
+    /// overflow at the FRONT preserving relative order — `admission.rs`),
+    /// so index 0 is the OLDEST pending request. Always taking it gives a
+    /// hard bound: every request advances at least one position per
+    /// selecting tick, so a request at position `p` waits at most `p`
+    /// ticks. Aging by wall-clock would need a timestamp plumbed through
+    /// [`PendingRequestInfo`] and would make this decision clock-dependent
+    /// (it is currently pure, and tested as such); the positional bound
+    /// needs neither and cannot be tuned wrong.
+    ///
+    /// The remaining `capacity - 1` seats are still filled shortest-first,
+    /// which is where SLAI's median-TTFT win comes from — the reservation
+    /// costs one seat per tick, and only when a request is actually queued
+    /// behind others.
     fn select_prefills(&self, requests: &[PendingRequestInfo], capacity: usize) -> Vec<usize> {
-        // Sort ALL pending by prompt_len, pick shortest N.
-        let mut indices: Vec<usize> = (0..requests.len()).collect();
-        indices.sort_by_key(|&i| requests[i].prompt_len);
-        indices.truncate(capacity);
+        if capacity == 0 || requests.is_empty() {
+            return Vec::new();
+        }
+        // Seat 0: the oldest pending request, unconditionally.
+        let mut indices: Vec<usize> = vec![0];
+        // Remaining seats: shortest-first over everything else.
+        let mut rest: Vec<usize> = (1..requests.len()).collect();
+        rest.sort_by_key(|&i| requests[i].prompt_len);
+        rest.truncate(capacity - 1);
+        indices.extend(rest);
         indices
     }
 
@@ -157,216 +189,5 @@ impl SchedulingPolicy for SlaiPolicy {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fifo_always_prefills() {
-        let policy = FifoPolicy;
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now(),
-        }];
-        assert!(policy.should_prefill(&timings));
-        assert!(policy.should_prefill(&[]));
-    }
-
-    #[test]
-    fn fifo_selects_first_n() {
-        let policy = FifoPolicy;
-        let requests = vec![
-            PendingRequestInfo {
-                prompt_len: 100,
-                index: 0,
-            },
-            PendingRequestInfo {
-                prompt_len: 10,
-                index: 1,
-            },
-            PendingRequestInfo {
-                prompt_len: 50,
-                index: 2,
-            },
-            PendingRequestInfo {
-                prompt_len: 200,
-                index: 3,
-            },
-        ];
-        assert_eq!(policy.select_prefills(&requests, 2), vec![0, 1]);
-        assert_eq!(policy.select_prefills(&requests, 10), vec![0, 1, 2, 3]);
-    }
-
-    #[test]
-    fn slai_prefills_when_no_active() {
-        let policy = SlaiPolicy::new(100);
-        assert!(policy.should_prefill(&[]));
-    }
-
-    #[test]
-    fn slai_prefills_when_fresh() {
-        let policy = SlaiPolicy::new(100);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now(),
-        }];
-        assert!(policy.should_prefill(&timings));
-    }
-
-    #[test]
-    fn slai_skips_prefill_near_deadline() {
-        let policy = SlaiPolicy::new(100); // 80ms margin
-        let old_time = Instant::now() - Duration::from_millis(85);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: old_time,
-        }];
-        assert!(!policy.should_prefill(&timings));
-    }
-
-    #[test]
-    fn slai_prefills_within_margin() {
-        let policy = SlaiPolicy::new(100); // 80ms margin
-        let recent = Instant::now() - Duration::from_millis(50);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: recent,
-        }];
-        assert!(policy.should_prefill(&timings));
-    }
-
-    #[test]
-    fn slai_one_urgent_blocks_prefill() {
-        let policy = SlaiPolicy::new(100);
-        let now = Instant::now();
-        let timings = vec![
-            ActiveSeqTiming {
-                last_token_time: now,
-            },
-            ActiveSeqTiming {
-                last_token_time: now - Duration::from_millis(90),
-            },
-        ];
-        assert!(!policy.should_prefill(&timings));
-    }
-
-    #[test]
-    fn slai_selects_shortest_from_all() {
-        let policy = SlaiPolicy::new(100);
-        let requests = vec![
-            PendingRequestInfo {
-                prompt_len: 500,
-                index: 0,
-            },
-            PendingRequestInfo {
-                prompt_len: 10,
-                index: 1,
-            },
-            PendingRequestInfo {
-                prompt_len: 200,
-                index: 2,
-            },
-            PendingRequestInfo {
-                prompt_len: 50,
-                index: 3,
-            },
-            PendingRequestInfo {
-                prompt_len: 300,
-                index: 4,
-            },
-        ];
-        // Capacity 3: picks shortest 3 → indices 1(10), 3(50), 2(200)
-        assert_eq!(policy.select_prefills(&requests, 3), vec![1, 3, 2]);
-    }
-
-    #[test]
-    fn slai_selects_all_when_capacity_exceeds() {
-        let policy = SlaiPolicy::new(100);
-        let requests = vec![
-            PendingRequestInfo {
-                prompt_len: 100,
-                index: 0,
-            },
-            PendingRequestInfo {
-                prompt_len: 10,
-                index: 1,
-            },
-        ];
-        // Capacity 10 > 2 requests: returns all sorted
-        assert_eq!(policy.select_prefills(&requests, 10), vec![1, 0]);
-    }
-
-    #[test]
-    fn slai_stable_order_for_equal_lengths() {
-        let policy = SlaiPolicy::new(100);
-        let requests = vec![
-            PendingRequestInfo {
-                prompt_len: 50,
-                index: 0,
-            },
-            PendingRequestInfo {
-                prompt_len: 50,
-                index: 1,
-            },
-            PendingRequestInfo {
-                prompt_len: 50,
-                index: 2,
-            },
-        ];
-        assert_eq!(policy.select_prefills(&requests, 3), vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn select_prefills_empty() {
-        assert!(FifoPolicy.select_prefills(&[], 5).is_empty());
-        assert!(SlaiPolicy::new(100).select_prefills(&[], 5).is_empty());
-    }
-
-    #[test]
-    fn fifo_slice_budget_is_full_chunk() {
-        // Default trait impl: FIFO always injects the full chunk.
-        let policy = FifoPolicy;
-        assert_eq!(policy.prefill_slice_budget(&[], 4080), 4080);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now(),
-        }];
-        assert_eq!(policy.prefill_slice_budget(&timings, 4080), 4080);
-    }
-
-    #[test]
-    fn slai_slice_budget_full_when_no_active() {
-        let policy = SlaiPolicy::new(100);
-        assert_eq!(policy.prefill_slice_budget(&[], 4080), 4080);
-    }
-
-    #[test]
-    fn slai_slice_budget_zero_past_deadline() {
-        // worst >= tbt_deadline → hard suppress (0), decode-only this tick.
-        let policy = SlaiPolicy::new(100);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now() - Duration::from_millis(120),
-        }];
-        assert_eq!(policy.prefill_slice_budget(&timings, 4080), 0);
-    }
-
-    #[test]
-    fn slai_slice_budget_bounded_and_wy4_aligned() {
-        // Fresh decode, under deadline → a positive, WY4-aligned slice in
-        // [min, full_chunk], never 0.
-        let policy = SlaiPolicy::new(100);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now(),
-        }];
-        let b = policy.prefill_slice_budget(&timings, 4080);
-        assert!(b > 0, "non-deadline budget must be > 0");
-        assert!(b <= 4080, "must never exceed full_chunk");
-        assert_eq!(b % 4, 0, "must be WY4-aligned");
-    }
-
-    #[test]
-    fn slai_slice_budget_never_exceeds_small_full_chunk() {
-        // Small chunk cap must clamp the slice (and stay WY4-aligned).
-        let policy = SlaiPolicy::new(100);
-        let timings = vec![ActiveSeqTiming {
-            last_token_time: Instant::now(),
-        }];
-        let b = policy.prefill_slice_budget(&timings, 64);
-        assert!(b <= 64);
-        assert_eq!(b % 4, 0);
-    }
-}
+#[path = "scheduling_policy_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/scheduling_policy_tests.rs
+++ b/crates/spark-server/src/scheduling_policy_tests.rs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`scheduling_policy`). A sibling file via `#[path]`
+//! — the `mtp_dcut.rs`/`mtp_dcut_tests.rs` idiom — so `scheduling_policy.rs`
+//! stays under the 500-line cap. Module position (child of
+//! `scheduling_policy`) is unchanged, so `super::*` paths are untouched.
+use super::*;
+
+#[test]
+fn fifo_always_prefills() {
+    let policy = FifoPolicy;
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now(),
+    }];
+    assert!(policy.should_prefill(&timings));
+    assert!(policy.should_prefill(&[]));
+}
+
+#[test]
+fn fifo_selects_first_n() {
+    let policy = FifoPolicy;
+    let requests = vec![
+        PendingRequestInfo {
+            prompt_len: 100,
+            index: 0,
+        },
+        PendingRequestInfo {
+            prompt_len: 10,
+            index: 1,
+        },
+        PendingRequestInfo {
+            prompt_len: 50,
+            index: 2,
+        },
+        PendingRequestInfo {
+            prompt_len: 200,
+            index: 3,
+        },
+    ];
+    assert_eq!(policy.select_prefills(&requests, 2), vec![0, 1]);
+    assert_eq!(policy.select_prefills(&requests, 10), vec![0, 1, 2, 3]);
+}
+
+#[test]
+fn slai_prefills_when_no_active() {
+    let policy = SlaiPolicy::new(100);
+    assert!(policy.should_prefill(&[]));
+}
+
+#[test]
+fn slai_prefills_when_fresh() {
+    let policy = SlaiPolicy::new(100);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now(),
+    }];
+    assert!(policy.should_prefill(&timings));
+}
+
+#[test]
+fn slai_skips_prefill_near_deadline() {
+    let policy = SlaiPolicy::new(100); // 80ms margin
+    let old_time = Instant::now() - Duration::from_millis(85);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: old_time,
+    }];
+    assert!(!policy.should_prefill(&timings));
+}
+
+#[test]
+fn slai_prefills_within_margin() {
+    let policy = SlaiPolicy::new(100); // 80ms margin
+    let recent = Instant::now() - Duration::from_millis(50);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: recent,
+    }];
+    assert!(policy.should_prefill(&timings));
+}
+
+#[test]
+fn slai_one_urgent_blocks_prefill() {
+    let policy = SlaiPolicy::new(100);
+    let now = Instant::now();
+    let timings = vec![
+        ActiveSeqTiming {
+            last_token_time: now,
+        },
+        ActiveSeqTiming {
+            last_token_time: now - Duration::from_millis(90),
+        },
+    ];
+    assert!(!policy.should_prefill(&timings));
+}
+
+#[test]
+fn slai_selects_shortest_from_all() {
+    let policy = SlaiPolicy::new(100);
+    let requests = vec![
+        PendingRequestInfo {
+            prompt_len: 500,
+            index: 0,
+        },
+        PendingRequestInfo {
+            prompt_len: 10,
+            index: 1,
+        },
+        PendingRequestInfo {
+            prompt_len: 200,
+            index: 2,
+        },
+        PendingRequestInfo {
+            prompt_len: 50,
+            index: 3,
+        },
+        PendingRequestInfo {
+            prompt_len: 300,
+            index: 4,
+        },
+    ];
+    // Capacity 3: seat 0 is RESERVED for the queue head (index 0, the
+    // 500-token prompt — see `select_prefills`), then the shortest two
+    // of the rest: 1(10) and 3(50). Before the head reservation this
+    // read [1, 3, 2], which is the selection that starves index 0
+    // forever under a steady arrival of shorter prompts.
+    assert_eq!(policy.select_prefills(&requests, 3), vec![0, 1, 3]);
+    // The SJF preference is intact on the unreserved seats: widen the
+    // capacity by one and 2(200) joins, not 4(300).
+    assert_eq!(policy.select_prefills(&requests, 4), vec![0, 1, 3, 2]);
+    // One seat: the head takes it.
+    assert_eq!(policy.select_prefills(&requests, 1), vec![0]);
+    // No seats: nothing, and no panic on the `capacity - 1` arithmetic.
+    assert!(policy.select_prefills(&requests, 0).is_empty());
+}
+
+#[test]
+fn slai_selects_all_when_capacity_exceeds() {
+    let policy = SlaiPolicy::new(100);
+    let requests = vec![
+        PendingRequestInfo {
+            prompt_len: 100,
+            index: 0,
+        },
+        PendingRequestInfo {
+            prompt_len: 10,
+            index: 1,
+        },
+    ];
+    // Capacity 10 > 2 requests: BOTH are selected either way, so the
+    // head reservation changes only the order — oldest first, then
+    // shortest-first over the rest. (Was [1, 0] under pure SJF.)
+    assert_eq!(policy.select_prefills(&requests, 10), vec![0, 1]);
+}
+
+#[test]
+fn slai_stable_order_for_equal_lengths() {
+    let policy = SlaiPolicy::new(100);
+    let requests = vec![
+        PendingRequestInfo {
+            prompt_len: 50,
+            index: 0,
+        },
+        PendingRequestInfo {
+            prompt_len: 50,
+            index: 1,
+        },
+        PendingRequestInfo {
+            prompt_len: 50,
+            index: 2,
+        },
+    ];
+    assert_eq!(policy.select_prefills(&requests, 3), vec![0, 1, 2]);
+}
+
+/// Drive a policy the way the scheduler does: each tick it selects up
+/// to `capacity`, the selected requests LEAVE the queue, and a new
+/// short request arrives. Returns the tick on which `watch` (tracked by
+/// its `index` field, which is stable across the run) was selected, or
+/// `None` if it never was.
+///
+/// This is the arrival pattern a busy serve actually sees: a long
+/// prompt queued behind a steady stream of short ones.
+fn ticks_until_selected(
+    policy: &dyn SchedulingPolicy,
+    watch: usize,
+    capacity: usize,
+    ticks: usize,
+) -> Option<usize> {
+    // index 0 = the long prompt under test; the queue is in ARRIVAL
+    // order, which is what the scheduler hands the policy.
+    let mut queue: Vec<usize> = vec![5000];
+    let mut ids: Vec<usize> = vec![watch];
+    for tick in 0..ticks {
+        // Arrivals land at the BACK of the queue BEFORE this tick's
+        // selection — the ordering that makes the starvation reachable
+        // at all. `capacity` of them, so the queue never drains and the
+        // policy always has a full menu of shorter jobs to prefer.
+        for a in 0..capacity.max(1) {
+            queue.push(10);
+            ids.push(watch + 1 + tick * capacity.max(1) + a);
+        }
+        let infos: Vec<PendingRequestInfo> = queue
+            .iter()
+            .enumerate()
+            .map(|(i, &prompt_len)| PendingRequestInfo {
+                prompt_len,
+                index: i,
+            })
+            .collect();
+        let sel = policy.select_prefills(&infos, capacity);
+        if sel.iter().any(|&i| ids[i] == watch) {
+            return Some(tick);
+        }
+        let mut rm = sel.clone();
+        rm.sort_unstable_by(|a, b| b.cmp(a));
+        for i in rm {
+            queue.remove(i);
+            ids.remove(i);
+        }
+    }
+    None
+}
+
+// A queued long prompt must eventually be prefilled. Pure
+// shortest-job-first re-sorts it to the tail on EVERY tick, so under a
+// steady arrival of shorter requests it is never selected — an
+// unbounded wait, not a slow one. The bound is the queue position, so
+// the head of the queue must be selected on the very first tick.
+#[test]
+fn slai_does_not_starve_a_long_prompt_behind_short_arrivals() {
+    let policy = SlaiPolicy::new(100);
+    assert_eq!(
+        ticks_until_selected(&policy, 0, 1, 500),
+        Some(0),
+        "the oldest pending request must be selected immediately"
+    );
+}
+
+// Same guarantee at wider capacity: reserving a seat for the queue head
+// must not depend on the batch being narrow.
+#[test]
+fn slai_head_reservation_holds_at_every_capacity() {
+    let policy = SlaiPolicy::new(100);
+    for capacity in 1..=8usize {
+        assert_eq!(
+            ticks_until_selected(&policy, 0, capacity, 200),
+            Some(0),
+            "starved at capacity {capacity}"
+        );
+    }
+}
+
+// FIFO is bounded by construction — pinned so the harness above is
+// shown to detect selection, not merely to return Some for anything.
+#[test]
+fn fifo_never_starves_the_head() {
+    assert_eq!(ticks_until_selected(&FifoPolicy, 0, 1, 10), Some(0));
+}
+
+#[test]
+fn select_prefills_empty() {
+    assert!(FifoPolicy.select_prefills(&[], 5).is_empty());
+    assert!(SlaiPolicy::new(100).select_prefills(&[], 5).is_empty());
+}
+
+#[test]
+fn fifo_slice_budget_is_full_chunk() {
+    // Default trait impl: FIFO always injects the full chunk.
+    let policy = FifoPolicy;
+    assert_eq!(policy.prefill_slice_budget(&[], 4080), 4080);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now(),
+    }];
+    assert_eq!(policy.prefill_slice_budget(&timings, 4080), 4080);
+}
+
+#[test]
+fn slai_slice_budget_full_when_no_active() {
+    let policy = SlaiPolicy::new(100);
+    assert_eq!(policy.prefill_slice_budget(&[], 4080), 4080);
+}
+
+#[test]
+fn slai_slice_budget_zero_past_deadline() {
+    // worst >= tbt_deadline → hard suppress (0), decode-only this tick.
+    let policy = SlaiPolicy::new(100);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now() - Duration::from_millis(120),
+    }];
+    assert_eq!(policy.prefill_slice_budget(&timings, 4080), 0);
+}
+
+#[test]
+fn slai_slice_budget_bounded_and_wy4_aligned() {
+    // Fresh decode, under deadline → a positive, WY4-aligned slice in
+    // [min, full_chunk], never 0.
+    let policy = SlaiPolicy::new(100);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now(),
+    }];
+    let b = policy.prefill_slice_budget(&timings, 4080);
+    assert!(b > 0, "non-deadline budget must be > 0");
+    assert!(b <= 4080, "must never exceed full_chunk");
+    assert_eq!(b % 4, 0, "must be WY4-aligned");
+}
+
+#[test]
+fn slai_slice_budget_never_exceeds_small_full_chunk() {
+    // Small chunk cap must clamp the slice (and stay WY4-aligned).
+    let policy = SlaiPolicy::new(100);
+    let timings = vec![ActiveSeqTiming {
+        last_token_time: Instant::now(),
+    }];
+    let b = policy.prefill_slice_budget(&timings, 64);
+    assert!(b <= 64);
+    assert_eq!(b % 4, 0);
+}

--- a/scripts/check_kernel_shadows.py
+++ b/scripts/check_kernel_shadows.py
@@ -114,11 +114,28 @@ def main() -> int:
         print(f"error: kernels root not found: {kernels_root}", file=sys.stderr)
         return 1
 
+    # ★ Every hardware tree in the map must EXIST. The loop below skips a
+    # missing one, so a rename or a move of `kernels/gb10` left this required
+    # check scanning nothing and printing "kernel shadow structure: OK" --
+    # verified by running it against an empty `kernels/`: rc=0. A gate that
+    # cannot see its inputs must refuse, not congratulate. HW_SOURCE_EXT is the
+    # SSOT for which trees are covered; adding or removing hardware means
+    # editing it in the same commit, which is exactly the moment to notice.
+    missing = [hw for hw in sorted(HW_SOURCE_EXT) if not (kernels_root / hw).is_dir()]
+    if missing:
+        print(
+            f"error: {kernels_root}/ is missing hardware tree(s): {', '.join(missing)}.\n"
+            f"       They are listed in HW_SOURCE_EXT, so this check believes it covers\n"
+            f"       them -- and it silently scanned nothing instead. If a tree moved or\n"
+            f"       was retired, update HW_SOURCE_EXT in the same commit.",
+            file=sys.stderr,
+        )
+        return 1
+
     violations = []
     for hw_name, ext in sorted(HW_SOURCE_EXT.items()):
         hw_dir = kernels_root / hw_name
-        if hw_dir.is_dir():
-            violations.extend(check_hw(hw_name, hw_dir, ext))
+        violations.extend(check_hw(hw_name, hw_dir, ext))
 
     if violations:
         print(f"kernel shadow structure: {len(violations)} violation(s)")
@@ -126,7 +143,10 @@ def main() -> int:
             print(f"  {v}")
         return 1
 
-    print("kernel shadow structure: OK")
+    print(
+        "kernel shadow structure: OK "
+        f"({len(HW_SOURCE_EXT)} hardware trees scanned: {', '.join(sorted(HW_SOURCE_EXT))})"
+    )
     return 0
 
 


### PR DESCRIPTION
## One campaign, three lanes, ten fixes

Three autonomous audit lanes ran overnight against `origin/main`. Every commit here touches `crates/`, so each would owe its own ~5 GPU-hour campaign standing alone — **grouped, they owe one.** Composed with zero cherry-pick conflicts.

### Lane A — error paths (3 commits)

| finding | why it matters |
|---|---|
| **Shutdown dropped in-flight requests silently.** Of the three parked states, only `preempted` got an error frame; `prefilling` was freed and `swapped` had its disk image deleted, sinks dropped | A dropped sink is not a quiet failure but a **false** one — the client renders `500 "Inference cancelled"`, the same words used when the *client* aborts, so log and client agree on a lie. Streaming clients get a truncated body under an HTTP 200 already committed. `docker stop` is the common path in |
| Swap-IN failure was log-only; the sequence's sink and its claimed slot were both lost | |
| `/v1/completions` mid-stream error frame built by string interpolation | any message with `"`, `\` or a newline emitted **invalid JSON under HTTP 200** — the client's parser raises instead of showing the reason |

### Lane B — record honesty (6 commits)

| finding | why it matters |
|---|---|
| An unreadable `pulls/N/files` recorded `changed_paths: []` | read downstream as *touches nothing* → no targets, no owners, no promotion debt — and **first place in the merge order**, because 0 partners / 0 targets / 0 files *are* the sort keys. An API error published **"Merge next: #N"** |
| `git diff … > changed.txt \|\| true` — the redirect truncates before git runs | a failed diff → `Changed paths (0 total)` in the classifier prompt, i.e. the model classifying from **title and body alone**, with its confident answer appended to the journey ledger |
| `mapfile < <(git diff … )` in **"One PR, one commit, one signer"** | a process substitution's status is invisible to `set -euo pipefail`, so a failed enumeration → *"this PR adds no records — nothing to agree on"* + exit 0, **clearing every unsigned-record check at once** |
| Throttle counters summed with `unwrap_or(0)` into `.benchmarks/**` | "nothing readable" became `Some(0.0)` — identical to a cool run |
| `min_cached_prompt_tokens: …unwrap_or(0)` | "no round reported a figure" stamped with the **vacuity value the metric exists to detect** |
| Blind PR grouped under `"host / non-kernel"` | a claim about a diff nobody read, and the least alarming category available |

Schema choice, stated: **mark, don't drop.** A dropped record is absent, and absent reads as *no such PR* — vanishing from the collision table and the merge order it should be blocking. `paths_unknown` is `#[serde(default)]`, so old records still parse and still mean *known-and-empty*.

### Lane C — required-check honesty (1 commit)

An audit of **all 20 required contexts** on `main`. Five could not do their job:

| context | defect |
|---|---|
| `cargo test --features metal` | inherits `ATLAS_SKIP_BUILD: "1"` workflow-wide → `atlas-kernels` emits a stub → the suite's verdict is about **the stub, not the kernels** |
| `Enforce ≤500 LoC` | `find crates` on a missing tree feeds the loop nothing → **passes** |
| `kernel shadow structure` | skipped absent trees → empty `kernels/` → **"OK"** |
| `No block_on under tui/` | same shape — a renamed directory silences it |
| `Build mdBook + rustdoc` | `needs:` with **no `if:`** — a failed dependency *skips* it, and a skipped required check counts as satisfied |

The metal fix is `ATLAS_SKIP_BUILD: "0"` on that step, with two anti-permanence guards: a static check (env merges workflow→job→step, so re-inheriting is caught) and `metal_backend::tests::embedded_kernels`, a runtime assert **with no skip path**.

## Gates on the composed tree

`cargo check --workspace --all-targets` ✅ · spark-server **2338/2338** · atlas-plugin **910/910** · certification-selftest **138 passed, 0 failed** (110 on main — 28 new rows, each with a negative control observed red then green) · `cargo fmt --check` clean.

## Campaign accounting

10 commits touching `crates/` → **one** campaign for the group, not ten. Every constituent lane branch is kept intact, so a failing gate can drop one lane and re-certify the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
