### PR TITLE
kernels: exclude unsupported dense NVFP4 MMQ entry points

### DIFF
--- a/crates/atlas-kernels/tests/nvfp4_mmq_capability.rs
+++ b/crates/atlas-kernels/tests/nvfp4_mmq_capability.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! A resolved symbol must not disguise the vendor's unsupported-ISA trap.
+//! The first real H100 dense-27B request hit quantize_impl.cuh's NO_DEVICE_CODE
+//! despite a green symbol audit. Guard the entire optional module using the
+//! vendor's capability predicate, before Rust resolves any of its handles.
+
+use std::path::{Path, PathBuf};
+
+fn root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../kernels")
+}
+
+fn source() -> String {
+    std::fs::read_to_string(root().join("gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu")).unwrap()
+}
+
+fn exports(text: &str) -> Vec<String> {
+    text.lines()
+        .filter(|line| line.starts_with("extern \"C\" __global__ void "))
+        .map(|line| {
+            let name = line.split("atlas_nvfp4_").nth(1).unwrap();
+            format!("atlas_nvfp4_{}", name.split('(').next().unwrap())
+        })
+        .collect()
+}
+
+#[test]
+fn every_mmq_export_is_inside_the_vendor_capability_guard() {
+    let text = source();
+    let marker = "#if defined(BLACKWELL_MMA_AVAILABLE) // Atlas optional module";
+    let (before, inside) = text.split_once(marker).expect(
+        "Hopper resolves trap-only MMQ symbols: guard exports before handle-based selection",
+    );
+    assert!(exports(before).is_empty());
+    assert!(
+        inside
+            .trim_end()
+            .ends_with("#endif // Atlas optional module")
+    );
+    assert_eq!(exports(inside).len(), 13);
+    // This is the SAME macro used by both quantize_mmq_nvfp4_worker and MMA.
+    // A generic 'Blackwell or newer' check would incorrectly admit B200.
+    let vendor =
+        std::fs::read_to_string(root().join("gb10/qwen3.6-27b/nvfp4/q4k_vendor/common.cuh"))
+            .unwrap();
+    assert!(vendor.contains("#define GGML_CUDA_CC_BLACKWELL       1200"));
+    assert!(vendor.contains("#define GGML_CUDA_CC_RUBIN           1300"));
+    assert!(
+        vendor.contains(
+            "__CUDA_ARCH__ >= GGML_CUDA_CC_BLACKWELL && __CUDA_ARCH__ < GGML_CUDA_CC_RUBIN"
+        )
+    );
+}
+
+#[test]
+fn gb10_dense_targets_keep_every_supported_mmq_export() {
+    let functions = exports(&source());
+    assert_eq!(functions.len(), 13);
+    // GB10 is SM 12.1: BLACKWELL_MMA_AVAILABLE is defined, so every entry
+    // point above compiles to real device code and none of them may be
+    // declared absent. A target whose arch does not define the predicate
+    // records each exclusion under `expected_absent.nvfp4_mmq` instead.
+    for model in ["qwen3.6-27b", "qwen3.8-27b"] {
+        let path = root().join("gb10").join(model).join("MODEL.toml");
+        let doc: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let absent = doc.get("expected_absent").and_then(|t| t.get("nvfp4_mmq"));
+        assert!(absent.is_none(), "GB10 must retain the supported MMQ path");
+    }
+}

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -2666,6 +2666,10 @@ fn native_small_batch_uses_prefill(has_bf16: bool, has_fp8: bool) -> bool {
 }
 
 #[cfg(test)]
+#[path = "dense_ffn_mmq_tests.rs"]
+mod mmq_tests;
+
+#[cfg(test)]
 mod tests {
     use super::native_small_batch_uses_prefill;
 

--- a/crates/spark-model/src/layers/dense_ffn_mmq_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_mmq_tests.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Missing optional MMQ kernels must leave the W4A16 fallback usable at load.
+
+use super::{DenseFfnLayer, DenseFfnWeights};
+use crate::weight_map::QuantizedWeight;
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+#[test]
+fn unavailable_mmq_preserves_transposed_weights_without_repack_or_free() {
+    let gpu = MockGpuBackend::new();
+    let mut weight = QuantizedWeight::null();
+    weight.weight = gpu.alloc(64).unwrap();
+    weight.weight_scale = gpu.alloc(8).unwrap();
+    let weights = DenseFfnWeights {
+        gate_proj: weight,
+        up_proj: weight,
+        down_proj: weight,
+        gate_proj_t: Some(weight),
+        up_proj_t: Some(weight),
+        down_proj_t: Some(weight),
+    };
+    let mut layer = DenseFfnLayer::new(weights, &gpu).unwrap();
+    // try_kernel returns this handle when the capability-guarded entry point
+    // is absent. Other handles remain present: one missing required operation
+    // must disable the entire MMQ load path, including freeing fallback twins.
+    layer.nvfp4_mmq_nc_k = KernelHandle(0);
+    let allocations = gpu.alloc_count();
+    let launches = gpu.launch_count();
+    layer.finalize_nvfp4_mmq_load(&gpu, 64, 64, 0).unwrap();
+    assert_eq!(gpu.alloc_count(), allocations);
+    assert_eq!(gpu.launch_count(), launches);
+    assert_eq!(gpu.sync_count(), 0);
+    for transpose in [
+        layer.weights.gate_proj_t,
+        layer.weights.up_proj_t,
+        layer.weights.down_proj_t,
+    ] {
+        assert_eq!(transpose.unwrap().weight, weight.weight);
+    }
+    assert!(layer.fp4mmq_gate.get().is_none());
+    assert!(layer.fp4mmq_up.get().is_none());
+    assert!(layer.fp4mmq_down.get().is_none());
+}

--- a/kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu
+++ b/kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu
@@ -19,6 +19,11 @@
 #include "q4k_vendor/mmq.cuh"
 #include "q4k_vendor/quantize_impl.cuh"
 
+// A symbol must not resolve to the vendor's NO_DEVICE_CODE trap. Use its
+// capability predicate (SM 12.x, not datacentre Blackwell SM 10.x). Absent
+// handles keep DenseFfn's W4A16 fallback and its transposed weights intact.
+#if defined(BLACKWELL_MMA_AVAILABLE) // Atlas optional module
+
 // Conventional-tiling setup mirroring mul_mat_q's pre-VOLTA path, specialized: no ids,
 // nchannels_y=nsamples_y=1 (blockIdx.z==0). Calls the existing __device__ process_tile.
 template <int mmq_x, bool need_check>
@@ -310,3 +315,5 @@ extern "C" __global__ void atlas_nvfp4_silu_mul_quant(
     NO_DEVICE_CODE;
 #endif
 }
+
+#endif // Atlas optional module


### PR DESCRIPTION
## Summary

The dense NVFP4 MMQ entry points in `kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu` were exported unconditionally, but the vendor code they call is gated on `BLACKWELL_MMA_AVAILABLE`, which is only defined for `__CUDA_ARCH__` in `[1200, 1300)` — i.e. consumer/GB10 SM 12.x. Compiling the same sources for a non-SM-12.x arch still produced the 13 `atlas_nvfp4_*` symbols, with bodies that are nothing but the vendor's `NO_DEVICE_CODE` trap.

That made the symbol audit lie. `--check-kernels` resolved every handle and reported green, so `DenseFfnLayer` took the MMQ load path, repacked the NVFP4 weights and freed the transposed W4A16 twins. The first real prefill on an H100 then hit `quantize_mmq_nvfp4_worker has no device code compatible with CUDA arch 900`, which leaves the context in a sticky CUDA 719 — every subsequent launch fails and the server never serves a token.

Fixes #913

## Why

A resolved symbol must not be able to disguise an unsupported-ISA trap. Handle-based capability selection is only sound if absence of the capability means absence of the handle. Guarding the whole optional module with the vendor's own predicate — rather than a hand-rolled "Blackwell or newer" test, which would wrongly admit datacentre SM 10.x — restores that invariant at the source level, before Rust ever resolves a handle.

## What changed

- `kernels/gb10/qwen3.6-27b/nvfp4/nvfp4_mmq.cu`: wrap the public implementation, from the first template through the last `extern "C" __global__`, in `#if defined(BLACKWELL_MMA_AVAILABLE)`. On a supported arch nothing changes; on an unsupported one the module compiles to nothing and the handles are simply absent.
- `crates/spark-model/src/layers/dense_ffn.rs` + `dense_ffn_mmq_tests.rs`: a regression test pinning the behaviour the absent handles must produce — one missing required entry point disables the entire MMQ load path, so the transposed W4A16 weights are neither repacked nor freed and no `fp4mmq_*` state is installed. No allocations, launches or syncs on that path.
- `crates/atlas-kernels/tests/nvfp4_mmq_capability.rs`: a source-level guard test. Every one of the 13 exports must live inside the marker block, the block must use the same macro the vendor uses for `quantize_mmq_nvfp4_worker` and MMA, and the GB10 targets — which do define the predicate — must keep the supported MMQ path with no exclusions recorded.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --locked -p atlas-kernels` — 32 passed, 0 failed, 7 ignored (need nvcc/GPU), including both new `nvfp4_mmq_capability` tests
- [x] `cargo test --locked -p spark-model` — 645 passed, 0 failed, 14 ignored, including `mmq_tests::unavailable_mmq_preserves_transposed_weights_without_repack_or_free`
- [x] `cargo clippy --locked -p atlas-kernels -p spark-model --tests` — clean
- [ ] `typos` — not installed on the gate host, skipped
- [x] Tested against real hardware: see below

## Hardware evidence

Verified on an H100 with the dense 27B NVFP4 target. The rebuilt binary boots in 22 s, the log carries zero trap lines, the coherency check passes 4/4, and the C=1 ladder runs to completion — where the pre-fix binary died on the first prefill with the arch-900 trap and the sticky 719.

## Notes for reviewers

The equivalent `expected_absent.nvfp4_mmq` audit tables for the Hopper targets live in the Hopper kernel-target PR (#895), together with the `kernels/hopper/` directories they belong to; they are deliberately not in this PR, which is arch-agnostic and only fixes the source guard plus the fallback behaviour. The capability test here asserts the GB10 half of that contract, and #895 extends it to the arches that record exclusions.

Split out of the campaign branch `hopper/sm90-target-tdd-2026-09` (#895); origin commit 9cfce36c.

## Authorship

AI-authored (Claude).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
