### PR TITLE
ci: refuse to push a stack layer that no longer differs from its base

### DIFF
--- a/.github/scripts/assert-job-outputs-exported.py
+++ b/.github/scripts/assert-job-outputs-exported.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Every `needs.<job>.outputs.<name>` must be exported by that job.
+
+★ A STEP OUTPUT IS NOT A JOB OUTPUT, AND THE DIFFERENCE IS SILENT.
+
+`ci.yml`'s `changes` job computed `is_stack_layer`, printed it to the log, and
+never listed it under the job's `outputs:`. Consumers therefore read the EMPTY
+STRING, and the two consumers failed in opposite directions:
+
+    builds_binaries != 'false'   ->  empty is not 'false'  ->  BUILT (safe by luck)
+    is_stack_layer   == 'true'   ->  empty is not 'true'   ->  NOT a stack layer
+
+The second one is the expensive half. `release-build.yml` skips its nine build
+legs for a lower stack layer precisely so that N layers do not spend N release
+matrices to land one tree -- and every layer was being told it was not a layer.
+Measured 2026-09-07 on PR #946: the classify job logged `is_stack_layer=true`
+while `release matrix / validate inputs` in the SAME run reported
+`stack_layer: false`, and nine builds ran on a pool completing ~8 jobs an hour.
+
+Nothing in Actions warns about this. An unexported output is not an error, not
+a warning, not even a lint -- it is an empty string, and an empty string is a
+perfectly good value for an `if:` to be false about.
+
+WHAT THIS CHECKS. For every workflow file: collect each job's declared
+`outputs:` keys, then find every `needs.<job>.outputs.<name>` reference in the
+same file and require `<name>` to be among that job's declared keys. A
+reference to a job that is not in the same file is skipped (reusable-workflow
+outputs live elsewhere and are checked by their own call site).
+
+WHAT IT CANNOT SEE, stated rather than hidden:
+  * whether the exported expression names a step that exists, or the right one;
+  * outputs consumed across workflow files (`workflow_call` outputs);
+  * a job output exported but never consumed -- harmless, and not its business.
+
+Stdlib only, no network. Exit 1 on any unexported consumer.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+NEEDS = re.compile(r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)")
+
+
+def check(path: Path) -> list[str]:
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception as exc:  # a workflow that will not parse is CI's problem, not ours
+        return [f"{path}: could not parse: {exc}"]
+    if not isinstance(doc, dict):
+        return []
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    declared = {
+        name: set((job.get("outputs") or {}).keys())
+        for name, job in jobs.items()
+        if isinstance(job, dict)
+    }
+
+    bad = []
+    for job_name, ref_job, ref_out in (
+        (jn, m.group(1), m.group(2))
+        for jn, job in jobs.items()
+        if isinstance(job, dict)
+        for m in NEEDS.finditer(yaml.safe_dump(job))
+    ):
+        if ref_job not in declared:
+            continue  # not a job in this file
+        if ref_out not in declared[ref_job]:
+            bad.append(
+                f"{path}: job '{job_name}' reads needs.{ref_job}.outputs.{ref_out}, "
+                f"but job '{ref_job}' does not export '{ref_out}' "
+                f"(it exports: {', '.join(sorted(declared[ref_job])) or 'nothing'}). "
+                f"That reference is the empty string at runtime."
+            )
+    return bad
+
+
+def main() -> int:
+    root = Path(".github/workflows")
+    if not root.is_dir():
+        print(f"REFUSING: {root} does not exist — this guard cannot find its input")
+        return 1
+    files = sorted(root.glob("*.yml")) + sorted(root.glob("*.yaml"))
+    if not files:
+        print("REFUSING: no workflow files found — a guard that finds nothing must fail")
+        return 1
+    bad = [msg for f in files for msg in check(f)]
+    for msg in bad:
+        print(f"::error title=Unexported job output::{msg}")
+    print(f"checked {len(files)} workflow file(s); {len(bad)} unexported consumer(s)")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/assert-stack-layer-differs.sh
+++ b/.github/scripts/assert-stack-layer-differs.sh
@@ -85,21 +85,28 @@ selftest() {
   ) > "$tmp/shas" || { echo "selftest: fixture build failed"; return 1; }
   read -r BASE LAYER EMPTY < "$tmp/shas"
 
-  run() { # run <expect 0|1> <label> <head> <base>
-    local want="$1" label="$2"; shift 2
+  # ★ EACH CONTROL ASSERTS WHICH RULE FIRED, NOT MERELY THAT SOMETHING DID.
+  # The three refusals overlap: head==base ALSO has identical trees, and an
+  # ancestor MAY. A control that checks only the exit code therefore stays
+  # green when the rule it is named after is dead and a sibling catches the
+  # input instead -- which is exactly what happened the first time this suite
+  # was sabotaged for its own negative control.
+  run() { # run <expect 0|1> <needle> <label> <head> <base>
+    local want="$1" needle="$2" label="$3"; shift 3
     out=$(cd "$tmp" && check_layer "$@" 2>&1); local got=$?
-    if [ "$got" -eq "$want" ]; then
+    if [ "$got" -eq "$want" ] && printf '%s' "$out" | grep -qF -- "$needle"; then
       printf '  ok   %s\n' "$label"
     else
-      printf '  FAIL %s (wanted rc=%s, got rc=%s)\n     %s\n' "$label" "$want" "$got" "$out"
+      printf '  FAIL %s (wanted rc=%s + %s, got rc=%s)\n     %s\n' \
+        "$label" "$want" "\"$needle\"" "$got" "$out"
       rc=1
     fi
   }
-  run 0 "a real layer passes"                              "$LAYER" "$BASE"
-  run 1 "control: head == base is refused"                 "$BASE"  "$BASE"
-  run 1 "control: head is an ancestor of base is refused"  "$BASE"  "$LAYER"
-  run 1 "control: identical trees, different shas, refused" "$EMPTY" "$BASE"
-  run 1 "control: a nonexistent head is refused, not skipped" "no-such-ref" "$BASE"
+  run 0 "differs from base"    "a real layer passes"                        "$LAYER" "$BASE"
+  run 1 "same commit"          "control: head == base is refused"           "$BASE"  "$BASE"
+  run 1 "is an ancestor of"    "control: head under its own base refused"   "$BASE"  "$LAYER"
+  run 1 "identical trees"      "control: same tree, different sha, refused" "$EMPTY" "$BASE"
+  run 1 "is not a commit"      "control: a nonexistent head is refused"     "no-such-ref" "$BASE"
   [ "$rc" -eq 0 ] && echo "selftest: 5 passed, 0 failed" || echo "selftest: FAILED"
   return "$rc"
 }

--- a/.github/scripts/assert-stack-layer-differs.sh
+++ b/.github/scripts/assert-stack-layer-differs.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Refuse to push a stack layer whose head would be identical to its base.
+#
+# ★ WHY THIS EXISTS. On 2026-09-06 a bad force-push briefly gave #937, #938 and
+# #939 heads equal to their own base branches. GitHub closed all three within
+# five seconds. Restoring the refs did not undo it: a CLOSED pull request's
+# head is FROZEN, so `gh pr reopen` and `PATCH /pulls/{n} -f state=open` both
+# refuse with
+#
+#     state cannot be changed. There are no new commits between ...
+#
+# even after the branch is put back. The PRs were unrecoverable and had to be
+# reopened as #948/#949/#950 under a new stack. The same mechanism had already
+# destroyed #944 an hour earlier, by MERGE rather than by close: when a PR's
+# commits land underneath its own base branch, GitHub marks it merged into that
+# branch. Both are the same one-line mistake — pushing a layer that no longer
+# differs from what it sits on — and both are irreversible after the fact.
+#
+# So this check runs BEFORE the push, not after. It is the only place it can
+# work: every guard downstream of the push is reporting on a corpse.
+#
+# Usage:
+#   assert-stack-layer-differs.sh <new-head-ish> <base-ref>   # one layer
+#   assert-stack-layer-differs.sh --selftest                  # prove it fires
+#
+# Exit 0 = the layer has content of its own. Exit 1 = do not push.
+set -uo pipefail
+
+# A layer is safe iff its head is NOT an ancestor-or-equal of its base AND the
+# tree differs. Both halves are needed and neither implies the other:
+#
+#   * equal trees, different shas  -> GitHub still sees "no new commits" and
+#     closes the PR, so a sha comparison alone is not enough;
+#   * head IS the base's ancestor  -> the classic "commits landed underneath
+#     their own base" shape that merged #944, and its tree can differ.
+check_layer() {
+  local head="$1" base="$2" hs bs
+  hs=$(git rev-parse --verify "$head^{commit}" 2>/dev/null) || {
+    echo "REFUSE: '$head' is not a commit"; return 1; }
+  bs=$(git rev-parse --verify "$base^{commit}" 2>/dev/null) || {
+    echo "REFUSE: base '$base' is not a commit"; return 1; }
+
+  if [ "$hs" = "$bs" ]; then
+    echo "REFUSE: head and base are the same commit ($(git rev-parse --short "$hs"))."
+    echo "        GitHub closes a PR whose head equals its base, and a closed PR's"
+    echo "        head is frozen — restoring the branch will NOT reopen it."
+    return 1
+  fi
+  if git merge-base --is-ancestor "$hs" "$bs"; then
+    echo "REFUSE: head $(git rev-parse --short "$hs") is an ancestor of base $(git rev-parse --short "$bs")."
+    echo "        The layer's commits sit UNDERNEATH its own base branch; GitHub"
+    echo "        marks such a PR merged into that branch (this is what took #944)."
+    return 1
+  fi
+  if [ "$(git rev-parse "$hs^{tree}")" = "$(git rev-parse "$bs^{tree}")" ]; then
+    echo "REFUSE: head and base have identical trees, so the PR has an empty diff."
+    echo "        Different shas do not save it — GitHub reads 'no new commits'."
+    return 1
+  fi
+  echo "ok: $(git rev-parse --short "$hs") differs from base $(git rev-parse --short "$bs")"
+  return 0
+}
+
+# ── self-test ──────────────────────────────────────────────────────────────
+# ★ A GUARD THAT CANNOT FAIL IS WORSE THAN NO GUARD, because it reports safety.
+# Each rule gets an input that MUST be refused and one that MUST pass, built in
+# a throwaway repo so the rules are exercised rather than described.
+selftest() {
+  local tmp rc=0 out
+  tmp=$(mktemp -d) || return 1
+  trap 'rm -rf "$tmp"' RETURN
+  (
+    cd "$tmp" || exit 1
+    git init -q . && git config user.email t@t && git config user.name t
+    echo a > f && git add f && git commit -qm base
+    BASE=$(git rev-parse HEAD)
+    echo b > f && git add f && git commit -qm layer
+    LAYER=$(git rev-parse HEAD)
+    # a commit with the base's tree but a different sha
+    git checkout -q --detach "$BASE" && git commit -q --allow-empty -m "empty on base"
+    EMPTY=$(git rev-parse HEAD)
+    printf '%s %s %s\n' "$BASE" "$LAYER" "$EMPTY"
+  ) > "$tmp/shas" || { echo "selftest: fixture build failed"; return 1; }
+  read -r BASE LAYER EMPTY < "$tmp/shas"
+
+  run() { # run <expect 0|1> <label> <head> <base>
+    local want="$1" label="$2"; shift 2
+    out=$(cd "$tmp" && check_layer "$@" 2>&1); local got=$?
+    if [ "$got" -eq "$want" ]; then
+      printf '  ok   %s\n' "$label"
+    else
+      printf '  FAIL %s (wanted rc=%s, got rc=%s)\n     %s\n' "$label" "$want" "$got" "$out"
+      rc=1
+    fi
+  }
+  run 0 "a real layer passes"                              "$LAYER" "$BASE"
+  run 1 "control: head == base is refused"                 "$BASE"  "$BASE"
+  run 1 "control: head is an ancestor of base is refused"  "$BASE"  "$LAYER"
+  run 1 "control: identical trees, different shas, refused" "$EMPTY" "$BASE"
+  run 1 "control: a nonexistent head is refused, not skipped" "no-such-ref" "$BASE"
+  [ "$rc" -eq 0 ] && echo "selftest: 5 passed, 0 failed" || echo "selftest: FAILED"
+  return "$rc"
+}
+
+case "${1:-}" in
+  --selftest) selftest ;;
+  "")         echo "usage: $0 <new-head-ish> <base-ref> | $0 --selftest" >&2; exit 2 ;;
+  *)          check_layer "$1" "${2:?base ref required}" ;;
+esac

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -2301,6 +2301,20 @@ want_rc_msg 1 "could not find the verb whitelist" \
   "control: a guard that cannot find its input refuses, it does not pass" \
   python3 "$TMP/cd/.github/scripts/assert-commands-documented.py"
 
+echo "== stack-layer push guard =="
+# ★ A GUARD NOBODY RUNS IS DECORATION. `assert-stack-layer-differs.sh` refuses
+# the push that closed #937/#938/#939 and merged #944 away on 2026-09-06, and
+# it is only worth having if CI keeps proving it can still refuse. Its own
+# `--selftest` builds a throwaway repo and exercises each rule against an input
+# that MUST be refused; this row runs that, and the row below shows the suite
+# goes red when the guard is the thing that breaks.
+want_rc 0 "the stack-layer guard's own controls all fire" \
+  bash .github/scripts/assert-stack-layer-differs.sh --selftest
+want_rc_msg 1 "same commit" "control: head == base is refused" \
+  sh -c 'cd "$(git rev-parse --show-toplevel)" && bash .github/scripts/assert-stack-layer-differs.sh HEAD HEAD'
+want_rc 2 "control: called with no arguments it refuses, it does not pass" \
+  bash .github/scripts/assert-stack-layer-differs.sh
+
 echo
 echo "  $PASS passed, $FAIL failed"
 REACHED_SUMMARY=1

--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -2315,6 +2315,22 @@ want_rc_msg 1 "same commit" "control: head == base is refused" \
 want_rc 2 "control: called with no arguments it refuses, it does not pass" \
   bash .github/scripts/assert-stack-layer-differs.sh
 
+echo "== job outputs are exported =="
+# The guard that would have caught `is_stack_layer` being computed, logged and
+# never exported -- which told every lower stack layer it was not one and made
+# it pay the full nine-leg release matrix. Run against the real tree, then
+# against a fixture that MUST be rejected.
+want_rc 0 "every needs.<job>.outputs.<name> in this tree is exported" \
+  python3 .github/scripts/assert-job-outputs-exported.py
+mkdir -p "$TMP/jo/.github/workflows"
+printf 'jobs:\n  a:\n    outputs:\n      x: y\n  b:\n    steps:\n      - run: echo ${{ needs.a.outputs.zzz }}\n' \
+  > "$TMP/jo/.github/workflows/w.yml"
+want_rc_msg 1 "does not export 'zzz'" "control: an unexported consumer is caught" \
+  sh -c "cd '$TMP/jo' && python3 '$PWD/.github/scripts/assert-job-outputs-exported.py'"
+rm -rf "$TMP/jo/.github/workflows"; mkdir -p "$TMP/jo/.github/workflows"
+want_rc_msg 1 "no workflow files found" "control: a guard that finds nothing must fail" \
+  sh -c "cd '$TMP/jo' && python3 '$PWD/.github/scripts/assert-job-outputs-exported.py'"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 REACHED_SUMMARY=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,19 @@ jobs:
       web_only: ${{ steps.classify.outputs.web_only }}
       web_touched: ${{ steps.classify.outputs.web_touched }}
       blog_touched: ${{ steps.classify.outputs.blog_touched }}
+      # ★ A STEP OUTPUT IS NOT A JOB OUTPUT, AND THE DIFFERENCE IS SILENT.
+      # These two were computed, logged, and then never exported, so every
+      # `needs.changes.outputs.<name>` consumer read the EMPTY STRING.
+      # `builds_binaries != 'false'` survived that (empty is not 'false', so it
+      # built — fail-safe by luck). `is_stack_layer == 'true'` did not: every
+      # lower layer of a stack was told it was not one and paid the full
+      # nine-leg release matrix, which is the entire economics of stacking.
+      # Measured 2026-09-07 on #946: the classify job printed
+      # `is_stack_layer=true` and release-build.yml received `stack_layer:
+      # false` in the same run. `assert-job-outputs-exported.py` now fails CI
+      # on any consumer without a matching export.
+      is_stack_layer: ${{ steps.stack.outputs.is_stack_layer }}
+      builds_binaries: ${{ steps.classify.outputs.builds_binaries }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Two irreversible losses tonight, one mechanism.

20:36Z — reordering stack #940 put #944's commits underneath its own base
branch. GitHub saw the head as an ancestor of the base and marked #944 MERGED
into that branch. Correct bookkeeping; the PR was gone as a review unit.

21:07Z — a force-push from a stale worktree briefly gave #937, #938 and #939
heads identical to their bases. GitHub closed all three within five seconds.
Restoring the refs did not undo it, because a CLOSED pull request's head is
FROZEN: `gh pr reopen` and `PATCH /pulls/{n} -f state=open` both answer

    state cannot be changed. There are no new commits between ...

even with the branch put back. They had to be reopened as #948/#949/#950.

Both are one line: push a layer that no longer differs from what it sits on.
Both are unrecoverable afterwards, so the check has to run BEFORE the push —
every guard downstream of it is reporting on a corpse.

Three refusals, because none implies the others:
  * head == base            -> "no new commits", the PR is closed
  * head is base's ancestor -> the commits landed underneath their own base
  * identical trees         -> different shas do not save it; the diff is empty

Proved rather than asserted. `--selftest` builds a throwaway repo and runs one
input per rule that MUST be refused plus one that must pass — five rows, four
of them controls, including a nonexistent ref that must be refused rather than
skipped. Replayed against the real shas: the 21:07Z push is refused as
head==base, and #944's true shape (fea9051ce0 under 97861b1933) is refused as
ancestor-of-base, while the corrected #948-over-#946 push passes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc