### PR TITLE
xgrammar: borrow the vocabulary during grammar mask preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,6 +2735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stats_alloc"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e04424e733e69714ca1bbb9204c1a57f09f5493439520f9f68c132ad25eec"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +3601,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "stats_alloc",
  "thiserror",
 ]
 

--- a/crates/xgrammar/Cargo.toml
+++ b/crates/xgrammar/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "2"
 # Micro-benchmark harness for the Tier-1 perf work — measures
 # `GrammarCompiler::compile_*` and `GrammarMatcher::fill_next_token_bitmask`.
 criterion = "0.8"
+stats_alloc = "=0.1.10"
 
 [[bench]]
 name = "grammar_bench"

--- a/crates/xgrammar/src/compiler/mask_gen/intervals.rs
+++ b/crates/xgrammar/src/compiler/mask_gen/intervals.rs
@@ -60,9 +60,13 @@ impl MaskGenerator<'_> {
         first_char_mask: &[bool; 256],
         is_root_rule: bool,
     ) -> bool {
-        let sorted = self.tokenizer_info.sorted_decoded_vocab().to_vec();
-        let subtree = self.tokenizer_info.trie_subtree_nodes_range().to_vec();
-        let (intervals, possible) = possible_token_intervals(&sorted, first_char_mask);
+        // The tokenizer is external immutable data: copy its reference so
+        // mutating the parser does not require copying every vocabulary token
+        // for each prepared mask (especially costly with concurrent workers).
+        let tokenizer_info = self.tokenizer_info;
+        let sorted = tokenizer_info.sorted_decoded_vocab();
+        let subtree = tokenizer_info.trie_subtree_nodes_range();
+        let (intervals, possible) = possible_token_intervals(sorted, first_char_mask);
         if intervals.is_empty() {
             return true;
         }
@@ -87,7 +91,7 @@ impl MaskGenerator<'_> {
 
         let mut prev_matched: i32 = 0;
         let mut last_rejected_range: i32 = 0;
-        let mut prev_token: Option<Vec<u8>> = None;
+        let mut prev_token: Option<&[u8]> = None;
 
         for interval_idx in 0..intervals.len() {
             let (lo, hi) = intervals[interval_idx];
@@ -126,8 +130,8 @@ impl MaskGenerator<'_> {
                     continue;
                 }
 
-                let advanced = self.scan_one_token(token, prev_token.as_deref(), &mut prev_matched);
-                prev_token = Some(token.clone());
+                let advanced = self.scan_one_token(token, prev_token, &mut prev_matched);
+                prev_token = Some(token);
 
                 let can_reach_end = *self.can_reach_end_prefix_or_stack.last().unwrap();
                 if advanced {

--- a/crates/xgrammar/tests/vocabulary_allocations.rs
+++ b/crates/xgrammar/tests/vocabulary_allocations.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Allocation oracle for the production cold-mask path, with no timing limit.
+
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
+use std::alloc::System;
+use xgrammar::compiler::GrammarCompiler;
+use xgrammar::matcher::GrammarMatcher;
+use xgrammar::tokenizer::{TokenizerInfo, VocabType};
+
+#[global_allocator]
+static ALLOCATOR: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+fn cold_mask_allocations(irrelevant_tokens: usize) -> usize {
+    let mut vocab: Vec<String> = (0..irrelevant_tokens)
+        .map(|i| format!("z-irrelevant-token-{i:012}"))
+        .collect();
+    vocab.push("yes".into());
+    vocab.push("<eos>".into());
+    let eos = (vocab.len() - 1) as i32;
+    let info = TokenizerInfo::new(&vocab, VocabType::Raw, None, Some(vec![eos]), false);
+    let compiler = GrammarCompiler::new(info, 1, false, -1);
+    let grammar = compiler
+        .compile_grammar_from_ebnf("root ::= \"yes\"\n", "root")
+        .unwrap();
+
+    // Tokenizer construction is intentionally outside the measured region.
+    // None of the added z-prefixed tokens can match any state of "yes".
+    let region = Region::new(ALLOCATOR);
+    let states = grammar.compile_top_k_masks(512);
+    let stats = region.change();
+    assert_eq!(states, 3);
+    let allocations = stats.allocations + stats.reallocations;
+    println!("irrelevant={irrelevant_tokens} states={states} allocations={allocations}");
+
+    let mut matcher = GrammarMatcher::new(grammar, None, false, -1);
+    assert!(!matcher.accept_string("z-irrelevant", false));
+    assert!(matcher.accept_string("yes", false));
+    assert!(matcher.accept_token(eos, false));
+    assert!(matcher.is_terminated());
+    allocations
+}
+
+#[test]
+fn irrelevant_vocabulary_does_not_allocate_per_token_during_mask_preparation() {
+    let small = cold_mask_allocations(4096);
+    let large = cold_mask_allocations(8192);
+    assert!(
+        large <= small,
+        "cold mask preparation allocated buffers for irrelevant vocabulary: {small} -> {large}"
+    );
+}


### PR DESCRIPTION
## Summary

`MaskGenerator::token_mask_with_first_char_check` opened by cloning the tokenizer's sorted decoded vocabulary and its trie subtree ranges — `.to_vec()` on both — and then cloned each token again into `prev_token` while scanning. The tokenizer is immutable external data; the clones existed only to sidestep the borrow against `&mut self`. At a 248k-token vocabulary that is roughly 30M small allocations per compiled schema, paid once per prepared state.

Refs #918

## Why

The cost is invisible in a profile that looks at grammar logic, because none of it is grammar logic — it is allocator traffic proportional to vocabulary size times prepared states, on a path whose actual work is proportional to the *matching* tokens. Borrowing the tokenizer instead of copying it makes the cost track the work.

## What changed

- `crates/xgrammar/src/compiler/mask_gen/intervals.rs`: copy the `&TokenizerInfo` reference out of `self` before the mutable borrow begins, then use `sorted_decoded_vocab()` and `trie_subtree_nodes_range()` as slices. `prev_token` becomes `Option<&[u8]>` instead of `Option<Vec<u8>>`, removing the per-token clone in the scan loop.
- `crates/xgrammar/tests/vocabulary_allocations.rs`: an allocation oracle over `stats_alloc`, which measures how cold compile allocations grow when the vocabulary gains tokens the schema can never match. This is the property that regressed silently before — a correctness test cannot see it, because the masks were always right.
- `Cargo.lock`, `crates/xgrammar/Cargo.toml`: `stats_alloc = "=0.1.10"` as a dev-dependency. Pinned exactly because it is a measurement instrument; a patch bump that changes counting would move the oracle's numbers for reasons unrelated to Atlas.

## Numbers

Doubling the vocabulary with tokens irrelevant to the schema:

| | allocations before | allocations after doubling |
|---|---|---|
| old code | 12,356 | 24,644 |
| new code | 58 | 58 |

Masks are byte-identical against the golden files in both the serial and the parallel mode — this changes how the vocabulary is reached, not what is computed from it.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --locked -p xgrammar` — 825 passed, 0 failed: 822 unit, 2 `qwen_toolcall_mask`, 1 new `vocabulary_allocations`
- [x] `cargo clippy --locked -p xgrammar --tests` — clean
- [ ] `typos` — not installed on the gate host, skipped
- [x] Tested against real hardware: see below

## Hardware evidence

On an H100, cold time to the first tool token with the serial default: 4.82 s -> 3.38 s.

## Notes for reviewers

Partial fix for #918 — this removes the allocation waste, but the ~3.4 s cold compile remains and the issue stays open. The parallel prewarm that was tried against the remainder is not in this PR; it was added and reverted on the campaign branch and is a net no-op.

Split out of the campaign branch `hopper/sm90-target-tdd-2026-09` (#895); origin commits 72834f21 and cd8c1193.

## Authorship

AI-authored (Claude).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
