### PR TITLE
spark-model: select native FP8 FFN kernels by batch size

### DIFF
--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -238,6 +238,8 @@ pub struct DenseFfnLayer {
     fp8_weights: Option<DenseFfnWeightsFp8>,
     w8a16_gemv_k: KernelHandle,
     w8a16_gemm_k: KernelHandle,
+    w8a16_gemv_batch4_k: KernelHandle,
+    w8a16_gemm_pipelined_k: KernelHandle,
     // Fused FP8 decode GEMVs (gate+up in one launch / silu+down in one launch),
     // mirroring the NVFP4 w4a16_gemv_dual / w4a16_gemv_silu_input. KernelHandle(0)
     // on miss → fall back to the 3-launch w8a16_gemv path. Module = .cu file stem.
@@ -407,6 +409,12 @@ impl DenseFfnLayer {
             fp8_weights: None,
             w8a16_gemv_k: super::try_kernel(gpu, "w8a16_gemv", "w8a16_gemv"),
             w8a16_gemm_k: super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),
+            w8a16_gemv_batch4_k: super::try_kernel(gpu, "w8a16_gemv_batch4", "w8a16_gemv_batch4"),
+            w8a16_gemm_pipelined_k: super::try_kernel(
+                gpu,
+                "w8a16_gemm_pipelined",
+                "w8a16_gemm_pipelined",
+            ),
             w8a16_gemv_dual_k: super::try_kernel(gpu, "w8a16_gemv_fused", "w8a16_gemv_dual"),
             w8a16_gemv_silu_input_k: super::try_kernel(
                 gpu,
@@ -1921,19 +1929,28 @@ impl DenseFfnLayer {
             return Ok(());
         }
 
-        // FP8 prefill dispatch: per-projection block-scaled E4M3 weight × BF16
-        // act. Prefer the fast transposed `w8a16_gemm_t_m128` (128x128 / 8-warp /
-        // two-level FP32 fold) when a transposed FP8 weight copy is available;
-        // fall back to the non-transposed `w8a16_gemm`. `DenseFfnWeightsFp8`
-        // currently stores only non-transposed weights, so the fallback is taken
-        // here today — the m128 preference engages once a `*_proj_t` FP8 copy is
-        // installed (the kernel + handle are wired and ship via common/).
+        // Native FP8: small batches stream each weight once via the existing
+        // M<=4 GEMV, avoiding padded MMA tiles. Larger prefills prefer a
+        // transposed copy when available, then the same-format pipelined GEMM.
+        // Every fallback retains the original E4M3 bytes and FP32 block scales.
         if let Some(ref fp8w) = self.fp8_weights {
-            // helper: transposed m128 when a B_t copy + handle are present, else
-            // non-transposed w8a16_gemm.
             macro_rules! w8_gemm {
                 ($w:expr, $wt:expr, $in:expr, $out:expr, $n:expr, $k:expr) => {
                     match $wt {
+                        _ if (1..=4).contains(&m) && self.w8a16_gemv_batch4_k.0 != 0 => {
+                            ops::w8a16_gemv_batch4(
+                                ctx.gpu,
+                                self.w8a16_gemv_batch4_k,
+                                $in,
+                                $w.weight,
+                                $w.row_scale,
+                                $out,
+                                m,
+                                $n,
+                                $k,
+                                stream,
+                            )?
+                        }
                         Some(wt) if self.w8a16_gemm_t_m128_k.0 != 0 => {
                             let wt: Fp8WeightTransposed = wt;
                             ops::w8a16_gemm_n128_m128(
@@ -1949,6 +1966,18 @@ impl DenseFfnLayer {
                                 stream,
                             )?
                         }
+                        _ if self.w8a16_gemm_pipelined_k.0 != 0 => ops::w8a16_gemm_pipelined(
+                            ctx.gpu,
+                            self.w8a16_gemm_pipelined_k,
+                            $in,
+                            $w.weight,
+                            $w.row_scale,
+                            $out,
+                            m,
+                            $n,
+                            $k,
+                            stream,
+                        )?,
                         _ => ops::w8a16_gemm(
                             ctx.gpu,
                             self.w8a16_gemm_k,
@@ -2674,6 +2703,10 @@ fn native_small_batch_uses_prefill(has_bf16: bool, has_fp8: bool) -> bool {
 #[cfg(test)]
 #[path = "dense_ffn_native_batch_tests.rs"]
 mod native_batch_tests;
+
+#[cfg(test)]
+#[path = "dense_ffn_kernel_tests.rs"]
+mod kernel_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -1564,6 +1564,12 @@ impl DenseFfnLayer {
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
+        // As in k2/k3, concurrent decode must preserve an installed native
+        // overlay even when valid, lower-precision NVFP4 fallbacks coexist.
+        if native_small_batch_uses_prefill(self.bf16_weights.is_some(), self.fp8_weights.is_some())
+        {
+            return self.forward_prefill(input, m as usize, ctx, stream);
+        }
         let h = ctx.config.hidden_size as u32;
         let inter = ctx.config.intermediate_size as u32;
         let kh = self.batchm_kernel(m);
@@ -2659,11 +2665,15 @@ impl DenseFfnLayer {
     }
 }
 
-/// Native BF16/FP8 layers do not own usable NVFP4 fallback weights. Their
-/// small-batch path must therefore use the format-aware prefill dispatcher.
+/// Native BF16/FP8 overlays take precedence over any NVFP4 fallback weights.
+/// Small batches must use the same format-aware dispatcher as prefill.
 fn native_small_batch_uses_prefill(has_bf16: bool, has_fp8: bool) -> bool {
     has_bf16 || has_fp8
 }
+
+#[cfg(test)]
+#[path = "dense_ffn_native_batch_tests.rs"]
+mod native_batch_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/dense_ffn_kernel_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_kernel_tests.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Native FP8 FFN must use the existing kernels suited to the row count.
+
+use super::{DenseFfnLayer, DenseFfnWeights};
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::weight_map::{Fp8Weight, QuantizedWeight, WeightQuantFormat};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::{MockArg, MockGpuBackend};
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+fn run_case(
+    rows: u32,
+    prefill: bool,
+    expected: u64,
+    grid: [u32; 3],
+    block: [u32; 3],
+    configure: impl FnOnce(&mut DenseFfnLayer),
+) {
+    let gpu = MockGpuBackend::new();
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = 128;
+    config.intermediate_size = 128;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    let buffers = BufferArena::new(&config, 8, 256, 256, 8, &gpu).unwrap();
+    // Real fallback weights coexist with the FP8 overlay in the loader.
+    // The regression is selecting these valid but lower-precision bytes.
+    let mut fallback = QuantizedWeight::null();
+    fallback.weight = gpu.alloc(128 * 64).unwrap();
+    fallback.weight_scale = gpu.alloc(128 * 8).unwrap();
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: fallback,
+            up_proj: fallback,
+            down_proj: fallback,
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        &gpu,
+    )
+    .unwrap();
+    // Mock kernel lookup deliberately returns one placeholder for every name;
+    // separate these handles so the oracle identifies actual dispatch routes.
+    layer.w8a16_gemm_k = KernelHandle(0xF08);
+    layer.act_mul = KernelHandle(0xAC7);
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(128 * 128).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n: 128,
+        k: 128,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    layer.set_fp8_weights(fp8, fp8, fp8);
+    configure(&mut layer);
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let ctx = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu: &gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    let start = gpu.launch_count();
+    let allocs = gpu.alloc_count();
+    if prefill {
+        layer
+            .forward_prefill(buffers.norm_output(), rows as usize, &ctx, 7)
+            .unwrap();
+    } else {
+        assert!(layer.can_forward_km(rows));
+        layer
+            .forward_km(buffers.norm_output(), rows, &ctx, 7)
+            .unwrap();
+    }
+    assert_eq!(
+        gpu.alloc_count(),
+        allocs,
+        "dispatch must not allocate weight copies"
+    );
+    let launches = gpu.launches_snapshot();
+    let launches = &launches[start..];
+    let projections: Vec<_> = launches
+        .iter()
+        .filter(|launch| launch.func != layer.act_mul.0)
+        .collect();
+    assert_eq!(projections.len(), 3);
+    for launch in projections {
+        assert_eq!(
+            launch.func, expected,
+            "M={rows}: gate/up/down selected the wrong native kernel"
+        );
+        assert_eq!(launch.grid, grid);
+        assert_eq!(launch.block, block);
+        assert_eq!(launch.stream, 7);
+        assert_eq!(launch.args[1], MockArg::Buffer(fp8.weight));
+        assert_eq!(launch.args[2], MockArg::Buffer(fp8.row_scale));
+        assert_eq!(launch.args[4], MockArg::Bytes(rows.to_ne_bytes().to_vec()));
+        assert_eq!(
+            launch.args[5],
+            MockArg::Bytes(128_u32.to_ne_bytes().to_vec())
+        );
+        assert_eq!(
+            launch.args[6],
+            MockArg::Bytes(128_u32.to_ne_bytes().to_vec())
+        );
+        assert!(!launch.args.contains(&MockArg::Buffer(fallback.weight)));
+    }
+}
+
+#[test]
+fn small_native_ffn_uses_existing_batched_gemv() {
+    for rows in [1, 2, 3, 4] {
+        run_case(rows, true, 0xDEAD, [32, 1, 1], [256, 1, 1], |_| {});
+    }
+    run_case(4, false, 0xDEAD, [32, 1, 1], [256, 1, 1], |_| {});
+}
+
+#[test]
+fn larger_native_ffn_uses_existing_pipelined_gemm() {
+    for rows in [5, 8, 129] {
+        run_case(
+            rows,
+            true,
+            0xDEAD,
+            [4, rows.div_ceil(128), 1],
+            [256, 1, 1],
+            |_| {},
+        );
+    }
+    run_case(5, false, 0xDEAD, [4, 1, 1], [256, 1, 1], |_| {});
+}
+
+#[test]
+fn missing_small_batch_kernel_uses_same_precision_pipelined_fallback() {
+    run_case(4, false, 0xDEAD, [4, 1, 1], [256, 1, 1], |layer| {
+        layer.w8a16_gemv_batch4_k = KernelHandle(0);
+    });
+}
+
+#[test]
+fn missing_optional_kernels_keep_base_native_gemm() {
+    for rows in [4, 5, 129] {
+        run_case(
+            rows,
+            true,
+            0xF08,
+            [2, rows.div_ceil(64), 1],
+            [128, 1, 1],
+            |layer| {
+                layer.w8a16_gemv_batch4_k = KernelHandle(0);
+                layer.w8a16_gemm_pipelined_k = KernelHandle(0);
+            },
+        );
+    }
+}

--- a/crates/spark-model/src/layers/dense_ffn_native_batch_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_native_batch_tests.rs
@@ -41,6 +41,9 @@ fn run_batch(native_fp8: bool, rows: u32) {
     // Mock kernel lookup deliberately returns one placeholder for every name;
     // separate these handles so the oracle identifies actual dispatch routes.
     layer.w8a16_gemm_k = KernelHandle(0xF08);
+    // Also prove the original native fallback when optional fast kernels are absent.
+    layer.w8a16_gemv_batch4_k = KernelHandle(0);
+    layer.w8a16_gemm_pipelined_k = KernelHandle(0);
     layer.act_mul = KernelHandle(0xAC7);
     let fp8 = Fp8Weight {
         weight: gpu.alloc(128 * 128).unwrap(),

--- a/crates/spark-model/src/layers/dense_ffn_native_batch_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_native_batch_tests.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The real multi-row entry point must retain the installed weight format.
+
+use super::{DenseFfnLayer, DenseFfnWeights};
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::weight_map::{Fp8Weight, QuantizedWeight, WeightQuantFormat};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::{MockArg, MockGpuBackend};
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+fn run_batch(native_fp8: bool, rows: u32) {
+    let gpu = MockGpuBackend::new();
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = 128;
+    config.intermediate_size = 128;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    let buffers = BufferArena::new(&config, 8, 16, 16, 8, &gpu).unwrap();
+    // Real fallback weights coexist with the FP8 overlay in the loader.
+    // The regression is selecting these valid but lower-precision bytes.
+    let mut fallback = QuantizedWeight::null();
+    fallback.weight = gpu.alloc(128 * 64).unwrap();
+    fallback.weight_scale = gpu.alloc(128 * 8).unwrap();
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: fallback,
+            up_proj: fallback,
+            down_proj: fallback,
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        &gpu,
+    )
+    .unwrap();
+    // Mock kernel lookup deliberately returns one placeholder for every name;
+    // separate these handles so the oracle identifies actual dispatch routes.
+    layer.w8a16_gemm_k = KernelHandle(0xF08);
+    layer.act_mul = KernelHandle(0xAC7);
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(128 * 128).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n: 128,
+        k: 128,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    if native_fp8 {
+        layer.set_fp8_weights(fp8, fp8, fp8);
+    }
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let ctx = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu: &gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    assert!(layer.can_forward_km(rows));
+    let start = gpu.launch_count();
+    layer
+        .forward_km(buffers.norm_output(), rows, &ctx, 0)
+        .unwrap();
+    let launches = gpu.launches_snapshot();
+    let launches = &launches[start..];
+    let expected = if native_fp8 {
+        layer.w8a16_gemm_k
+    } else {
+        layer.batchm_kernel(rows)
+    };
+    assert_eq!(
+        launches
+            .iter()
+            .filter(|launch| launch.func == expected.0)
+            .count(),
+        3,
+        "M={rows}: gate/up/down must all use the installed weight format"
+    );
+    if native_fp8 {
+        assert!(
+            launches
+                .iter()
+                .all(|launch| { !launch.args.contains(&MockArg::Buffer(fallback.weight)) }),
+            "M={rows}: native FP8 dispatch read the NVFP4 fallback"
+        );
+    }
+}
+
+#[test]
+fn native_fp8_multi_row_dispatch_preserves_checkpoint_weights() {
+    for rows in [4, 5, 8] {
+        run_batch(true, rows);
+    }
+}
+
+#[test]
+fn nvfp4_multi_row_dispatch_keeps_existing_batch_kernels() {
+    for rows in [4, 5, 8] {
+        run_batch(false, rows);
+    }
+}


### PR DESCRIPTION
## Summary

With `ATLAS_DENSE_FP8=1`, the dense FFN resolved the batched FP8 GEMV and the pipelined FP8 GEMM at layer construction and then never used either of them: every native-FP8 projection went to the basic `w8a16_gemm`, whatever the row count. The kernels were present, wired, and idle. Native-FP8 prefill measured ~3.7x slower than the NVFP4 profile on the same model, and multi-row decode collapsed. This routes small batches to `w8a16_gemv_batch4` and larger prompts to `w8a16_gemm_pipelined`.

Refs #917

## Why

The FP8 prefill dispatcher had one shape-independent route. Its comment described a preference between the transposed `w8a16_gemm_t_m128` and the non-transposed `w8a16_gemm`, and since `DenseFfnWeightsFp8` stores no transposed copy today, the non-transposed arm was the only one ever taken. Row count never entered the decision, so an M=4 decode step paid for padded MMA tiles and a 129-row prompt ran a kernel with no pipelining — while the two kernels built for exactly those shapes sat behind live handles.

This is a selection bug, not a numerics one. Every arm consumes the same E4M3 weight bytes and the same FP32 block scales; nothing is requantized, and no arm copies a weight.

## What changed

- `crates/spark-model/src/layers/dense_ffn.rs`: `DenseFfnLayer` resolves and stores `w8a16_gemv_batch4_k` and `w8a16_gemm_pipelined_k`. The FP8 prefill `w8_gemm!` macro gains two arms ahead of the existing ones: M in 1..=4 takes `w8a16_gemv_batch4`, and anything larger takes `w8a16_gemm_pipelined` when the transposed m128 route is unavailable. The unconditional `w8a16_gemm` arm remains last, so a target that compiles neither optional kernel behaves exactly as before.
- `crates/spark-model/src/layers/dense_ffn_kernel_tests.rs` (new): four tests over the mock backend asserting which kernel each row count selects, with distinct handles so the oracle can tell the routes apart. They also assert the launches carry the FP8 weight and row-scale buffers, never the NVFP4 fallback buffer, and that dispatch allocates nothing.
- `crates/spark-model/src/layers/dense_ffn_native_batch_tests.rs`: the multi-row regression test from #922 now zeroes both new handles, so it keeps proving the base `w8a16_gemm` fallback rather than silently retargeting to a faster kernel.

The red version of the new test failed with the selection reversed: dispatch chose the basic `w8a16_gemm` for every row count while `w8a16_gemv_batch4` and `w8a16_gemm_pipelined` were both resolved.

Weight quantization is untouched, and the NVFP4 path is untouched.

## Test plan

- [x] `cargo +1.93.1 fmt --all -- --check` — clean
- [x] `cargo +1.93.1 test --locked -p spark-model` — 646 passed, 0 failed, 11 ignored in the lib suite (642 -> 646: the four new kernel-selection tests), plus 4 passed across the integration targets
- [x] `cargo +1.93.1 clippy --locked -p spark-model --tests -- -D warnings` — clean
- [ ] `typos` — not installed on the gate host, skipped
- [x] Tested against real hardware: see below

## Hardware evidence

H100, Qwen/Qwen3.8-27B-FP8, 1,193 prompt / 256 output tokens, batch-4 profile, temperature 0.

At C=1, TTFT drops from 3,409 ms to 1,074 ms and decode goes from 28.9 to 39.3 tok/s. TPOT is unchanged at 21.3 ms, which is the expected result and worth stating plainly: single-row decode uses the M=1 GEMV path, which this change does not touch.

At C=16, per-active-row decode goes from roughly 3 tok/s to roughly 17-19 tok/s, for an aggregate of 65.0 tok/s.

GPU numerical checks pass for both kernel paths, including equivalence between a batched run and the same rows run repeatedly at C=1. Sixteen concurrent arithmetic prompts were all answered correctly.

## Notes for reviewers

Stacked on #922 — the new tests exercise `forward_km` for native FP8, which only reaches the format-aware dispatcher after that PR's fix. The branch is #922's commit plus this one; review the second commit, or merge #922 first and this diff becomes the whole change.

`Refs` and not `Fixes` for #917: this closes the kernel-selection half only. The M=1 decode GEMV path is untouched, and native FP8 still has not caught the NVFP4 profile — both remain open.

The transposed `w8a16_gemm_t_m128` arm is deliberately left where it is. It is unreachable today because no transposed FP8 weight copy is installed, and making it reachable is a loader change that does not belong in a dispatch fix.

Split out of the campaign branch `hopper/sm90-target-tdd-2026-09` (#895); origin commit 5cde118.

## Authorship

AI-authored (Claude).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
