### PR TITLE
gate: ratchet the video-fidelity leg floor 13 → 14, because #891 added a leg

### DIFF
--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -860,7 +860,7 @@ min = 1.0
 # arithmetic over the patch grid or an exact color sequence, so there is no
 # run-to-run variance for a tolerance to absorb.
 #
-#   legs_passed   = 13  every leg. The ones that carry the weight:
+#   legs_passed   = 14  every leg. The ones that carry the weight:
 #                         order fwd + REVERSED -- the same clip both ways,
 #                           requiring the answer to reverse with it. The only
 #                           assertion separating "the frames arrived in order"
@@ -926,8 +926,16 @@ prior gets that right twice, which is what makes the other legs evidence rather 
 plausible prose. || Requires ffmpeg; without it the MP4 legs SKIP and only the GIF \
 subset runs (measured: PASS 5/5, 4 skipped)."""
 
+# ★ RATCHETED 13 -> 14 on 2026-09-07, when #891 landed a fourteenth leg.
+# This is a COUNT, not a measurement: every committed record before #891 reads
+# exactly 13/13 and the first one after reads exactly 14/14. There is no
+# variance for a tolerance to absorb, so the floor tracks the count exactly and
+# a stale one guards nothing -- at min = 13 a later change that silently drops
+# the new leg passes BOTH the scorer (13 asserted == 13 passed) and the floor
+# (13 >= 13), and nobody hears about it. Count metrics are the easy half of
+# threshold ratcheting and should never be left behind the instrument.
 [benchmarks.metrics.legs_passed]
-min = 13.0
+min = 14.0
 
 [benchmarks.metrics.legs_skipped]
 max = 0.0


### PR DESCRIPTION
#891 landed a fourteenth video-fidelity leg. main's newest record reads
14/14 where every record before it reads exactly 13/13, and the floor still
says 13.

A stale count floor guards nothing. At `min = 13` a later change that silently
drops the new leg passes BOTH halves of the gate: the scorer, because it only
requires passed == asserted (13 == 13), and the threshold, because 13 >= 13.
The leg would simply stop existing and no check would notice.

This is the easy half of threshold ratcheting and it deserves saying plainly:
`legs_passed` is a COUNT, not a measurement. It has no run-to-run variance for
a tolerance to absorb -- 13/13 in every committed record before #891, 14/14 in
the first one after -- so the floor tracks the instrument exactly. No mean, no
sigma, no bimodality question. Throughput floors are the hard half; counts are
not, and leaving them behind the instrument is pure loss.

BENCH.toml is deliberately outside every target's closure hash (taxon::configs
omits it, and coverage.rs lists it in NON_COMPILED_KERNEL_FILES) precisely so a
ratchet does not invalidate the records that justified it. So this owes no
campaign.

The prose above the bound is moved in the same commit, and
check_bench_threshold_prose.py proves it: leaving the comment at 13 while the
bound reads 14 turns it red naming the file, the line and both numbers.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHvLyzv6Ma5ySK48Rh3ytc