### PR TITLE
spark-model: restore batched BF16 decode head dispatch

### DIFF
--- a/crates/spark-model/src/model/trait_impl/decode_a2.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_a2.rs
@@ -20,14 +20,6 @@ use crate::layer::{ForwardContext, LayerState, SsmLayerState};
 use crate::layers::ops;
 use crate::traits::{Model, SequenceState};
 
-/// Route the BF16 lm_head decode through the batched GEMV (dense_gemv_bf16_batchm)
-/// instead of the scalar dense_gemm_bf16. Default ON. Mirrors PR #332's
-/// ATLAS_LMHEAD_BATCH_GEMV for the NVFP4 head; this is the BF16 sibling.
-fn lmhead_batch_gemv_enabled() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var("ATLAS_LMHEAD_BATCH_GEMV").ok().as_deref() != Some("0"))
-}
-
 /// Multi-seq decode CUDA graphs: **ON by default**, disabled by
 /// `ATLAS_NO_DECODE_GRAPHS_MULTISEQ=1`.
 ///

--- a/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
+++ b/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
@@ -22,8 +22,9 @@
 //! mixed path has never been A/B'd. Any throughput claim for it must be gated
 //! spec-OFF or on reversed-order pairs (a single spec-ON pair drifts +/-2%).
 
+use crate::weight_map::DenseWeight;
 use anyhow::Result;
-use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 
 use super::super::types::TransformerModel;
 use crate::layers::ops;
@@ -37,6 +38,44 @@ use crate::layers::ops;
 pub(super) fn lm_head_batch_gemv_enabled() -> bool {
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var("ATLAS_NO_LM_HEAD_BATCH_GEMV").as_deref() != Ok("1"))
+}
+
+/// Legacy BF16-head switch: only the exact value "0" disables it.
+fn bf16_batch_gemv_from_value(value: Option<&str>) -> bool {
+    value != Some("0")
+}
+
+fn lmhead_batch_gemv_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        bf16_batch_gemv_from_value(std::env::var("ATLAS_LMHEAD_BATCH_GEMV").ok().as_deref())
+    })
+}
+
+/// Shared BF16-head dispatch for ordinary and mixed multi-sequence decode.
+#[allow(clippy::too_many_arguments)]
+fn project_bf16_lm_head(
+    gpu: &dyn GpuBackend,
+    fallback: KernelHandle,
+    batch_gemv: KernelHandle,
+    input: DevicePtr,
+    weight: &DenseWeight,
+    output: DevicePtr,
+    [m, n, k]: [u32; 3],
+    batch_enabled: bool,
+    stream: u64,
+) -> Result<()> {
+    // The existing kernel shares one BF16 weight read across up to eight rows.
+    // Its uint4 loads require each input/weight row to remain 16-byte aligned.
+    if batch_enabled
+        && batch_gemv.0 != 0
+        && (1..=ops::DENSE_GEMV_BATCHM_MAX_M).contains(&m)
+        && k.is_multiple_of(8)
+    {
+        ops::dense_gemv_batchm(gpu, batch_gemv, input, weight, output, m, n, k, n, stream)
+    } else {
+        ops::dense_gemm(gpu, fallback, input, weight, output, m, n, k, stream)
+    }
 }
 
 impl TransformerModel {
@@ -154,18 +193,22 @@ impl TransformerModel {
                 }
             }
         } else {
-            ops::dense_gemm(
+            project_bf16_lm_head(
                 self.gpu.as_ref(),
                 self.dense_gemm_kernel,
+                self.dense_gemv_batchm_kernel,
                 normed,
                 &self.lm_head_weight,
                 logits,
-                padded_n as u32,
-                v as u32,
-                h as u32,
+                [padded_n as u32, v as u32, h as u32],
+                lmhead_batch_gemv_enabled(),
                 stream,
             )?;
         }
         Ok(logits)
     }
 }
+
+#[cfg(test)]
+#[path = "lm_head_bf16_tests.rs"]
+mod bf16_tests;

--- a/crates/spark-model/src/model/trait_impl/lm_head_bf16_tests.rs
+++ b/crates/spark-model/src/model/trait_impl/lm_head_bf16_tests.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exercise the BF16 projection used by both ordinary and mixed decode.
+
+use super::{bf16_batch_gemv_from_value, project_bf16_lm_head};
+use crate::weight_map::DenseWeight;
+use spark_runtime::gpu::mock::{MockArg, MockGpuBackend};
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+fn run_case(m: u32, k: u32, present: bool, enabled: bool, expect_batch: bool) {
+    let gpu = MockGpuBackend::new();
+    let n = 67_u32;
+    let input = gpu.alloc((m * k * 2) as usize).unwrap();
+    let weight = DenseWeight {
+        weight: gpu.alloc((n * k * 2) as usize).unwrap(),
+    };
+    let output = gpu.alloc((m * n * 2) as usize).unwrap();
+    let allocated = gpu.alloc_count();
+    let batch = KernelHandle(if present { 0xBF16 } else { 0 });
+    project_bf16_lm_head(
+        &gpu,
+        KernelHandle(0xCAFE),
+        batch,
+        input,
+        &weight,
+        output,
+        [m, n, k],
+        enabled,
+        7,
+    )
+    .unwrap();
+    assert_eq!(
+        gpu.alloc_count(),
+        allocated,
+        "the checkpoint weight must not be copied or quantized"
+    );
+    let launches = gpu.launches_snapshot();
+    assert_eq!(launches.len(), 1);
+    let launch = &launches[0];
+    assert_eq!(
+        launch.func,
+        if expect_batch { batch.0 } else { 0xCAFE },
+        "M={m}: BF16 head selected the wrong kernel"
+    );
+    assert_eq!(launch.stream, 7);
+    assert_eq!(
+        &launch.args[..3],
+        &[
+            MockArg::Buffer(input),
+            MockArg::Buffer(weight.weight),
+            MockArg::Buffer(output)
+        ]
+    );
+    let mut sizes = vec![m, n, k];
+    if expect_batch {
+        sizes.push(n);
+    }
+    assert_eq!(
+        launch.args[3..],
+        sizes
+            .iter()
+            .map(|value| MockArg::Bytes(value.to_ne_bytes().to_vec()))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        launch.grid,
+        if expect_batch {
+            [n.div_ceil(4), 1, 1]
+        } else {
+            [n.div_ceil(16), m.div_ceil(16), 1]
+        }
+    );
+    assert_eq!(
+        launch.block,
+        if expect_batch {
+            [256, 1, 1]
+        } else {
+            [16, 16, 1]
+        }
+    );
+}
+
+#[test]
+fn default_small_bf16_head_uses_existing_batch_gemv() {
+    for m in [1, 2, 4, 8] {
+        run_case(m, 128, true, bf16_batch_gemv_from_value(None), true);
+    }
+}
+
+#[test]
+fn opt_out_missing_kernel_and_wide_head_keep_scalar_fallback() {
+    run_case(4, 128, true, bf16_batch_gemv_from_value(Some("0")), false);
+    run_case(4, 128, false, true, false);
+    // Existing uint4 loads need 16-byte alignment at every input/weight row.
+    run_case(4, 130, true, true, false);
+    for m in [9, 16] {
+        run_case(m, 128, true, true, false);
+    }
+}
+
+#[test]
+fn legacy_opt_out_value_is_preserved() {
+    assert!(!bf16_batch_gemv_from_value(Some("0")));
+    for value in [None, Some("1"), Some(""), Some("false"), Some(" 0 ")] {
+        assert!(bf16_batch_gemv_from_value(value));
+    }
+}


### PR DESCRIPTION
## Summary

With `--lm-head-dtype bf16` — which is what keeps the checkpoint's original head in the native-FP8 profile — every batched decode row ran the LM head through the scalar BF16 GEMM. Atlas already loads a BF16 batched-GEMV kernel for exactly this projection and already has a default-on switch for it, and the shared output-head dispatch ignored both. This restores the batched-GEMV branch.

Fixes #926

## Why

The BF16 head has two consumers, ordinary multi-sequence decode and the mixed decode path, and both land in one shared projection helper. That helper called `ops::dense_gemm` unconditionally. Meanwhile `dense_gemv_batchm_kernel` was resolved and live on the model, and `ATLAS_LMHEAD_BATCH_GEMV` — the BF16 sibling of the NVFP4 head's switch, default ON — was read by a function in `decode_a2.rs` whose result no longer reached any dispatch decision. So the kernel was loaded, the switch was honoured, and neither had an effect: a four-row decode step paid full padded GEMM tiles over the whole vocabulary.

This is a dispatch bug, not a numerics one. Both arms read the same BF16 weight buffer; nothing is copied, widened or requantized.

## What changed

- `crates/spark-model/src/model/trait_impl/lm_head_batched.rs`: the BF16 arm of the shared projection now goes through a new `project_bf16_lm_head`, which takes the batched-GEMV branch when the switch is on, the kernel handle is non-null, M is within `DENSE_GEMV_BATCHM_MAX_M`, and K is a multiple of 8 — the alignment the kernel's `uint4` loads require. Anything else falls through to the existing `dense_gemm`. The legacy opt-out is preserved verbatim in `bf16_batch_gemv_from_value`: only the exact string `0` disables it.
- `crates/spark-model/src/model/trait_impl/decode_a2.rs`: drops the now-dead local `lmhead_batch_gemv_enabled` (-8 lines); the switch moved next to the dispatch it controls.
- `crates/spark-model/src/model/trait_impl/lm_head_bf16_tests.rs` (new): three tests over the mock backend. They assert which kernel each row count selects, that the launch carries the input, BF16 weight and output buffers with the batched GEMV's extra leading-dimension argument and its distinct grid/block shape, that dispatch allocates nothing (the checkpoint weight is never copied), and that the four fallback conditions each still reach the scalar GEMM — switch off, null handle, M above the batched maximum, and a K that is not 8-aligned.

The red version of the new test failed with the scalar `dense_gemm` selected for every row count while the batched-GEMV handle was resolved and the switch was on — the shipped behaviour.

## Test plan

- [x] `cargo +1.93.1 fmt --all -- --check` — clean
- [x] `cargo +1.93.1 test --locked -p spark-model` — 643 passed, 0 failed, 11 ignored in the lib suite (640 -> 643: the three new BF16 head tests), plus 4 passed across the integration targets
- [x] `cargo +1.93.1 clippy --locked -p spark-model --tests -- -D warnings` — clean
- [ ] `typos` — not installed on the gate host, skipped
- [x] Tested against real hardware: see below

## Hardware evidence

H100, Qwen/Qwen3.8-27B-FP8, native FP8 profile, batch-4 recipe, 1,193 prompt / 256 output tokens, temperature 0, 1 warmup plus 3 measured reps.

At C=16, aggregate decode goes from 65.0 to 73.8 tok/s (74.0 / 73.7 / 73.7 across the three reps). TPOT drops from 51.5 to 46.2 ms, TTFT p50 from 26.3 to 23.4 s, and end-to-end from 39.4 to 35.6 s.

At C=1 throughput is unchanged at 39.3 tok/s. That is the expected result and worth stating plainly: M=1 already took the fast path, so this change cannot move it.

Nine numerical comparisons on the H100 between the batched GEMV and the scalar GEMM pass. Seventeen concurrent arithmetic prompts were all answered correctly, with zero request errors.

## Notes for reviewers

The K-alignment and M-range guards are the kernel's real preconditions, not defensive padding: the batched GEMV loads input and weight rows as `uint4`, so a K that is not a multiple of 8 must keep the scalar path. The tests pin both boundaries rather than only the happy case.

The opt-out is deliberately left as the legacy exact-`0` comparison instead of being normalised to a general truthy parse. Changing what values disable it would be a behaviour change for anyone already setting it, and does not belong in a dispatch fix.

Independent of #922 and #925 — this touches the output head, not `dense_ffn.rs`, and applies cleanly to `main` on its own.

Split out of the campaign branch `hopper/sm90-target-tdd-2026-09` (#895); origin commit 7c786cc.

## Authorship

AI-authored (Claude).

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
