### PR TITLE
commands: "CI is still running" is two cases and only one is benign

### DIFF
--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -1608,6 +1608,18 @@ case "$all" in
     printf '{"workflow_runs":[{"id":%s,"name":"CI","created_at":"2026-01-01T00:00:00Z","status":"%s"}]}\n' \
       "${_rm%% *}" "${_rm##* }"
     exit 0 ;;
+  *"/jobs?per_page"*)
+    # Which of the in-flight run's jobs have ALREADY finished. RUNJOBS is a
+    # comma list of completed job names; empty = the run has not reached them.
+    printf '{"jobs":['
+    _first=1; _saved_ifs=$IFS; IFS=','
+    for _j in ${RUNJOBS:-}; do
+      [ -z "$_j" ] && continue
+      [ "$_first" -eq 1 ] || printf ','
+      printf '{"name":"%s","status":"completed"}' "$_j"; _first=0
+    done
+    IFS=$_saved_ifs; printf ']}\n'
+    exit 0 ;;
   *"issues/"*"/comments"*)    printf '%s\n' "$all" >> "$SCALLS"; exit 0 ;;
   *)                          exit 0 ;;
 esac
@@ -1729,6 +1741,71 @@ esac' >/dev/null
     bad "control: it warned about a benign in-flight run"
   else
     ok "control: and no false warning is posted"
+  fi
+
+  # CONTROL: "in flight" is TWO cases and only one is benign. When the jobs that
+  # READ the mark already finished -- before the mark existed -- their verdict
+  # is final for this run, and a job inside an in-progress run cannot be
+  # re-run. Silence there is how #934/#935/#908 each ended 2026-09-06 with a
+  # green `Seal` check run and a red `seal status`.
+  #
+  # This control installs its OWN stub: whichever stub ran last may not answer
+  # the /jobs call, and then this would measure the benign branch and pass for
+  # the wrong reason.
+  cat > "$TMP/sbin/gh" <<'STUB2'
+#!/usr/bin/env bash
+all="$*"
+case "$all" in
+  *"actions/runs/"*"/rerun"*) printf 'RERUN %s\n' "$all" >> "$SCALLS"; exit 0 ;;
+  # ★ JSON, NOT A BARE STRING. The merged lookup pipes this through jq
+  # ITSELF so that an unanswered API is distinguishable from "no run"; a
+  # plain "<id> <status>" makes jq fail, the step takes the could-not-list
+  # branch, and the two controls below then measure the WRONG branch and
+  # report the stale-jobs warning as missing. That is what they did the
+  # first time #908 and #937 met.
+  *"actions/runs?head_sha"*)
+    _rm="${RUNMETA:-12345 completed}"
+    printf '{"workflow_runs":[{"id":%s,"name":"CI","created_at":"2026-01-01T00:00:00Z","status":"%s"}]}\n' \
+      "${_rm%% *}" "${_rm##* }"
+    exit 0 ;;
+  *"/jobs?per_page"*)
+    printf '{"jobs":['
+    _first=1; _saved_ifs=$IFS; IFS=','
+    for _j in ${RUNJOBS:-}; do
+      [ -z "$_j" ] && continue
+      [ "$_first" -eq 1 ] || printf ','
+      printf '{"name":"%s","status":"completed"}' "$_j"; _first=0
+    done
+    IFS=$_saved_ifs; printf ']}\n'; exit 0 ;;
+  *"issues/"*"/comments"*)    printf '%s\n' "$all" >> "$SCALLS"; exit 0 ;;
+  *)                          exit 0 ;;
+esac
+STUB2
+  chmod +x "$TMP/sbin/gh"
+  : > "$TMP/scalls"
+  ( PATH="$TMP/sbin:$PATH" SCALLS="$TMP/scalls" RUNMETA="777 in_progress" \
+    RUNJOBS="seal status,stamp status" REPO=o/r PR=1 VERB=/seal \
+    ACTOR=me AUTHOR=me PERM=write HEAD_SHA=abc1234567 SHORT=abc1234 \
+    bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  if grep -q "the checks that read it have already run" "$TMP/scalls"; then
+    ok "control: a mark minted after its gate jobs already ran is reported"
+  else
+    bad "control: gate jobs that already ran were treated as not-yet-run"
+  fi
+  if grep -q 'seal status' "$TMP/scalls"; then
+    ok "control: and the warning NAMES the jobs whose verdict is already final"
+  else
+    bad "control: the warning did not say which jobs had already run"
+  fi
+  # And the benign case must stay silent: nothing finished yet.
+  : > "$TMP/scalls"
+  ( PATH="$TMP/sbin:$PATH" SCALLS="$TMP/scalls" RUNMETA="777 in_progress" RUNJOBS="" \
+    REPO=o/r PR=1 VERB=/seal ACTOR=me AUTHOR=me PERM=write HEAD_SHA=abc1234567 SHORT=abc1234 \
+    bash "$TMP/stamp.sh" >/dev/null 2>&1 )
+  if grep -q "already run" "$TMP/scalls"; then
+    bad "control: warned although no gate job had finished"
+  else
+    ok "control: an in-flight run that has not reached its gate jobs still warns nothing"
   fi
 else
   bad "could not extract the /stamp step"

--- a/.github/workflows/certification-commands.yml
+++ b/.github/workflows/certification-commands.yml
@@ -303,7 +303,49 @@ jobs:
           > \`\`\`
           > </details>"
             elif [ -n "${run_id:-}" ] && [ "$run_id" != "null" ] && [ "$run_status" != "completed" ]; then
-              echo "::notice title=CI is still running::run $run_id is '$run_status'. Its gate jobs read the $name when they execute, so nothing is re-run. If they already ran, re-run CI once this one finishes."
+              # ★ "IN FLIGHT" IS TWO CASES, AND ONLY ONE OF THEM IS BENIGN.
+              #
+              # The benign one: the run has not reached its gate jobs, so they
+              # will read the mark when they execute and there is nothing to
+              # re-run. The other one: those jobs ALREADY RAN, before the mark
+              # existed, and their verdict is final for this run — the PR sits
+              # red on `seal status` / `stamp status` with no further run coming.
+              #
+              # Treating both as benign happened to #934, #935 and #908 on
+              # 2026-09-06, all three at once:
+              #     #934  seal status done 13:37:51   Seal minted 13:40:22
+              #     #935  seal status done 13:41:46   Seal minted 13:42:44
+              #     #908  seal status done 13:41:50   Seal minted 13:42:57
+              # Each ended with a green `Seal` check run and a red `seal status`,
+              # and this step said nothing. Its own message already named the
+              # case — "if they already ran, re-run CI once this one finishes" —
+              # and then left a human to notice. Nobody was watching.
+              #
+              # A job inside an in-progress run CANNOT be re-run (`gh run rerun
+              # --job` answers "job N cannot be rerun"), so this cannot
+              # self-heal. Say so loudly instead of implying all is well.
+              stale_jobs=""
+              if jobs_json=$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=100" 2>&1); then
+                stale_jobs=$(printf '%s' "$jobs_json" \
+                  | jq -r '[.jobs[] | select(.status == "completed")
+                            | select(.name == "seal status" or .name == "stamp status"
+                                     or .name == "PR Benchmark Certifications"
+                                     or .name == "PR benchmark gate")
+                            | .name] | unique | join(", ")' 2>/dev/null) || stale_jobs=""
+              fi
+              if [ -n "$stale_jobs" ]; then
+                echo "::error title=$name recorded, but the jobs that read it have already run::run $run_id is '$run_status', and these of its jobs finished BEFORE the mark existed: $stale_jobs"
+                rerun_note="
+
+          > [!WARNING]
+          > **The $name is recorded, but the checks that read it have already run.** CI run [\`$run_id\`](https://github.com/$REPO/actions/runs/$run_id) is still \`$run_status\`, but these jobs finished before the mark was minted and their verdict is final for this run: \`$stale_jobs\`.
+          >
+          > A job inside an in-progress run cannot be re-run, so this cannot fix itself. **Re-run the CI workflow once the current run finishes**, or push any commit to this PR.
+          >
+          > (A \`/seal\` is voided by the next commit, so prefer the re-run.)"
+              else
+                echo "::notice title=CI is still running::run $run_id is '$run_status' and none of the jobs that read the $name have finished yet, so they will see it when they execute. Nothing to re-run."
+              fi
             elif [ -n "${run_id:-}" ] && [ "$run_id" != "null" ]; then
               # Capture stderr rather than discarding it. The first time this
               # failed in production the reason went to /dev/null, the Stamp


### PR DESCRIPTION
**Stack 1 of 3.** Base: `main`.

## The defect

The `/stamp` and `/seal` handler treats "the CI run is still in flight" as always benign: the gate jobs haven't executed yet, so they'll read the mark when they do, and there is nothing to re-run.

That is true only sometimes. The other case is that those jobs **already ran, before the mark existed**, and their verdict is final for this run — the PR sits red on `seal status` / `stamp status` with no further run coming.

It happened to #934, #935 and #908 on 2026-09-06, all three at once:

| PR | `seal status` completed | `Seal` minted |
|---|---|---|
| #934 | 13:37:51 | 13:40:22 |
| #935 | 13:41:46 | 13:42:44 |
| #908 | 13:41:50 | 13:42:57 |

Each ended with a green `Seal` check run and a red `seal status`, and the handler said nothing at all. Its own message already named the case — *"if they already ran, re-run CI once this one finishes"* — and then left a human to notice. Nobody was watching.

## Why it can't self-heal

A job inside an in-progress run **cannot** be re-run: `gh run rerun --job N` answers `job N cannot be rerun`. So the fix is not to try harder, it is to stop reporting a problem as fine.

## The change

The in-flight branch splits in two: ask which of the run's jobs have already completed, and if any of the four that read a mark has, raise an error and put a warning in the PR comment **naming them**. If none has, keep the benign notice — and say so explicitly rather than implying it.

## Controls

- a mark minted after its gate jobs already ran is **reported**, and the warning names them (`seal status, stamp status`)
- an in-flight run that has **not** reached its gate jobs still warns nothing
- reintroducing the defect: **140 passed, 6 failed**; restored: **146 passed, 0 failed**

Self-test 143 → 146 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc

---

*Reopened as a new PR: #937 was closed at 21:07Z when a bad force-push briefly made this branch identical to its base. GitHub freezes a closed PR's head, so #937 could not be reopened ("state cannot be changed. There are no new commits"). Content is unchanged — same commit, replayed onto the corrected base chain.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
