### PR TITLE
gemv (6/8, G4): batched BF16 GEMV activation tile in shared memory; dense row batch widened to 16, routed MoE kept at 8, decode band at 8

### DIFF
--- a/crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs
+++ b/crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs
@@ -14,6 +14,13 @@
 //!      meaningfully faster at M=2 and M=4 (ideally ~M x, since the weight read
 //!      is paid once instead of M times).
 //!
+//! 🪤 The bit-identity assertion is the load-bearing one, and it is a REGRESSION
+//! test, not just a property test: the kernel stages the A tile in shared memory,
+//! which is a pure data-movement change that must not perturb a single bit. A
+//! standalone cold-weight A/B against the pre-staging revision lives in spark-bench
+//! at `scripts/glm53-dense-bf16/bench_dense_bf16.cu` (80/80 (N,K,M) cases identical,
+//! 1.06-1.45x depending on shape).
+//!
 //! Run:
 //!   ATLAS_TARGET_HW=gb10 ATLAS_TARGET_MODEL=laguna-s-2.1 ATLAS_TARGET_QUANT=nvfp4 \
 //!     cargo run -p spark-model --release --features cuda,gpu-examples \
@@ -31,8 +38,20 @@ const SHAPES: &[(usize, usize, &str)] = &[
     (9216, 3072, "q_proj"),
     (3072, 9216, "o_proj"),
     (1024, 3072, "k/v/shared"),
+    // GLM-5.3 prefill at PREFILL_ROWS=8. N=4096 carries 69 % of the dense BF16
+    // bucket (292,500 launches / 35.40 s of a 9000-token prefill); K=16384 is the
+    // large-K arm where the A tile overflows L1.
+    (4096, 3072, "glm N4096"),
+    (4096, 16384, "glm N4096 K16k"),
+    // 🪤 N % N_PER_BLOCK != 0: the last block has lanes with n >= N. They must
+    // still reach the shared-memory staging barriers, so the kernel masks rather
+    // than returning early. This shape is the regression test for that.
+    (4098, 3072, "N not mult of 4"),
 ];
-const MS: &[usize] = &[1, 2, 4];
+// M = 8 is MAX_M and the width GLM prefill actually runs at; it is also the width
+// at which the kernel issues the most activation loads per weight load, so it is
+// the one the shared-memory staging changes most.
+const MS: &[usize] = &[1, 2, 4, 8];
 const ITERS: usize = 50;
 const WARMUP: usize = 10;
 

--- a/crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs
+++ b/crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs
@@ -38,20 +38,35 @@ const SHAPES: &[(usize, usize, &str)] = &[
     (9216, 3072, "q_proj"),
     (3072, 9216, "o_proj"),
     (1024, 3072, "k/v/shared"),
-    // GLM-5.3 prefill at PREFILL_ROWS=8. N=4096 carries 69 % of the dense BF16
+    // GLM-5.3 prefill at PREFILL_ROWS. N=4096 carries 69 % of the dense BF16
     // bucket (292,500 launches / 35.40 s of a 9000-token prefill); K=16384 is the
     // large-K arm where the A tile overflows L1.
     (4096, 3072, "glm N4096"),
     (4096, 16384, "glm N4096 K16k"),
+    // The rest of the real GLM per-rank dense sites, so the M<=16 identity contract
+    // is asserted on every shape the prefill actually launches — not just the two
+    // biggest. Shallow-K `f_b` is here because it is the one shape a wider tier makes
+    // SLOWER (0.77x per token, measured), and a future width change must not quietly
+    // break it while chasing the others.
+    (4096, 4096, "glm KDA qkv/o"),
+    (16384, 1536, "glm DSA q_absorb"),
+    (1024, 4096, "glm shared gate/up"),
+    (4096, 1024, "glm shared down"),
+    (4096, 128, "glm KDA f_b (shallow K)"),
+    (32, 4096, "glm KDA b_proj (8 blocks)"),
     // 🪤 N % N_PER_BLOCK != 0: the last block has lanes with n >= N. They must
     // still reach the shared-memory staging barriers, so the kernel masks rather
     // than returning early. This shape is the regression test for that.
     (4098, 3072, "N not mult of 4"),
 ];
-// M = 8 is MAX_M and the width GLM prefill actually runs at; it is also the width
-// at which the kernel issues the most activation loads per weight load, so it is
-// the one the shared-memory staging changes most.
-const MS: &[usize] = &[1, 2, 4, 8];
+// Every width the dispatch can hand the kernel, 1..=MAX_M.
+//
+// 🔴 The narrow widths are the ones that matter most here. MAX_M is 16 since
+// 2026-09-02, but decode, the MTP verify arm and the BF16 lm_head arm still run
+// m <= 8 on this same kernel — so a width extension is only safe if 1..=8 come back
+// byte-for-byte what they were. 9..=16 is the new prefill capability; 16 is the
+// width `PREFILL_ROWS` actually runs at.
+const MS: &[usize] = &[1, 2, 4, 8, 9, 12, 15, 16];
 const ITERS: usize = 50;
 const WARMUP: usize = 10;
 

--- a/crates/spark-model/src/layers/glm5next_layer/mod.rs
+++ b/crates/spark-model/src/layers/glm5next_layer/mod.rs
@@ -146,12 +146,26 @@ pub struct Glm5NextLayer {
 /// Tokens per batched prefill sub-chunk — the width `Glm5NextLayer::prefill` hands
 /// [`Glm5NextLayer::forward_k`].
 ///
-/// 🔴 **8, and the ceiling is a KERNEL boundary, not a bandwidth knee.** Every dense projection
-/// on this path goes through [`ops::dense_mm_bf16`], whose batched-GEMV arm
+/// 🔴 **16, and the ceiling is still a KERNEL boundary, not a bandwidth knee.** Every dense
+/// projection on this path goes through [`ops::dense_mm_bf16`], whose batched-GEMV arm
 /// (`dense_gemv_bf16_batchm`) is **bit-identical to M serial GEMVs** and stops at
-/// `DENSE_GEMV_BATCHM_MAX_M = 8`. At `R > 8` the same call falls to the tile GEMM, which both
+/// `DENSE_GEMV_BATCHM_MAX_M`. Past it the same call falls to the tile GEMM, which both
 /// reassociates (so prefill stops being bit-identical to the per-token walk) and is the slower
 /// kernel at these widths — Atlas measured it 3.6x slower than the batched GEMV at M <= 8.
+///
+/// 🔴 WIDENED 8 -> 16 (2026-09-02). The A65 measurement below — "R = 32 is no faster" — was
+/// TRUE AND MISATTRIBUTED. R = 32 lost because it left the batched GEMV for the tile GEMM, not
+/// because row batching stops paying. With the tier itself widened to 16, the same 12 GLM
+/// prefill shapes cost **1.36-1.98x less per token at M = 16 than at M = 8** with cold weights
+/// (11 of 12; shallow-K N4096 K128 is the one loser at 0.77x), worth a modelled **-17.6 s of a
+/// 173.9 s 9K TTFT**, bit-identical (`scripts/glm53-dense-bf16/bench_m16.cu`, spark-bench).
+///
+/// 🪤 The routed MoE does NOT follow the width up. `glm5next_mlp::forward::forward_moe` splits a
+/// wider row group into even sub-groups of at most `MOE_ROW_BATCH_MAX_ROWS` — exact, because a
+/// row's expert sum depends only on its own top-k, never on which rows share the sweep — so the
+/// routed experts still amortize over 8 rows, not 16. Widening THAT is a separate and unmeasured
+/// question: the union kernel is a single block with an O(T^3) scan, and the tier's register
+/// cost was already 80 at R = 8.
 ///
 /// 🔴 MEASURED 2026-08-31, one image, one control, ~1,950-token prompt: control TTFT 125.3 s;
 /// R = 8 **43.4 s (2.89x) and byte-identical on all four probes**; R = 32 44.3 / 51.8 s — no
@@ -160,7 +174,7 @@ pub struct Glm5NextLayer {
 /// modelled weight traffic only, and above R = 8 the traffic saved is handed to a slower kernel.
 /// The routed experts do not amortize past R = 4 either way (`forward_moe`'s union arm caps
 /// there), so R = 8 takes the whole available win. ANOMALIES A65.
-pub(crate) const PREFILL_ROWS: usize = 8;
+pub(crate) const PREFILL_ROWS: usize = 16;
 
 /// `PREFILL_ROWS`, overridable at launch with `ATLAS_GLM_PREFILL_ROWS`.
 ///
@@ -169,8 +183,9 @@ pub(crate) const PREFILL_ROWS: usize = 8;
 /// fixed control in ONE serve instead of one image per width. `1` restores the per-token walk
 /// exactly — the `rows > 1` gate in `prefill` falls through to `forward_one`.
 ///
-/// 🪤 Above 8 the dense projections leave the bit-identical batched-GEMV arm for the tile GEMM,
-/// so a width > 8 is a NUMERICS change as well as a speed one. Measured: it is not faster.
+/// 🪤 Above `DENSE_GEMV_BATCHM_MAX_M` the dense projections leave the bit-identical batched-GEMV
+/// arm for the tile GEMM, so a width past it is a NUMERICS change as well as a speed one. Keep
+/// this lever at or below that constant.
 ///
 /// 🪤 Read once and cached: an env read per layer per sub-chunk would sit in the hot loop.
 pub(crate) fn prefill_rows() -> usize {

--- a/crates/spark-model/src/layers/glm5next_mlp/forward.rs
+++ b/crates/spark-model/src/layers/glm5next_mlp/forward.rs
@@ -420,7 +420,44 @@ pub(crate) fn row_batch_max() -> usize {
 /// Widest compiled `w4a16_gemv_sw_moe_batchm_mR` tier. Mirror of the
 /// `ATLAS_MOE_BATCHM_ENTRY` list in `kernels/gb10/common/w4a16_gemv.cu` and of the
 /// `[KernelHandle; 7]` in `Glm5NextMlpKernels`.
+///
+/// 🔴 Since 2026-09-02 this is a **sub-group width, not a caller contract**. The prefill sub-chunk
+/// is 16 rows wide (`glm5next_layer::PREFILL_ROWS`) because the DENSE tier widened to 16; the
+/// routed experts did not follow, so [`forward_moe`] splits any wider row group into even
+/// sub-groups of at most this and sweeps each one. Callers may pass any `rows` their workspace
+/// holds.
 pub const MOE_ROW_BATCH_MAX_ROWS: usize = 8;
+
+/// Split `rows` into consecutive `(start, width)` sub-groups of at most `cap`, as evenly as the
+/// count allows.
+///
+/// 🪤 Even, not greedy. A greedy split of 9 rows at cap 8 leaves a trailing group of ONE, and
+/// there is no `w4a16_gemv_sw_moe_batchm_m1` tier — the array starts at m2. Balancing gives 5 + 4,
+/// and at the shipping cap of `MOE_ROW_BATCH_MAX_ROWS` every group is >= 2 for every `rows >= 2`.
+///
+/// 🪤 A width-1 group is still REACHABLE at a small cap, where it is arithmetically forced (3 rows
+/// at cap 2 has no all->=2 split). That is not a correctness hole — the caller's gate requires
+/// every group to have a tier, so such a call simply runs the per-row arm — but it does mean
+/// `ATLAS_GLM_MOE_ROW_BATCH_MAX=2` silently disables row batching at odd widths. Only the A/B
+/// lever can reach it.
+///
+/// 🔴 Splitting is EXACT. A row's routed output is the sum over ITS OWN top-k slots, each slot a
+/// single expert's GEMV whose accumulation order (`w4a16_gemv_partial_rows`) does not depend on
+/// `R` or on which rows share the sweep; the union table only decides which experts get swept and
+/// in what order the sweeps are issued, never what any row adds. So `forward_moe(rows)` returns
+/// the same bits however it is grouped. What splitting costs is amortization, not accuracy: two
+/// 8-row sweeps visit the union of 8 rows twice instead of the (smaller) union of 16 once.
+fn moe_row_groups(rows: usize, cap: usize) -> Vec<(usize, usize)> {
+    let n = rows.div_ceil(cap.max(1)).max(1);
+    let mut out = Vec::with_capacity(n);
+    let mut start = 0usize;
+    for i in 0..n {
+        let w = (rows - start).div_ceil(n - i);
+        out.push((start, w));
+        start += w;
+    }
+    out
+}
 
 /// 🪤 `glm5next_moe_row_union` is ONE block of `rows * top_k` threads. A CUDA block is capped
 /// at 1024 threads, but this kernel's own scans are `O(T^2)`/`O(T^3)` over that extent and the
@@ -534,16 +571,21 @@ pub fn forward_moe(
     // instead of 8K. The per-row path pays 8K; this one pays the union.
     // 🪤 The route trace reads `ids` back per row, which the batched path never does — leave
     // it on the per-row arm rather than reconstructing the trace from the union table.
+    // Sub-groups the routed sweep runs at. `rows` may exceed the widest tier — the prefill
+    // sub-chunk is 16 wide since the dense tier widened — so every gate below is PER GROUP.
+    let groups = moe_row_groups(rows, row_batch_max());
     let batched = rows >= 2
-        && rows <= row_batch_max()
-        // 🪤 The union table is one block of `rows * top_k` threads; past 64 ids it would
-        // silently drop entries. GLM-5.3 is 8 x 8 = 64 exactly, so this is a live edge.
-        && rows * cfg.top_k <= MOE_ROW_UNION_MAX_IDS
         && !host_dispatch_forced()
         && !row_batch_disabled()
         && !profile::trace_on()
         && k.moe_row_union.0 != 0
-        && k.w4a16_gemv_sw_moe_batchm[rows - 2].0 != 0;
+        && groups.iter().all(|&(_, w)| {
+            // 🪤 The union table is one block of `w * top_k` threads; past 64 ids it would
+            // silently drop entries. GLM-5.3 is 8 x 8 = 64 exactly, so this is a live edge.
+            w >= 2
+                && w * cfg.top_k <= MOE_ROW_UNION_MAX_IDS
+                && k.w4a16_gemv_sw_moe_batchm[w - 2].0 != 0
+        });
     announce_row_batch(batched, rows);
 
     // ── router: FULL expert set, FP32 logits, replicated on every rank ──
@@ -787,86 +829,95 @@ pub fn forward_moe(
     if batched {
         let t = profile::start();
         let mi = cfg.moe_intermediate;
-        // The union table: one block, one thread per (row, slot) id. Stays on device.
-        KernelLaunch::new(gpu, k.moe_row_union)
-            .grid([1, 1, 1])
-            .block([(rows * cfg.top_k) as u32, 1, 1])
-            .arg_ptr(ws.ids)
-            .arg_ptr(ws.u_eid)
-            .arg_ptr(ws.u_slot)
-            .arg_u32(rows as u32)
-            .arg_u32(cfg.top_k as u32)
-            .launch(stream)?;
+        // ONE sweep per sub-group. At `rows <= MOE_ROW_BATCH_MAX_ROWS` this is the single pass it
+        // always was; a wider prefill sub-chunk runs it twice over disjoint row ranges, which is
+        // byte-identical (see `moe_row_groups`) and keeps the routed experts at the tier width
+        // that was actually measured.
+        for &(r0, w_rows) in &groups {
+            // The union table: one block, one thread per (row, slot) id. Stays on device.
+            // 🪤 Rebuilt per sub-group over that group's slice of `ids` — the scratch is sized for
+            // the widest group, and a later group overwrites the earlier one's table after its
+            // sweeps have been issued on the same stream.
+            KernelLaunch::new(gpu, k.moe_row_union)
+                .grid([1, 1, 1])
+                .block([(w_rows * cfg.top_k) as u32, 1, 1])
+                .arg_ptr(ws.ids.offset(r0 * cfg.top_k * 4))
+                .arg_ptr(ws.u_eid)
+                .arg_ptr(ws.u_slot)
+                .arg_u32(w_rows as u32)
+                .arg_u32(cfg.top_k as u32)
+                .launch(stream)?;
 
-        let kb = k.w4a16_gemv_sw_moe_batchm[rows - 2];
-        // gate and up: a row's slots all read the SAME x, so the slot stride is 0.
-        w4a16_gemv_moe_batchm(
-            gpu,
-            kb,
-            x,
-            &w.ptrs.gate,
-            ws.a_gate,
-            ws.u_eid,
-            ws.u_slot,
-            mi,
-            cfg.hidden,
-            rows,
-            cfg.top_k,
-            cfg.num_experts,
-            cfg.hidden,
-            0,
-            cfg.top_k * mi,
-            stream,
-        )?;
-        w4a16_gemv_moe_batchm(
-            gpu,
-            kb,
-            x,
-            &w.ptrs.up,
-            ws.a_up,
-            ws.u_eid,
-            ws.u_slot,
-            mi,
-            cfg.hidden,
-            rows,
-            cfg.top_k,
-            cfg.num_experts,
-            cfg.hidden,
-            0,
-            cfg.top_k * mi,
-            stream,
-        )?;
-        // Elementwise over every (row, slot) at once. Slots this rank does not own activate
-        // uninitialised rows; the down projection skips them, so those rows are never read.
-        swiglu(
-            gpu,
-            k.swiglu,
-            ws.a_gate,
-            ws.a_up,
-            ws.a_act,
-            rows * cfg.top_k * mi,
-            cfg.swiglu_limit,
-            stream,
-        )?;
-        // down: slot-major activations, so the slot stride is one expert's width.
-        w4a16_gemv_moe_batchm(
-            gpu,
-            kb,
-            ws.a_act,
-            &w.ptrs.down,
-            ws.expert_out,
-            ws.u_eid,
-            ws.u_slot,
-            cfg.hidden,
-            mi,
-            rows,
-            cfg.top_k,
-            cfg.num_experts,
-            cfg.top_k * mi,
-            mi,
-            cfg.top_k * cfg.hidden,
-            stream,
-        )?;
+            let kb = k.w4a16_gemv_sw_moe_batchm[w_rows - 2];
+            // gate and up: a row's slots all read the SAME x, so the slot stride is 0.
+            w4a16_gemv_moe_batchm(
+                gpu,
+                kb,
+                x.offset(r0 * cfg.hidden * 2),
+                &w.ptrs.gate,
+                ws.a_gate.offset(r0 * cfg.top_k * mi * 2),
+                ws.u_eid,
+                ws.u_slot,
+                mi,
+                cfg.hidden,
+                w_rows,
+                cfg.top_k,
+                cfg.num_experts,
+                cfg.hidden,
+                0,
+                cfg.top_k * mi,
+                stream,
+            )?;
+            w4a16_gemv_moe_batchm(
+                gpu,
+                kb,
+                x.offset(r0 * cfg.hidden * 2),
+                &w.ptrs.up,
+                ws.a_up.offset(r0 * cfg.top_k * mi * 2),
+                ws.u_eid,
+                ws.u_slot,
+                mi,
+                cfg.hidden,
+                w_rows,
+                cfg.top_k,
+                cfg.num_experts,
+                cfg.hidden,
+                0,
+                cfg.top_k * mi,
+                stream,
+            )?;
+            // Elementwise over every (row, slot) at once. Slots this rank does not own activate
+            // uninitialised rows; the down projection skips them, so those rows are never read.
+            swiglu(
+                gpu,
+                k.swiglu,
+                ws.a_gate.offset(r0 * cfg.top_k * mi * 2),
+                ws.a_up.offset(r0 * cfg.top_k * mi * 2),
+                ws.a_act.offset(r0 * cfg.top_k * mi * 2),
+                w_rows * cfg.top_k * mi,
+                cfg.swiglu_limit,
+                stream,
+            )?;
+            // down: slot-major activations, so the slot stride is one expert's width.
+            w4a16_gemv_moe_batchm(
+                gpu,
+                kb,
+                ws.a_act.offset(r0 * cfg.top_k * mi * 2),
+                &w.ptrs.down,
+                ws.expert_out.offset(r0 * cfg.top_k * cfg.hidden * 2),
+                ws.u_eid,
+                ws.u_slot,
+                cfg.hidden,
+                mi,
+                w_rows,
+                cfg.top_k,
+                cfg.num_experts,
+                cfg.top_k * mi,
+                mi,
+                cfg.top_k * cfg.hidden,
+                stream,
+            )?;
+        }
         profile::end(profile::MOE_EXPERTS, t, gpu, stream);
     }
 
@@ -905,4 +956,43 @@ pub fn forward_moe(
         .launch(stream)?;
     profile::end(profile::MOE_COMBINE, t, gpu, stream);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MOE_ROW_BATCH_MAX_ROWS, moe_row_groups};
+
+    /// The split must cover every row exactly once, in order, never exceed the tier width,
+    /// and never emit a group of ONE — there is no `w4a16_gemv_sw_moe_batchm_m1`, so a
+    /// trailing single row would silently drop the whole batched arm for that sub-chunk.
+    #[test]
+    fn row_groups_cover_and_never_orphan_a_row() {
+        for cap in 1..=MOE_ROW_BATCH_MAX_ROWS {
+            for rows in 1..=64 {
+                let g = moe_row_groups(rows, cap);
+                assert_eq!(g[0].0, 0, "rows={rows} cap={cap}: does not start at 0");
+                let mut next = 0;
+                for &(start, w) in &g {
+                    assert_eq!(start, next, "rows={rows} cap={cap}: gap or overlap");
+                    assert!(w >= 1 && w <= cap, "rows={rows} cap={cap}: width {w}");
+                    // No orphan at the width that ships. At a small cap an all->=2 split can be
+                    // arithmetically impossible (3 rows at cap 2), and the caller's per-group
+                    // tier gate handles that by falling back — see the fn doc.
+                    if rows >= 2 && cap == MOE_ROW_BATCH_MAX_ROWS {
+                        assert!(w >= 2, "rows={rows} cap={cap}: orphaned a single row");
+                    }
+                    next += w;
+                }
+                assert_eq!(next, rows, "rows={rows} cap={cap}: {next} rows covered");
+            }
+        }
+    }
+
+    /// The two widths this actually ships at.
+    #[test]
+    fn row_groups_at_the_shipping_widths() {
+        assert_eq!(moe_row_groups(16, 8), vec![(0, 8), (8, 8)]);
+        assert_eq!(moe_row_groups(8, 8), vec![(0, 8)]);
+        assert_eq!(moe_row_groups(9, 8), vec![(0, 5), (5, 4)]);
+    }
 }

--- a/crates/spark-model/src/layers/mtp_head/row_dispatch.rs
+++ b/crates/spark-model/src/layers/mtp_head/row_dispatch.rs
@@ -44,16 +44,21 @@
 //!
 //! ## Where the crossover comes from
 //!
-//! Not invented here. `dense_gemv_bf16_batchm` has a compile-time `MAX_M 8`
-//! ([`DENSE_GEMV_BATCHM_MAX_M`]) and **clamps silently** above it, so 8 is a
-//! hard ceiling, not a tuning choice. The floor is 2 because M=1 already has
-//! a dedicated kernel and never reaches this path. The main model runs the
-//! identical kernel over the identical `(2..=8)` band at three sites
+//! Not invented here. The floor is 2 because M=1 already has a dedicated
+//! kernel and never reaches this path. The main model runs the identical
+//! kernel over the identical `(2..=8)` band at three sites
 //! (`multi_seq/qkv.rs`, `multi_seq/attn/o_proj.rs` x2), measured +6% at C=2
 //! and +24% at C=4 (commit 84d5b763c). Above 8 the batched-GEMV family was
 //! measured NEGATIVE against the tile GEMM (-14.4% at C=16, -29.4% at C=32,
-//! commit 78d276832), which is why this tier stops at 8 instead of growing a
-//! wider kernel.
+//! commit 78d276832), which is why this tier stops at 8.
+//!
+//! 🔴 The 8 used to be the kernel's own `MAX_M`; since 2026-09-02 it is not.
+//! `dense_gemv_bf16_batchm` compiles to `MAX_M 16` for the batched prefill
+//! sub-chunk, so this band is now a POLICY — [`DENSE_GEMV_BATCHM_DECODE_MAX_M`]
+//! — held at 8 on purpose. The upper edge decides whether a width picks the
+//! batched GEMV or a **reassociating** GEMM, so moving it changes which bits a
+//! decode of that width produces. It moves on its own A/B against the sealed
+//! decode reference, not as a side effect of a prefill change.
 //!
 //! No drafter-specific microbench exists for these shapes (`batchm_bench` is
 //! the w4a16 family, not the BF16 one), so the band is mirrored from the
@@ -80,7 +85,7 @@
 //! accepted output is unaffected by construction. Only the ACCEPT RATE can
 //! move, and it moves toward the C=1 path.
 
-use crate::layers::ops::DENSE_GEMV_BATCHM_MAX_M;
+use crate::layers::ops::DENSE_GEMV_BATCHM_DECODE_MAX_M;
 
 /// N at or above which the pipelined tile GEMM fills its 128-wide tile well
 /// enough to beat the per-row GEMV loop. Pre-existing threshold, unchanged —
@@ -132,7 +137,7 @@ pub(crate) fn drafter_row_kernel(
     if batchm_ready
         && !small_m_tier_off
         && k_vec8
-        && (2..=DENSE_GEMV_BATCHM_MAX_M as usize).contains(&m)
+        && (2..=DENSE_GEMV_BATCHM_DECODE_MAX_M as usize).contains(&m)
         && !(small_n && kv_gemv_pinned)
     {
         return RowKernel::Batchm;
@@ -209,7 +214,7 @@ mod tests {
     /// `small_n_tile = m >= 8` sub-defect subsumed rather than re-tuned.
     #[test]
     fn every_projection_batches_across_the_covered_widths() {
-        for m in 2..=DENSE_GEMV_BATCHM_MAX_M as usize {
+        for m in 2..=DENSE_GEMV_BATCHM_DECODE_MAX_M as usize {
             for &(label, n, k) in DRAFTER_SHAPES {
                 assert_eq!(
                     drafter_row_kernel(m, n, k, true, false, false),
@@ -277,7 +282,7 @@ mod tests {
     /// swallow it. Large-N projections still batch.
     #[test]
     fn kv_gemv_lever_still_pins_small_n_at_every_width() {
-        for m in 2..=DENSE_GEMV_BATCHM_MAX_M as usize {
+        for m in 2..=DENSE_GEMV_BATCHM_DECODE_MAX_M as usize {
             // N=1024 K/V.
             assert_eq!(
                 drafter_row_kernel(m, 1024, 5120, true, true, false),
@@ -308,8 +313,8 @@ mod tests {
                 ] {
                     if drafter_row_kernel(m, n, k, batchm, kv_pin, off) == RowKernel::Batchm {
                         assert!(
-                            (2..=DENSE_GEMV_BATCHM_MAX_M as usize).contains(&m),
-                            "batchm selected at m={m}, outside 2..={DENSE_GEMV_BATCHM_MAX_M}"
+                            (2..=DENSE_GEMV_BATCHM_DECODE_MAX_M as usize).contains(&m),
+                            "batchm selected at m={m}, outside 2..={DENSE_GEMV_BATCHM_DECODE_MAX_M}"
                         );
                     }
                 }

--- a/crates/spark-model/src/layers/ops/gemm_quant.rs
+++ b/crates/spark-model/src/layers/ops/gemm_quant.rs
@@ -185,7 +185,36 @@ pub fn dense_gemv_batch2(
 #[allow(clippy::too_many_arguments)]
 /// Mirror of `MAX_M` in `kernels/gb10/common/dense_gemv_bf16_batchm.cu`.
 /// The kernel clamps silently above this, so the Rust side must refuse.
-pub const DENSE_GEMV_BATCHM_MAX_M: u32 = 8;
+///
+/// 🔴 16 since 2026-09-02. The old 8 was the kernel's compiled row array, never an
+/// arithmetic boundary: each row is an independent FP32 accumulator over the same `kv`
+/// order, `m` appears in no row's operand sequence, and the fold is per-row. So every
+/// width up to `MAX_M` is bit-identical both to the narrower tier and to M serial
+/// `dense_gemv_bf16` calls. Verified on the 12 real GLM-5.3 prefill shapes with cold
+/// weights, including the regression direction that matters — m <= 8 byte-unchanged,
+/// because decode, the MTP verify arm and the BF16 lm_head arm all run m <= 8 on this
+/// same kernel (`scripts/glm53-dense-bf16/bench_m16.cu`, spark-bench).
+///
+/// 🪤 This constant is load-bearing OUTSIDE the GEMV: it gates the lm_head batched arm
+/// (`model/impl_a3.rs`), the MTP row dispatch (`layers/mtp_head/row_dispatch.rs`) and it
+/// sizes `verify_k` for the KDA/DSA/MLP workspaces (`weight_loader/glm5_next_load.rs`).
+/// Raising it widens those arms and grows per-layer scratch — a memory-budget change, not
+/// only a kernel one.
+pub const DENSE_GEMV_BATCHM_MAX_M: u32 = 16;
+
+/// The band the batched GEMV is allowed to CLAIM on the decode paths: the MTP row dispatch
+/// and the BF16 lm_head arm.
+///
+/// 🔴 Deliberately still 8, and NOT the same thing as the kernel's `MAX_M`. Those two sites
+/// pick between `dense_gemv_bf16_batchm` and a **reassociating** kernel (the pipelined /
+/// tile GEMM), so the band's upper edge decides which bits a decode of that width produces.
+/// Widening the GEMV tier to 16 for prefill would silently move widths 9..=16 off the tile
+/// GEMM they have always used — a numerics change on the MTP / DFlash γ>8 window, on a path
+/// the prefill measurement says nothing about. Moving this edge needs its own A/B and its
+/// own byte gate against the sealed decode reference; until then the decode band is frozen
+/// where it was measured (+6 % at C=2, +24 % at C=4; NEGATIVE above 8 against the tile GEMM,
+/// -14.4 % at C=16 — commits 84d5b763c / 78d276832).
+pub const DENSE_GEMV_BATCHM_DECODE_MAX_M: u32 = 8;
 
 pub fn dense_gemv_batchm(
     gpu: &dyn GpuBackend,

--- a/crates/spark-model/src/model/impl_a3.rs
+++ b/crates/spark-model/src/model/impl_a3.rs
@@ -201,7 +201,7 @@ impl TransformerModel {
                 }
             }
         } else if self.lm_head_nvfp4.is_none()
-            && (2..=ops::DENSE_GEMV_BATCHM_MAX_M).contains(&num_tokens)
+            && (2..=ops::DENSE_GEMV_BATCHM_DECODE_MAX_M).contains(&num_tokens)
             && self.dense_gemv_batchm_kernel.0 != 0
         {
             // BF16 head, 2..8 verify rows: ONE sweep over `[vocab, hidden]` for every row.

--- a/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
+++ b/crates/spark-model/src/model/trait_impl/lm_head_batched.rs
@@ -67,9 +67,17 @@ fn project_bf16_lm_head(
 ) -> Result<()> {
     // The existing kernel shares one BF16 weight read across up to eight rows.
     // Its uint4 loads require each input/weight row to remain 16-byte aligned.
+    //
+    // 🔴 `DENSE_GEMV_BATCHM_DECODE_MAX_M`, NOT the kernel's `MAX_M`. The GEMV
+    // tier was widened to 16 for PREFILL only; this is a decode head, and the
+    // band's upper edge is what decides whether a width lands on the batched
+    // GEMV or the reassociating tile GEMM — i.e. which bits a decode of that
+    // width produces. When `MAX_M` was 8 the two names were the same number
+    // and this site read the right one by accident; they are not the same
+    // number any more. See `layers/ops/gemm_quant.rs` for the frozen band.
     if batch_enabled
         && batch_gemv.0 != 0
-        && (1..=ops::DENSE_GEMV_BATCHM_MAX_M).contains(&m)
+        && (1..=ops::DENSE_GEMV_BATCHM_DECODE_MAX_M).contains(&m)
         && k.is_multiple_of(8)
     {
         ops::dense_gemv_batchm(gpu, batch_gemv, input, weight, output, m, n, k, n, stream)

--- a/kernels/gb10/common/dense_gemv_bf16_batchm.cu
+++ b/kernels/gb10/common/dense_gemv_bf16_batchm.cu
@@ -60,7 +60,26 @@
 #define N_PER_BLOCK 4
 #define WARP_SIZE 32
 #define VEC_SIZE 8   // BF16 values per vectorized load (uint4 = 16 bytes)
-#define MAX_M 8      // compile-time cap on batched rows; callers must pass M <= MAX_M
+// Compile-time cap on batched rows; callers must pass M <= MAX_M.
+//
+// 🔴 16, NOT 8. The cap was never arithmetic: `acc[t]` is one independent FP32 chain per
+// row over the same `kv` order, `m` appears in no row's operand sequence, and the reduce
+// is per-`t`. So a wider tier is bit-identical to the narrow one AND to M serial
+// `dense_gemv_bf16` calls — widening it only changes how much weight traffic each token
+// pays for. MEASURED on the 12 real GLM-5.3 prefill shapes with cold weights
+// (`scripts/glm53-dense-bf16/bench_m16.cu`, spark-bench): every row byte-identical to the
+// M=1 kernel at M=16, every m <= 8 byte-identical to the MAX_M=8 kernel this replaces
+// (the gate that matters — decode, the MTP verify and the lm_head arm all run m <= 8 on
+// this same kernel), and per-token cost 1.36-1.98x lower on 11 of the 12 shapes.
+//
+// 🪤 The one shape that LOSES is shallow-K: N4096 K128 goes 0.77x, because at K_VEC = 16
+// the staging barriers dominate a kernel that barely reads anything. It costs ~0.27 s of a
+// ~17.6 s win, so it is not worth a special case — but do not generalise "wider is faster"
+// past K >= 1024.
+//
+// 🪤 smem is `MAX_M * 64 * 16 B` = 16 KB at 16 (was 8 KB), plus 512 B for the fold. Still
+// 6 blocks/SM against the 100 KB/SM on GB10, so occupancy is not the limiter.
+#define MAX_M 16
 
 extern "C" __global__ void dense_gemv_bf16_batchm(
     const __nv_bfloat16* __restrict__ A,  // [M, K]
@@ -89,8 +108,8 @@ extern "C" __global__ void dense_gemv_bf16_batchm(
     const unsigned int K_VEC = K / VEC_SIZE;
     const uint4* B_vec = (const uint4*)(B + (unsigned long long)(active ? n : 0) * K);
 
-    // One 64-kv slab of every A row, shared by all four output groups. 8 KB at
-    // MAX_M = 8, so it never limits occupancy (100 KB/SM on GB10).
+    // One 64-kv slab of every A row, shared by all four output groups. 16 KB at
+    // MAX_M = 16, so it never limits occupancy (100 KB/SM on GB10).
     __shared__ uint4 As[MAX_M][BLOCK_SIZE / N_PER_BLOCK];
 
     for (unsigned int base = 0; base < K_VEC; base += threads_per_out) {

--- a/kernels/gb10/common/dense_gemv_bf16_batchm.cu
+++ b/kernels/gb10/common/dense_gemv_bf16_batchm.cu
@@ -32,6 +32,26 @@
 // padding, and was measured 3.6x SLOWER than the batched GEMV on this exact
 // workload (see the note in multi_seq/qkv.rs::wide_verify_gemm).
 //
+// THE A TILE LIVES IN SHARED MEMORY. The four output groups in a block walk the
+// SAME `kv` sequence, so each of them was re-reading identical `A[t][kv]` — 4x
+// redundant, and at M=8 that is EIGHT activation loads issued per ONE weight load.
+// While `m * K * 2` fits L1 those hit cache and cost only issue slots; once it
+// overflows L1 they all fall to L2 and the kernel becomes L2-bound rather than
+// DRAM-bound, which is where the measured bandwidth collapses (145 GB/s at
+// N=4096 K=16384 against 213 GB/s at K=3072 on the same part). Staging the tile
+// once per block per 64-`kv` chunk removes both effects.
+//
+// 🪤 This does NOT touch the arithmetic. Same `kv` order per row, same lo-then-hi
+// add order, same 64-thread stride, same warp-shuffle tree, same 2-warp fold —
+// the values reaching the FMUL/FADD chain are the same bits, just fetched
+// differently. Measured bit-identical to the previous revision on 64 (N, K)
+// shapes and on M = 1..8 (`scripts/glm53-dense-bf16/bench_dense_bf16.cu`,
+// spark-bench). Measured 1.02-1.50x depending on shape; 1.12x weighted by the
+// 9000-token GLM prefill's own launch histogram.
+//
+// 🪤 The old `if (n >= N) return;` is now a mask, not a return: threads in a
+// partial last block have to reach the staging barriers with everyone else.
+//
 // Grid: (ceil(N / 4), 1, 1)   Block: (256, 1, 1)
 
 #include <cuda_bf16.h>
@@ -56,7 +76,9 @@ extern "C" __global__ void dense_gemv_bf16_batchm(
     const unsigned int lane = threadIdx.x % threads_per_out;
 
     const unsigned int n = blockIdx.x * N_PER_BLOCK + local_out;
-    if (n >= N) return;
+    // 🪤 NOT a return: the staging loop below has __syncthreads(), so every thread
+    // in a partial last block must stay to reach them.
+    const bool active = (n < N);
 
     const unsigned int m = (M > MAX_M) ? MAX_M : M;
 
@@ -65,43 +87,66 @@ extern "C" __global__ void dense_gemv_bf16_batchm(
     for (int t = 0; t < MAX_M; t++) acc[t] = 0.0f;
 
     const unsigned int K_VEC = K / VEC_SIZE;
-    const uint4* B_vec = (const uint4*)(B + (unsigned long long)n * K);
+    const uint4* B_vec = (const uint4*)(B + (unsigned long long)(active ? n : 0) * K);
 
-    for (unsigned int kv = lane; kv < K_VEC; kv += threads_per_out) {
-        // ONE weight load feeds every row — this is the whole point.
-        uint4 b_data = B_vec[kv];
-        const unsigned int b_raw[4] = {b_data.x, b_data.y, b_data.z, b_data.w};
+    // One 64-kv slab of every A row, shared by all four output groups. 8 KB at
+    // MAX_M = 8, so it never limits occupancy (100 KB/SM on GB10).
+    __shared__ uint4 As[MAX_M][BLOCK_SIZE / N_PER_BLOCK];
 
-        float bf[8];
-        #pragma unroll
-        for (int i = 0; i < 4; i++) {
-            __nv_bfloat16 b_lo, b_hi;
-            *(unsigned short*)&b_lo = (unsigned short)(b_raw[i] & 0xFFFF);
-            *(unsigned short*)&b_hi = (unsigned short)(b_raw[i] >> 16);
-            bf[2 * i] = __bfloat162float(b_lo);
-            bf[2 * i + 1] = __bfloat162float(b_hi);
+    for (unsigned int base = 0; base < K_VEC; base += threads_per_out) {
+        // Cooperative stage: 256 threads fetch m x 64 uint4 once for the block.
+        for (unsigned int idx = threadIdx.x; idx < m * threads_per_out; idx += BLOCK_SIZE) {
+            const unsigned int t = idx / threads_per_out;
+            const unsigned int l = idx % threads_per_out;
+            const unsigned int kv = base + l;
+            if (kv < K_VEC) {
+                As[t][l] = ((const uint4*)(A + (unsigned long long)t * K))[kv];
+            }
         }
+        __syncthreads();
 
-        for (unsigned int t = 0; t < m; t++) {
-            const uint4* At_vec = (const uint4*)(A + (unsigned long long)t * K);
-            uint4 a_data = At_vec[kv];
-            const unsigned int a_raw[4] = {a_data.x, a_data.y, a_data.z, a_data.w};
-            float a = acc[t];
+        const unsigned int kv = base + lane;
+        if (kv < K_VEC && active) {
+            // ONE weight load feeds every row — this is the whole point.
+            uint4 b_data = B_vec[kv];
+            const unsigned int b_raw[4] = {b_data.x, b_data.y, b_data.z, b_data.w};
+
+            float bf[8];
             #pragma unroll
             for (int i = 0; i < 4; i++) {
-                __nv_bfloat16 a_lo, a_hi;
-                *(unsigned short*)&a_lo = (unsigned short)(a_raw[i] & 0xFFFF);
-                *(unsigned short*)&a_hi = (unsigned short)(a_raw[i] >> 16);
-                // Same add order as dense_gemv_bf16: lo then hi, per vector slot.
-                a += __bfloat162float(a_lo) * bf[2 * i];
-                a += __bfloat162float(a_hi) * bf[2 * i + 1];
+                __nv_bfloat16 b_lo, b_hi;
+                *(unsigned short*)&b_lo = (unsigned short)(b_raw[i] & 0xFFFF);
+                *(unsigned short*)&b_hi = (unsigned short)(b_raw[i] >> 16);
+                bf[2 * i] = __bfloat162float(b_lo);
+                bf[2 * i + 1] = __bfloat162float(b_hi);
             }
-            acc[t] = a;
+
+            for (unsigned int t = 0; t < m; t++) {
+                uint4 a_data = As[t][lane];
+                const unsigned int a_raw[4] = {a_data.x, a_data.y, a_data.z, a_data.w};
+                float a = acc[t];
+                #pragma unroll
+                for (int i = 0; i < 4; i++) {
+                    __nv_bfloat16 a_lo, a_hi;
+                    *(unsigned short*)&a_lo = (unsigned short)(a_raw[i] & 0xFFFF);
+                    *(unsigned short*)&a_hi = (unsigned short)(a_raw[i] >> 16);
+                    // Same add order as dense_gemv_bf16: lo then hi, per vector slot.
+                    a += __bfloat162float(a_lo) * bf[2 * i];
+                    a += __bfloat162float(a_hi) * bf[2 * i + 1];
+                }
+                acc[t] = a;
+            }
         }
+        // Before the next slab overwrites what the compute above is still reading.
+        __syncthreads();
     }
 
     // Scalar tail for K not divisible by VEC_SIZE (never hits for model dims).
-    {
+    // 🪤 Unreachable in practice for a different reason than the comment implies:
+    // the `(const uint4*)` casts above already fault on a K that is not a multiple
+    // of VEC_SIZE. Reproduced on the UNMODIFIED kernel at N=4096 K=3073
+    // ("misaligned address"), so this is pre-existing, not a property of staging.
+    if (active) {
         const unsigned int tail_start = K_VEC * VEC_SIZE;
         const __nv_bfloat16* B_row = B + (unsigned long long)n * K;
         for (unsigned int k = tail_start + lane; k < K; k += threads_per_out) {
@@ -111,6 +156,8 @@ extern "C" __global__ void dense_gemv_bf16_batchm(
             }
         }
     }
+
+    if (!active) return;
 
     const unsigned int warp_lane = threadIdx.x % WARP_SIZE;
 


### PR DESCRIPTION
# gemv (6/8, G4): batched BF16 GEMV activation tile in shared memory; dense row batch widened to 16, routed MoE kept at 8, decode band at 8

_Review unit **G4** (6/8) of the GLM-5.3-Flash upstream re-cut. Stack: `b2a01747` → M1 → M2 → M3 → G2 → G3 → G4 → G1 → O1 = `be6862ab` tree. Class: performance. Taxonomy: `performance/prefill`._

| | |
|---|---|
| base | `b1023745` (land/glm53-5-G3) |
| head | `e86f7879` (`land/glm53-6-G4`) |
| commits | 3 |
| files | 8 (8 files changed, 385 insertions(+), 138 deletions(-)) |
| allow-list entries added | 0 |

## Summary

`dense_gemv_bf16_batchm` stages its activation tile in shared memory and the bit-identical dense row batch is widened from 8 to 16 for prefill, while the routed-MoE union batch stays at 8 and the DECODE dispatch band is pinned at `DENSE_GEMV_BATCHM_DECODE_MAX_M = 8` (session 01's re-authoring on the upstream `lm_head_batched.rs`, so the decode width lands on the same kernel — and the same bits — as before).

## Dependency

Stacks on G3 (historically authored between G3's first and second halves); touches M2/M3 files (`glm5next_layer/mod.rs`, `glm5next_mlp/forward.rs`, `impl_a3.rs`, `gemm_quant.rs`).

## Commits (stack order; origin = candidate commit it was cherry-picked from)

| stack | origin | subject |
|---|---|---|
| `cb2be03d` | `a20248e9` | perf(gemv): stage the batched BF16 GEMV's activation tile in shared memory |
| `0b0b37e1` | `6228baa2` | perf(prefill): widen the bit-identical dense row batch to 16, keep the routed MoE at 8 |
| `e86f7879` | `recut` | recut(G4): upstream re-cut adaptations for the G4 files |

## Test plan

CPU (this head, CI-equivalent, run 2026-09-07):

- [x] cap: PASS
- [x] fmt: PASS
- [x] spdx: PASS
- [x] clippy: PASS (warnings=33) 10:43:26 — run on the pre-rebase head `slice/glm53-6-G4` (identical unit diff, patch-id equal; the rebase onto `b2a01747` was conflict-free and the 4 upstream commits touch none of this stack's files); re-run on the final landing head
- [x] `cargo test --workspace --locked`: PASS passed=5913 failed=0 ignored=84 suites=85 10:56:45 — run on the pre-rebase head `slice/glm53-6-G4` (identical unit diff, patch-id equal; the rebase onto `b2a01747` was conflict-free and the 4 upstream commits touch none of this stack's files); re-run on the final landing head

Required for this unit:

- `dense_gemv_bf16_batchm_microtest` (bit-parity across M ≤ 16) — GPU, run on the candidate
- `cargo test --workspace` (row-dispatch band tests)

**Validation label:** the runtime evidence cited is on the GPU-qualified candidate / the frozen integration tree `d5b44da1` (whose 248-file diff this landing stack carries unchanged onto `b2a01747`), not on this intermediate head. This head is **review-only** (`/stamp`-held; the certification lane runs once, on the integration PR whose tree equals `be6862ab` = the certification candidate `01e174ce` = merge(d5b44da1-content, origin/main `b2a01747`)).

## Certification evidence (on the integration PR, not this head)

- Certified candidate `01e174ce` (tree `be6862ab`) — 11/11 required gates PASS on GB10, 13 invocations, one signer `ed6bcdc50223ea40`.
- Records + signatures + signer key: commit `71ad0ba3` on branch `cert/glm53-records-20260907` (parent = `01e174ce`; adds 23 files, changes no source).
- This unit's tree is contained in that certified tree: `git merge-tree --write-tree e86f7879 origin/main` reproduces the same content (proof: `landing-proof.json`).
- Landing: this PR is **not merged on its own**. It is closed once the integration PR #965 squash-lands, with the containment proof, following the `#934` precedent.

## Notes for reviewers

- The prefill 16 / decode 8 split is deliberate: `DENSE_GEMV_BATCHM_MAX_M = 16` for prefill rows, decode stays at 8 so the byte-identity of the sealed decode path is preserved.

## Files

<details><summary>8 files</summary>

- `crates/spark-model/examples/dense_gemv_bf16_batchm_microtest.rs`
- `crates/spark-model/src/layers/glm5next_layer/mod.rs`
- `crates/spark-model/src/layers/glm5next_mlp/forward.rs`
- `crates/spark-model/src/layers/mtp_head/row_dispatch.rs`
- `crates/spark-model/src/layers/ops/gemm_quant.rs`
- `crates/spark-model/src/model/impl_a3.rs`
- `crates/spark-model/src/model/trait_impl/lm_head_batched.rs`
- `kernels/gb10/common/dense_gemv_bf16_batchm.cu`

</details>

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
