### PR TITLE
ci: a required check must not share a concurrency group at all

### DIFF
--- a/.github/scripts/assert-required-checks-not-comment-cancellable.py
+++ b/.github/scripts/assert-required-checks-not-comment-cancellable.py
@@ -60,7 +60,25 @@ COMMENT_TRIGGERS = {"issue_comment", "pull_request_review_comment", "pull_reques
 
 
 def cancels(section):
-    return isinstance(section, dict) and section.get("cancel-in-progress") is True
+    """Whether this concurrency block can cost a required context its run.
+
+    ★ `cancel-in-progress: true` is NOT the only way. From GitHub's docs: when a
+    run is queued while another in the same group is in progress it goes
+    PENDING, and "any previously pending job or workflow in the concurrency
+    group will be cancelled." That happens whatever `cancel-in-progress` says —
+    it governs the IN-PROGRESS run, not the pending one.
+
+    So a shared group is enough. On 2026-09-06 `cla.yml` carried
+    `cancel-in-progress: false`, added after the #907 incident and believed to
+    close this class, and `CLAAssistant` still went missing on #934, #935 and
+    #908 at once: each run for the current head was `completed/cancelled` with
+    ZERO jobs. This function said those workflows were safe, because it only
+    looked at the flag.
+
+    Any concurrency block therefore counts. A required context is worth more
+    than the runner-seconds a group saves.
+    """
+    return isinstance(section, dict) and bool(section.get("group"))
 
 
 def main(root="."):
@@ -90,8 +108,8 @@ def main(root="."):
             ):
                 problems.append(
                     f"{path.name}:{name} emits the required context {context!r}, "
-                    f"is triggered by {sorted(comment_fired)}, and sets "
-                    f"cancel-in-progress: true — two comments seconds apart will "
+                    f"is triggered by {sorted(comment_fired)}, and declares a "
+                    f"concurrency group — a later event leaves this run pending and "
                     f"cancel it and leave the PR red on a check that was never run. "
                     f"Set cancel-in-progress: false."
                 )

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -301,6 +301,27 @@ jobs: { advisory: { name: "PR categorize (advisory)", runs-on: ubuntu-latest, st
 Y
 want_rc 0 "a non-required comment-triggered job may cancel itself" \
   python3 .github/scripts/assert-required-checks-not-comment-cancellable.py "$TMP/cc"
+# CONTROL: `cancel-in-progress: false` is NOT sufficient, and believing it was
+# cost #934/#935/#908 their CLAAssistant runs on 2026-09-06 -- all three
+# `completed/cancelled` with zero jobs. A PENDING run is displaced by the next
+# one in the same group whatever the flag says, so a shared group on a
+# comment-triggered required context must be refused too.
+cat > "$TMP/cc/.github/workflows/a.yml" <<'Y'
+on: { issue_comment: { types: [created] } }
+concurrency:
+  group: cla-shared
+  cancel-in-progress: false
+jobs: { CLAAssistant: { name: CLAAssistant, runs-on: ubuntu-latest, steps: [{ run: "true" }] } }
+Y
+want_rc 1 "control: cancel-in-progress:false does not make a shared group safe" \
+  python3 .github/scripts/assert-required-checks-not-comment-cancellable.py "$TMP/cc"
+# NOT flagged: no concurrency block at all -- every event gets its own run.
+cat > "$TMP/cc/.github/workflows/a.yml" <<'Y'
+on: { issue_comment: { types: [created] } }
+jobs: { CLAAssistant: { name: CLAAssistant, runs-on: ubuntu-latest, steps: [{ run: "true" }] } }
+Y
+want_rc 0 "a required check with no concurrency group is accepted" \
+  python3 .github/scripts/assert-required-checks-not-comment-cancellable.py "$TMP/cc"
 
 echo "== certificate rendering =="
 T=docs/diagrams/states/certificate-merged.svg

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,9 +13,26 @@ name: "CLA Assistant"
 # re-dispatched by hand. A required check must not be cancellable by the timing
 # of unrelated comments; the runner-seconds this used to save are worth far less
 # than a PR that cannot merge. Serialised, not cancelled.
-concurrency:
-  group: cla-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: false
+# ★ NO CONCURRENCY GROUP AT ALL, AND THAT IS THE FIX.
+#
+# This file used to carry `group: cla-<pr>` with `cancel-in-progress: false`,
+# added after #907 sat red on a cancelled `CLAAssistant`. It was not enough, and
+# on 2026-09-06 the SAME context went missing on #934, #935 and #908
+# simultaneously — not failed, NEVER CREATED. Each PR's run for its current head
+# read `completed/cancelled` with ZERO jobs: created 13:41:26, cancelled
+# 13:42:01, never started one.
+#
+# `cancel-in-progress: false` protects a run that is IN PROGRESS. It does
+# nothing for a run that is PENDING. From GitHub's own docs: when a run is
+# queued while another in the same concurrency group is in progress, it goes
+# pending, and "any previously pending job or workflow in the concurrency group
+# will be cancelled." Three events on one PR in quick succession — an
+# update-branch and two comments — and the middle run is discarded silently.
+#
+# A required context that is never created cannot be told from one still
+# running: branch protection waits forever. Runner-seconds are worth far less,
+# so this workflow now serialises nothing and queues nothing. Every event gets
+# its own run and every run reports.
 
 on:
   issue_comment:


### PR DESCRIPTION
**Stack 2 of 3.** Base: `fix/seal-when-gate-jobs-already-ran` (stack 1).

## `cancel-in-progress: false` was not enough, and we believed it was

It was added to `cla.yml` after #907, to close the class "a required context lost to cancellation". On 2026-09-06 `CLAAssistant` — a **required** context — went missing on #934, #935 and #908 **simultaneously**. Not failed: never created.

| PR | cla run for the current head |
|---|---|
| #934 `9261fc0b37` | `completed/cancelled`, **zero jobs** |
| #935 `711c6a895f` | `completed/cancelled`, **zero jobs** |
| #908 `4884dcd852` | `completed/cancelled`, **zero jobs** |

Created 13:41:26, cancelled 13:42:01, never started a job. All three PRs sat `BLOCKED` with `pend=0` and `fail=[]` — the most confusing state available: nothing red, nothing running, and nothing that ever will.

## The flag governs the wrong run

From GitHub's docs: when a run is queued while another in the same concurrency group is in progress it goes **pending**, and *"any previously pending job or workflow in the concurrency group will be cancelled."* That happens whatever `cancel-in-progress` says — it governs the **in-progress** run, not the pending one. Three events on one PR in quick succession (an `update-branch` and two comments) and the middle run is discarded in silence.

## Two changes

1. **`cla.yml` declares no concurrency at all.** Every event gets its own run and every run reports. A required context that is never created cannot be distinguished from one still running, and branch protection waits forever; runner-seconds are worth far less than that.
2. **`assert-required-checks-not-comment-cancellable.py` now refuses *any* concurrency group** on a comment-triggered required context, not just `cancel-in-progress: true`. The old predicate is exactly why the guard reported `cla.yml` safe right up to the morning it lost three runs.

## Controls

- `cancel-in-progress: false` with a shared group is now **refused**
- a required check with **no** concurrency group is accepted
- narrowing the predicate back to the flag turns the first control red (**147 passed, 1 failed**)

Self-test 146 → 148 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc

---

*Reopened as a new PR: #938 was closed at 21:07Z when a bad force-push briefly made this branch identical to its base. GitHub freezes a closed PR's head, so #938 could not be reopened ("state cannot be changed. There are no new commits"). Content is unchanged — same commit, replayed onto the corrected base chain.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc
