### PR TITLE
scheduler (7/8, G1): tool-call parser registration for glm5_next; grammar constrains token 0 only outside <think>; MTP verify rows crossing </think>

### DIFF
--- a/crates/spark-server/src/grammar/mod.rs
+++ b/crates/spark-server/src/grammar/mod.rs
@@ -15,7 +15,7 @@ mod schema;
 mod state;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 pub use engine::{GrammarEngine, GrammarError};
 pub use schema::augment_schema_with_tafc_think;

--- a/crates/spark-server/src/grammar/tests/mod.rs
+++ b/crates/spark-server/src/grammar/tests/mod.rs
@@ -19,7 +19,7 @@ mod value_entry;
 
 /// Build a minimal vocabulary for testing.
 /// Contains basic ASCII + JSON structural tokens.
-pub(super) fn test_vocab() -> Vec<String> {
+pub(crate) fn test_vocab() -> Vec<String> {
     let mut vocab = Vec::new();
     // Token 0..127: single ASCII characters
     for i in 0u8..128 {
@@ -34,7 +34,7 @@ pub(super) fn test_vocab() -> Vec<String> {
     vocab
 }
 
-pub(super) fn test_tool_defs() -> Vec<ToolDefinition> {
+pub(crate) fn test_tool_defs() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         tool_type: "function".to_string(),
         function: crate::tool_parser::FunctionDefinition {

--- a/crates/spark-server/src/scheduler/first_token_policy.rs
+++ b/crates/spark-server/src/scheduler/first_token_policy.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Token-0 grammar policy — the one seam every prefill route shares.
+//!
+//! Invariant: **a grammar constrains or advances token 0 iff the sequence
+//! is born with `inside_thinking == false`.** While a sequence is inside
+//! `<think>` the matcher is paused: no bitmask, no `accept_token`, and
+//! `</think>` itself never advances it, so the first post-think token is
+//! the first token the grammar ever sees. The decode loop already honours
+//! this for tokens 1..N (`grammar_bitmask.rs`, `decode_logits_step.rs`,
+//! `emit_step.rs` all gate on `!inside_thinking`). Token 0 did not: every
+//! prefill route called `sample_first_token` with the armed grammar BEFORE
+//! the `ActiveSeq` (and its `inside_thinking`) existed, so a
+//! `required`/specific tool grammar forced `<tool_call>` into the reasoning
+//! span at token 0, `JsonObject`/`JsonSchema` forced structural syntax
+//! there, and the matcher was left one token ahead of the content stream
+//! when `</think>` finally arrived (GLM-5.3 forced-tool request, 2026-09-06:
+//! envelope fabricated inside `reasoning_content`, `tool_calls=null`).
+//!
+//! The fix is generic: the policy is derived from [`born_inside_thinking`],
+//! the SAME predicate that births `ActiveSeq::inside_thinking`, so the
+//! sampler cannot drift from the sequence it samples for. No model-,
+//! grammar-class- or parser-specific branch exists here on purpose.
+
+use crate::grammar::GrammarState;
+use anyhow::Result;
+
+/// The single birth predicate for `ActiveSeq::inside_thinking`.
+///
+/// Every `ActiveSeq` constructor and every [`FirstTokenPolicy`] derives
+/// from this function. Do not re-derive thinking semantics anywhere else.
+pub(super) fn born_inside_thinking(enable_thinking: bool, think_end_token: Option<u32>) -> bool {
+    enable_thinking && think_end_token.is_some()
+}
+
+/// What token 0 may do with an armed grammar.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct FirstTokenPolicy {
+    /// Token 0 is sampled inside `<think>`: skip the bitmask, skip
+    /// `accept_token`, leave the matcher pristine for the first post-think
+    /// token.
+    pub grammar_suspended: bool,
+    /// The `<tool_call>` id. Suppressed at token 0 while a grammar is armed
+    /// and suspended — the decode-loop twin is `ToolCallDuringThinkingMask`,
+    /// which only covers tokens 1..N.
+    pub tool_call_start: Option<u32>,
+}
+
+impl FirstTokenPolicy {
+    /// Policy for a sequence about to be born from these request facts.
+    pub(super) fn for_birth(
+        enable_thinking: bool,
+        think_end_token: Option<u32>,
+        tool_call_start: Option<u32>,
+    ) -> Self {
+        Self {
+            grammar_suspended: born_inside_thinking(enable_thinking, think_end_token),
+            tool_call_start,
+        }
+    }
+}
+
+/// Core of `sample_first_token`, generic over the model-dependent sampler.
+///
+/// `sample(suppress_ids, grammar)` is called exactly once. It receives the
+/// grammar only when the policy lets the grammar act; when it does, the
+/// matcher is advanced past the returned token (the decode loop's
+/// `accept_token` only runs for tokens 1..N). With no grammar the call is
+/// a plain pass-through — the non-grammar path is byte-identical to before.
+pub(super) fn first_token_with<F>(
+    policy: FirstTokenPolicy,
+    suppress_ids: &[u32],
+    grammar_state: Option<&mut GrammarState>,
+    sample: F,
+) -> Result<u32>
+where
+    F: FnOnce(&[u32], Option<&mut GrammarState>) -> Result<u32>,
+{
+    let Some(gs) = grammar_state else {
+        return sample(suppress_ids, None);
+    };
+    if policy.grammar_suspended {
+        // Grammar armed, sequence born inside <think>: the matcher must not
+        // see this token. Keep the opener out of the reasoning span too.
+        let mut ids = suppress_ids.to_vec();
+        if let Some(t) = policy.tool_call_start
+            && !ids.contains(&t)
+        {
+            ids.push(t);
+        }
+        return sample(&ids, None);
+    }
+    let tok = sample(suppress_ids, Some(&mut *gs))?;
+    // A grammar-disallowed first token here would indicate the mask was not
+    // applied — keep going rather than abort; the emit_step disengage path
+    // handles any later desync gracefully.
+    gs.accept_token(tok);
+    Ok(tok)
+}

--- a/crates/spark-server/src/scheduler/first_token_policy_tests.rs
+++ b/crates/spark-server/src/scheduler/first_token_policy_tests.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Behavioural tests for the token-0 grammar policy (`first_token_policy`)
+//! and the `</think>` hand-off it relies on. Every test drives a REAL
+//! xgrammar matcher over the shared toy vocabulary; the only stand-in is
+//! the model-dependent sampler, which is a closure that reports what it
+//! was handed and returns either the model's "free" pick or the first
+//! grammar-allowed id (what a bitmask-masked argmax would return).
+
+use super::emit_step::emit_token;
+use super::first_token_policy::{FirstTokenPolicy, born_inside_thinking, first_token_with};
+use super::sched_ctx::SchedCtx;
+use super::test_support::test_seq;
+use crate::grammar::tests::{test_tool_defs, test_vocab};
+use crate::grammar::{GrammarEngine, GrammarState};
+
+const TOOL_CALL_OPEN: u32 = 128; // "<tool_call>" in the toy vocab
+const EOS: u32 = 130; // "<eos>"
+/// A plain content byte no grammar under test allows as its first token.
+const HELLO: u32 = b'h' as u32;
+/// `</think>`. Deliberately OUTSIDE the toy vocab: the matcher must never
+/// be fed it, so an id it cannot know is the strongest possible probe.
+const THINK_END: u32 = 151_668;
+const VOCAB_LEN: u32 = 131;
+
+/// `tool_choice="required"` hermes grammar: `<tool_call>` is the only legal
+/// first token.
+fn required_tool_grammar() -> GrammarState {
+    let vocab = test_vocab();
+    let mut engine = GrammarEngine::new(&vocab, &[EOS as i32]).unwrap();
+    let compiled = engine
+        .compile_hermes_tool_grammar(&test_tool_defs(), false)
+        .unwrap();
+    GrammarState::new(&compiled, engine.vocab_size())
+        .unwrap()
+        .with_stop_tokens(&[EOS])
+}
+
+/// `response_format=json_schema`: only whitespace or `{` is legal first.
+fn json_schema_grammar() -> GrammarState {
+    let vocab = test_vocab();
+    let mut engine = GrammarEngine::new(&vocab, &[EOS as i32]).unwrap();
+    let compiled = engine
+        .compile_json_schema(
+            r#"{"type":"object","properties":{"a":{"type":"integer"}},"required":["a"]}"#,
+        )
+        .unwrap();
+    GrammarState::new(&compiled, engine.vocab_size())
+        .unwrap()
+        .with_stop_tokens(&[EOS])
+}
+
+/// What a bitmask-masked argmax returns for a model that prefers the
+/// single-token opener: `<tool_call>` when the grammar allows it, else the
+/// lowest allowed id. (The hermes tag also admits the byte-wise spelling
+/// `<`,`t`,… so "lowest allowed id" alone is `<` = 60.)
+fn masked_pick(gs: &mut GrammarState) -> u32 {
+    gs.fill_bitmask();
+    if gs.is_token_allowed(TOOL_CALL_OPEN) {
+        return TOOL_CALL_OPEN;
+    }
+    (0..VOCAB_LEN)
+        .find(|&t| gs.is_token_allowed(t))
+        .expect("grammar allows at least one token")
+}
+
+fn allows(gs: &mut GrammarState, tok: u32) -> bool {
+    gs.fill_bitmask();
+    gs.is_token_allowed(tok)
+}
+
+/// Run the seam once and report `(suppress_ids seen, grammar handed?)`.
+fn run(policy: FirstTokenPolicy, gs: Option<&mut GrammarState>) -> (u32, Vec<u32>, bool) {
+    let mut seen: Option<(Vec<u32>, bool)> = None;
+    let tok = first_token_with(policy, &[EOS], gs, |ids, g| {
+        seen = Some((ids.to_vec(), g.is_some()));
+        Ok(match g {
+            Some(g) => masked_pick(g),
+            None => HELLO,
+        })
+    })
+    .unwrap();
+    let (ids, masked) = seen.expect("sampler runs exactly once");
+    (tok, ids, masked)
+}
+
+fn thinking(tool_call_start: Option<u32>) -> FirstTokenPolicy {
+    FirstTokenPolicy::for_birth(true, Some(THINK_END), tool_call_start)
+}
+
+fn direct(tool_call_start: Option<u32>) -> FirstTokenPolicy {
+    FirstTokenPolicy::for_birth(false, Some(THINK_END), tool_call_start)
+}
+
+#[test]
+fn policy_is_the_birth_predicate() {
+    // The sampler's view and the ActiveSeq's view are one function.
+    assert!(born_inside_thinking(true, Some(THINK_END)));
+    assert!(
+        !born_inside_thinking(true, None),
+        "no </think> id = no thinking span"
+    );
+    assert!(!born_inside_thinking(false, Some(THINK_END)));
+    assert!(thinking(None).grammar_suspended);
+    assert!(!direct(None).grammar_suspended);
+}
+
+#[test]
+fn required_tool_grammar_leaves_token0_alone_when_born_thinking() {
+    // 1. Thinking at birth: token 0 is NOT forced to <tool_call>, the
+    //    opener is suppressed instead, and the matcher never moves.
+    let mut gs = required_tool_grammar();
+    let (tok, ids, masked) = run(thinking(Some(TOOL_CALL_OPEN)), Some(&mut gs));
+    assert!(!masked, "grammar must not mask token 0 inside <think>");
+    assert!(
+        ids.contains(&TOOL_CALL_OPEN),
+        "<tool_call> suppressed in thinking"
+    );
+    assert!(ids.contains(&EOS), "caller's suppress set preserved");
+    assert_eq!(tok, HELLO, "the model's free pick stands");
+    assert_eq!(gs.num_history_steps(), 0, "grammar history must stay 0");
+    assert!(allows(&mut gs, TOOL_CALL_OPEN), "grammar still pristine");
+    assert!(!allows(&mut gs, HELLO));
+}
+
+#[test]
+fn required_tool_grammar_still_forces_token0_when_born_direct() {
+    // 2. No thinking span: existing token-0 forcing is unchanged.
+    let mut gs = required_tool_grammar();
+    let (tok, ids, masked) = run(direct(Some(TOOL_CALL_OPEN)), Some(&mut gs));
+    assert!(masked, "grammar masks token 0 outside <think>");
+    assert_eq!(ids, vec![EOS], "no extra suppression outside <think>");
+    assert_eq!(tok, TOOL_CALL_OPEN);
+    assert!(gs.num_history_steps() >= 1, "matcher advanced past token 0");
+    assert!(
+        !allows(&mut gs, TOOL_CALL_OPEN),
+        "cannot re-open after the opener"
+    );
+}
+
+#[test]
+fn json_schema_leaves_token0_alone_when_born_thinking() {
+    // 3. Same invariant for structured output: no `{`/whitespace forcing
+    //    into the reasoning span, history 0, schema pristine.
+    let mut gs = json_schema_grammar();
+    let opener = masked_pick(&mut gs);
+    assert!(
+        !allows(&mut gs, HELLO),
+        "fixture: 'h' is schema-illegal first"
+    );
+    let (tok, _ids, masked) = run(thinking(None), Some(&mut gs));
+    assert!(!masked);
+    assert_eq!(tok, HELLO);
+    assert_eq!(gs.num_history_steps(), 0);
+    assert_eq!(masked_pick(&mut gs), opener, "schema still pristine");
+    assert!(!allows(&mut gs, HELLO));
+}
+
+#[test]
+fn json_schema_still_forces_token0_when_born_direct() {
+    // 4. Existing behaviour: masked pick, matcher advanced.
+    let mut gs = json_schema_grammar();
+    let expected = masked_pick(&mut gs);
+    let (tok, _ids, masked) = run(direct(None), Some(&mut gs));
+    assert!(masked);
+    assert_eq!(tok, expected);
+    assert!(gs.num_history_steps() >= 1);
+}
+
+#[test]
+fn no_grammar_path_is_a_pass_through_even_when_thinking() {
+    // Legacy/no-grammar token 0 is untouched: no opener suppression, the
+    // caller's ids go through verbatim, nothing to advance.
+    let (tok, ids, masked) = run(thinking(Some(TOOL_CALL_OPEN)), None);
+    assert!(!masked);
+    assert_eq!(ids, vec![EOS]);
+    assert_eq!(tok, HELLO);
+}
+
+#[test]
+fn think_end_leaves_grammar_pristine_and_first_content_token_is_step_one() {
+    // 5. The hand-off the policy relies on, on the real emit path: `</think>`
+    //    must not advance the matcher; the first content token after it is
+    //    grammar step 1 and does not disengage the grammar.
+    let (mut a, _rx) = test_seq(Vec::new(), 5000, None, 10);
+    a.finished = false;
+    a.inside_thinking = true;
+    a.enable_thinking = true;
+    a.think_end_token = Some(THINK_END);
+    a.grammar_state = Some(required_tool_grammar());
+    let sched = SchedCtx::for_test();
+
+    emit_token(&mut a, THINK_END, None, &sched);
+    assert!(
+        !a.inside_thinking && a.think_ended,
+        "</think> closes the span"
+    );
+    let gs = a.grammar_state.as_mut().expect("grammar survives </think>");
+    assert_eq!(
+        gs.num_history_steps(),
+        0,
+        "</think> must not advance the matcher"
+    );
+    assert!(
+        allows(gs, TOOL_CALL_OPEN),
+        "grammar pristine after </think>"
+    );
+
+    emit_token(&mut a, TOOL_CALL_OPEN, None, &sched);
+    let gs = a
+        .grammar_state
+        .as_mut()
+        .expect("first post-think token must not disengage the grammar");
+    assert!(
+        gs.num_history_steps() >= 1,
+        "first content token is grammar step 1"
+    );
+    assert!(!a.finished);
+}

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -25,6 +25,9 @@ mod emit_step;
 mod fast_greedy;
 #[cfg(test)]
 mod finish_guard_tests;
+mod first_token_policy;
+#[cfg(test)]
+mod first_token_policy_tests;
 mod helpers;
 mod lifecycle;
 #[cfg(test)]
@@ -91,6 +94,7 @@ use decode_logits_seq::*;
 use decode_logits_step::*;
 use decode_step::*;
 use emit_step::*;
+use first_token_policy::*;
 pub use helpers::WatchdogParams;
 pub(crate) use helpers::parse_disable_watchdogs;
 pub use helpers::resolve_content_loop_watchdog;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -36,8 +36,8 @@ use std::time::Instant;
 use spark_model::traits::Model;
 
 use super::phase_promote_prefills::promote_completed_prefills;
-use super::sample_first_token;
 use super::types::{ActiveSeq, PrefillInProgress};
+use super::{FirstTokenPolicy, sample_first_token};
 use crate::scheduling_policy::{ActiveSeqTiming, SchedulingPolicy};
 
 use run_batched_mixed::run_batched_mixed_step;
@@ -244,6 +244,8 @@ pub(super) fn continue_in_progress_prefills(
             max_batch_tokens,
             prefill_stream,
             prefill_event,
+            think_end_token,
+            tool_call_start_token,
         );
         promote_completed_prefills(
             model,
@@ -346,6 +348,11 @@ pub(super) fn continue_in_progress_prefills(
                         p.min_p,
                         &p.eos_tokens,
                         p.grammar_state.as_mut(),
+                        FirstTokenPolicy::for_birth(
+                            p.enable_thinking,
+                            think_end_token,
+                            tool_call_start_token,
+                        ),
                         &sched.levers.sampling(),
                     ) {
                         Ok(first) => {

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs
@@ -17,8 +17,8 @@ use spark_runtime::gpu::DevicePtr;
 use std::time::Instant;
 
 use super::super::decode_logits_step::process_decode_logits;
-use super::super::sample_first_token;
 use super::super::types::{ActiveSeq, PrefillInProgress};
+use super::super::{FirstTokenPolicy, sample_first_token};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_batched_mixed_step(
@@ -164,6 +164,7 @@ pub(super) fn run_batched_mixed_step(
             p.min_p,
             &p.eos_tokens,
             p.grammar_state.as_mut(),
+            FirstTokenPolicy::for_birth(p.enable_thinking, think_end_token, tool_call_start_token),
             &sched.levers.sampling(),
         ) {
             Ok(first) => {

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -14,8 +14,8 @@ use spark_model::traits::{Model, PrefillSlice};
 use spark_runtime::gpu::DevicePtr;
 use std::time::Instant;
 
-use super::super::sample_first_token;
 use super::super::types::PrefillInProgress;
+use super::super::{FirstTokenPolicy, sample_first_token};
 use super::prefill_waves::{WaveGeom, plan_prefill_waves};
 
 pub(super) fn run_batched_prefill_step(
@@ -27,6 +27,8 @@ pub(super) fn run_batched_prefill_step(
     max_batch_tokens: usize,
     prefill_stream: u64,
     prefill_event: u64,
+    think_end_token: Option<u32>,
+    tool_call_start_token: Option<u32>,
 ) {
     // Per-chunk InnerQ finalize poll — see `phase_continue_prefills::poll_innerq`.
     super::poll_innerq(model);
@@ -217,6 +219,11 @@ pub(super) fn run_batched_prefill_step(
                 p.min_p,
                 &p.eos_tokens,
                 p.grammar_state.as_mut(),
+                FirstTokenPolicy::for_birth(
+                    p.enable_thinking,
+                    think_end_token,
+                    tool_call_start_token,
+                ),
                 &sched.levers.sampling(),
             ) {
                 Ok(first) => {

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs
@@ -12,8 +12,8 @@ use std::time::Instant;
 
 use super::super::decode_logits_step::process_decode_logits;
 use super::super::lifecycle::send_error;
-use super::super::sample_first_token;
 use super::super::types::{ActiveSeq, PrefillInProgress};
+use super::super::{FirstTokenPolicy, sample_first_token};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn run_standard_chunk_loop(
@@ -201,6 +201,11 @@ pub(super) fn run_standard_chunk_loop(
                         p.min_p,
                         &p.eos_tokens,
                         p.grammar_state.as_mut(),
+                        FirstTokenPolicy::for_birth(
+                            p.enable_thinking,
+                            think_end_token,
+                            tool_call_start_token,
+                        ),
                         &sched.levers.sampling(),
                     ) {
                         Ok(first) => {
@@ -337,6 +342,11 @@ pub(super) fn run_standard_chunk_loop(
                     p.min_p,
                     &p.eos_tokens,
                     p.grammar_state.as_mut(),
+                    FirstTokenPolicy::for_birth(
+                        p.enable_thinking,
+                        think_end_token,
+                        tool_call_start_token,
+                    ),
                     &sched.levers.sampling(),
                 ) {
                     Ok(first) => {

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -183,9 +183,9 @@ fn build_active_seq_from_prefill(
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
         inside_thinking: if immediate_finish {
-            p.enable_thinking && think_end_token.is_some()
+            born_inside_thinking(p.enable_thinking, think_end_token)
         } else {
-            spontaneous_think || (p.enable_thinking && think_end_token.is_some())
+            spontaneous_think || born_inside_thinking(p.enable_thinking, think_end_token)
         },
         enable_thinking: p.enable_thinking,
         thinking_budget: if !immediate_finish && spontaneous_think {

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -221,7 +221,7 @@ pub fn start_chunked_prefill(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
-            inside_thinking: req_enable_thinking && think_end_token.is_some(),
+            inside_thinking: born_inside_thinking(req_enable_thinking, think_end_token),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
             repetition_detection: req_repetition_detection,
@@ -452,6 +452,11 @@ pub fn start_chunked_prefill(
             min_p,
             eos_tokens,
             grammar_state.as_mut(),
+            FirstTokenPolicy::for_birth(
+                req_enable_thinking,
+                think_end_token,
+                tool_call_start_token,
+            ),
             &sched.levers.sampling(),
         ) {
             Ok(t) => {
@@ -561,7 +566,7 @@ pub fn start_chunked_prefill(
                 logit_bias: logit_bias.clone(),
                 pending_drafts: Vec::new(),
                 pending_draft_conf: Vec::new(),
-                inside_thinking: req_enable_thinking && think_end_token.is_some(),
+                inside_thinking: born_inside_thinking(req_enable_thinking, think_end_token),
                 enable_thinking: req_enable_thinking,
                 thinking_budget: req_thinking_budget,
                 repetition_detection: req_repetition_detection,
@@ -651,7 +656,7 @@ pub fn start_chunked_prefill(
                 pending_drafts: Vec::new(),
                 pending_draft_conf: Vec::new(),
                 inside_thinking: spontaneous_think
-                    || (req_enable_thinking && think_end_token.is_some()),
+                    || born_inside_thinking(req_enable_thinking, think_end_token),
                 enable_thinking: req_enable_thinking,
                 thinking_budget: if spontaneous_think {
                     Some(spontaneous_think_budget)

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -192,7 +192,7 @@ pub fn prefill_request(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
-            inside_thinking: req_enable_thinking && think_end_token.is_some(),
+            inside_thinking: born_inside_thinking(req_enable_thinking, think_end_token),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
             repetition_detection: req_repetition_detection,
@@ -279,6 +279,11 @@ pub fn prefill_request(
             min_p,
             eos_tokens,
             grammar_state.as_mut(),
+            FirstTokenPolicy::for_birth(
+                req_enable_thinking,
+                think_end_token,
+                tool_call_start_token,
+            ),
             &sched.levers.sampling(),
         )
     })();
@@ -387,7 +392,7 @@ pub fn prefill_request(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
-            inside_thinking: req_enable_thinking && think_end_token.is_some(),
+            inside_thinking: born_inside_thinking(req_enable_thinking, think_end_token),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
             repetition_detection: req_repetition_detection,
@@ -473,7 +478,8 @@ pub fn prefill_request(
         logit_bias,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
-        inside_thinking: spontaneous_think || (req_enable_thinking && think_end_token.is_some()),
+        inside_thinking: spontaneous_think
+            || born_inside_thinking(req_enable_thinking, think_end_token),
         enable_thinking: req_enable_thinking,
         thinking_budget: if spontaneous_think {
             Some(spontaneous_think_budget)

--- a/crates/spark-server/src/scheduler/sample_step.rs
+++ b/crates/spark-server/src/scheduler/sample_step.rs
@@ -567,6 +567,13 @@ pub fn sample_token_with_grammar(
 /// so the unfloored min_p let the FP8/NVFP4 degenerate logit tail be
 /// sampled exactly where the floor was designed to block it. Kill-switch:
 /// `ATLAS_NO_MTP_MINP=1` restores the 0.0 literals via [`effective_min_p`].
+///
+/// `policy` (2026-09-06): whether the grammar may act on token 0 at all.
+/// A sequence born inside `<think>` keeps its matcher paused until
+/// `</think>`, exactly as the decode loop does for tokens 1..N — see
+/// [`super::first_token_policy`] for the invariant and the defect it closes.
+/// The policy is derived by the caller from the SAME predicate that births
+/// `ActiveSeq::inside_thinking`; this function never re-derives it.
 pub fn sample_first_token(
     model: &dyn Model,
     logits: DevicePtr,
@@ -576,60 +583,48 @@ pub fn sample_first_token(
     min_p: f32,
     suppress_ids: &[u32],
     grammar_state: Option<&mut GrammarState>,
+    policy: FirstTokenPolicy,
     levers: &crate::scheduler::logit_processors::SamplingLevers,
 ) -> Result<u32> {
-    let Some(gs) = grammar_state else {
-        return sample_token(
+    first_token_with(policy, suppress_ids, grammar_state, |ids, gs| {
+        let Some(gs) = gs else {
+            return sample_token(model, logits, temperature, top_k, top_p, min_p, ids, levers);
+        };
+        let neutral = SamplingParams {
+            temperature,
+            top_k,
+            top_p,
+            top_n_sigma: 0.0,
+            // P1-4 (2026-07-09): resolved min_p, consumed via `penalties.min_p`
+            // inside `sample_token_with_grammar` (kill-switch applied there).
+            min_p,
+            logit_bias: Vec::new(),
+            repetition_penalty: 1.0,
+            presence_penalty: 0.0,
+            frequency_penalty: 0.0,
+            repetition_penalty_window: 0,
+            lz_penalty: 0.0,
+            dry_multiplier: 0.0,
+            dry_base: DEFAULT_DRY_BASE,
+            dry_allowed_length: DEFAULT_DRY_ALLOWED_LENGTH,
+            dry_sequence_breakers: Vec::new(),
+            max_tokens: 0,
+            stop_token_ids: Vec::new(),
+            seed: None,
+        };
+        sample_token_with_grammar(
             model,
             logits,
             temperature,
             top_k,
             top_p,
-            min_p,
-            suppress_ids,
+            ids,
+            Some(gs),
+            &neutral,
+            &[],
             levers,
-        );
-    };
-    let neutral = SamplingParams {
-        temperature,
-        top_k,
-        top_p,
-        top_n_sigma: 0.0,
-        // P1-4 (2026-07-09): resolved min_p, consumed via `penalties.min_p`
-        // inside `sample_token_with_grammar` (kill-switch applied there).
-        min_p,
-        logit_bias: Vec::new(),
-        repetition_penalty: 1.0,
-        presence_penalty: 0.0,
-        frequency_penalty: 0.0,
-        repetition_penalty_window: 0,
-        lz_penalty: 0.0,
-        dry_multiplier: 0.0,
-        dry_base: DEFAULT_DRY_BASE,
-        dry_allowed_length: DEFAULT_DRY_ALLOWED_LENGTH,
-        dry_sequence_breakers: Vec::new(),
-        max_tokens: 0,
-        stop_token_ids: Vec::new(),
-        seed: None,
-    };
-    let tok = sample_token_with_grammar(
-        model,
-        logits,
-        temperature,
-        top_k,
-        top_p,
-        suppress_ids,
-        Some(gs),
-        &neutral,
-        &[],
-        levers,
-    )?;
-    // Advance the matcher past the first token (the emit_step accept_token
-    // only runs for tokens 2..N). A grammar-disallowed first token here would
-    // indicate the mask was not applied — keep going rather than abort; the
-    // emit_step disengage path handles any later desync gracefully.
-    gs.accept_token(tok);
-    Ok(tok)
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper.rs
@@ -52,6 +52,9 @@
 
 mod argmax;
 mod fast_masked;
+mod pick_positions;
+#[cfg(test)]
+mod pick_positions_tests;
 mod scratch;
 
 use crate::scheduler::ActiveSeq;
@@ -493,63 +496,5 @@ pub fn verify_pick_all_with_pipeline(
     }
     ctx.timing.record(Phase::D2h, t_d2h);
 
-    let mut picks: Vec<u32> = Vec::with_capacity(k);
-    // Snapshot the matcher's history depth BEFORE speculative advances so we
-    // roll back exactly the ACTUAL advances afterward. BUG#3 (2026-06-02):
-    // stop/EOS and terminated tokens return true from `accept_token` WITHOUT
-    // advancing the matcher, so a count of `accept_token`→true calls would
-    // over-rewind. `emit_token` (run after this helper) re-advances from the
-    // restored, clean state.
-    let grammar_steps_before = a.grammar_state.as_ref().map(|gs| gs.num_history_steps());
-
-    for i in 0..k {
-        let slice = &buf[i * vocab * elem_bytes..(i + 1) * vocab * elem_bytes];
-        // P1-3 (2026-07-09): `i` threads the verify-position index down for
-        // the per-position seed offset of the temp>0 sampling branch.
-        let pick = verify_pick_with_pipeline(slice, false, vocab, a, ctx, i);
-        picks.push(pick);
-
-        // Speculatively advance the matcher with `pick[i]` so the next
-        // position's bitmask reflects post-emit state. Skip on the last
-        // position (no next position to mask) and when the seq has no
-        // grammar (nothing to advance).
-        if i + 1 < k
-            && let Some(ref mut gs) = a.grammar_state
-            && !a.inside_thinking
-        {
-            // Matcher advance can fail if `pick` is not in the current
-            // bitmask. If our pipeline correctly applied the bitmask,
-            // pick is the argmax over masked logits → MUST be in the
-            // bitmask → advance MUST succeed. The defensive check
-            // exists for forced-token fast-path returns where the
-            // grammar may have terminated; those legitimately can't
-            // advance further.
-            if !gs.accept_token(pick) {
-                tracing::debug!(
-                    pick,
-                    i,
-                    "verify_pick: grammar speculative advance refused — pipeline picked a token outside the current bitmask. \
-                     This indicates a stale bitmask in the pipeline or a forced-token fastpath that terminated grammar. \
-                     Stopping speculation here; the real `accept_token` in emit_token will fail and end the response."
-                );
-                break;
-            }
-            // accept_token advanced the matcher as a side effect; the rollback
-            // below counts the ACTUAL advances from matcher history (BUG#3).
-        }
-    }
-
-    // Roll back exactly the ACTUAL speculative advances (history delta) so the
-    // matcher returns to its pre-call state; `emit_token` then re-advances it
-    // normally. BUG#3: counting from accept_token→true calls over-rewinds when
-    // a stop/EOS/terminated token (which returns true WITHOUT advancing) lands
-    // in the verified span.
-    if let (Some(before), Some(gs)) = (grammar_steps_before, a.grammar_state.as_mut()) {
-        let advanced = gs.num_history_steps().saturating_sub(before);
-        if advanced > 0 {
-            gs.rollback(advanced);
-        }
-    }
-
-    picks
+    pick_positions::pick_positions_from_host(&buf, vocab, elem_bytes, k, a, ctx)
 }

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The K-position pick loop of `verify_pick_all_with_pipeline`, split out so
+//! it can be driven over host logits without a model.
+
+use super::verify_pick_with_pipeline;
+use crate::scheduler::logit_processors::LogitsContext;
+use crate::scheduler::types::ActiveSeq;
+
+/// Run the pre-sample pipeline over `k` host-resident logits rows and return
+/// the processed pick per position.
+///
+/// Positions after the first are masked against the matcher state that the
+/// EARLIER picks would leave behind (speculative `accept_token`, rolled back
+/// at the end so `emit_token` re-advances from a clean matcher).
+///
+/// Reasoning boundary (2026-09-06): a row may cross `</think>`. The
+/// sequence's `inside_thinking` is its state at step START, so without
+/// tracking the close every later position was picked free-run and the
+/// unconstrained token was then fed to a pristine `required`/schema grammar
+/// by `emit_token` — a guaranteed disengage on the first content token. A
+/// `</think>` pick now flips the thinking flags for the REST of this loop
+/// (mirroring what `emit_token` will do for real), so the first post-think
+/// position is picked under the pristine grammar; drafts that disagree are
+/// simply rejected by the verifier. The flags are restored on exit — this
+/// loop only picks, it never commits.
+pub(super) fn pick_positions_from_host(
+    buf: &[u8],
+    vocab: usize,
+    elem_bytes: usize,
+    k: usize,
+    a: &mut ActiveSeq,
+    ctx: &LogitsContext,
+) -> Vec<u32> {
+    let mut picks: Vec<u32> = Vec::with_capacity(k);
+    // Snapshot the matcher's history depth BEFORE speculative advances so we
+    // roll back exactly the ACTUAL advances afterward. BUG#3 (2026-06-02):
+    // stop/EOS and terminated tokens return true from `accept_token` WITHOUT
+    // advancing the matcher, so a count of `accept_token`→true calls would
+    // over-rewind. `emit_token` (run after this helper) re-advances from the
+    // restored, clean state.
+    let grammar_steps_before = a.grammar_state.as_ref().map(|gs| gs.num_history_steps());
+    let think_flags_before = (a.inside_thinking, a.think_ended, a.think_just_ended);
+
+    for i in 0..k {
+        let slice = &buf[i * vocab * elem_bytes..(i + 1) * vocab * elem_bytes];
+        // P1-3 (2026-07-09): `i` threads the verify-position index down for
+        // the per-position seed offset of the temp>0 sampling branch.
+        let pick = verify_pick_with_pipeline(slice, false, vocab, a, ctx, i);
+        picks.push(pick);
+
+        // `</think>` closes the span for every later position. It is never
+        // fed to the matcher (the grammar only sees content tokens), so no
+        // speculative advance here either.
+        if a.inside_thinking && ctx.think_end_token == Some(pick) {
+            a.inside_thinking = false;
+            a.think_ended = true;
+            a.think_just_ended = true;
+            continue;
+        }
+
+        // Speculatively advance the matcher with `pick[i]` so the next
+        // position's bitmask reflects post-emit state. Skip on the last
+        // position (no next position to mask) and when the seq has no
+        // grammar (nothing to advance).
+        if i + 1 < k
+            && let Some(ref mut gs) = a.grammar_state
+            && !a.inside_thinking
+        {
+            // Matcher advance can fail if `pick` is not in the current
+            // bitmask. If our pipeline correctly applied the bitmask,
+            // pick is the argmax over masked logits → MUST be in the
+            // bitmask → advance MUST succeed. The defensive check
+            // exists for forced-token fast-path returns where the
+            // grammar may have terminated; those legitimately can't
+            // advance further.
+            if !gs.accept_token(pick) {
+                tracing::debug!(
+                    pick,
+                    i,
+                    "verify_pick: grammar speculative advance refused — pipeline picked a token outside the current bitmask. \
+                     This indicates a stale bitmask in the pipeline or a forced-token fastpath that terminated grammar. \
+                     Stopping speculation here; the real `accept_token` in emit_token will fail and end the response."
+                );
+                break;
+            }
+            // accept_token advanced the matcher as a side effect; the rollback
+            // below counts the ACTUAL advances from matcher history (BUG#3).
+        }
+    }
+
+    // Roll back exactly the ACTUAL speculative advances (history delta) so the
+    // matcher returns to its pre-call state; `emit_token` then re-advances it
+    // normally. BUG#3: counting from accept_token→true calls over-rewinds when
+    // a stop/EOS/terminated token (which returns true WITHOUT advancing) lands
+    // in the verified span.
+    if let (Some(before), Some(gs)) = (grammar_steps_before, a.grammar_state.as_mut()) {
+        let advanced = gs.num_history_steps().saturating_sub(before);
+        if advanced > 0 {
+            gs.rollback(advanced);
+        }
+    }
+    // Same discipline for the thinking flags: `emit_token` owns the real
+    // `</think>` transition on the accept path.
+    (a.inside_thinking, a.think_ended, a.think_just_ended) = think_flags_before;
+
+    picks
+}

--- a/crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions_tests.rs
+++ b/crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions_tests.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Reasoning-boundary tests for the K-position verify pick loop.
+//!
+//! A verify row may cross `</think>`: position i closes the reasoning span,
+//! so position i+1 is the FIRST content token and must be masked from the
+//! pristine grammar — exactly what a fresh decode step would do. The loop
+//! used to read `inside_thinking` as it stood at step start, so every
+//! position after the close was picked unmasked and the unconstrained draft
+//! X was then fed to the matcher by `emit_token`, disengaging a `required`
+//! grammar on its very first content token. These tests drive the real loop
+//! over synthetic host logits and a real xgrammar matcher.
+
+use super::pick_positions::pick_positions_from_host;
+use crate::grammar::tests::{test_tool_defs, test_vocab};
+use crate::grammar::{GrammarEngine, GrammarState};
+use crate::scheduler::logit_processors::{LogitsContext, SamplingLevers};
+use crate::scheduler::test_support::test_seq;
+use crate::scheduler::types::ActiveSeq;
+
+const VOCAB: usize = 131;
+const TOOL_CALL_OPEN: u32 = 128;
+const TOOL_CALL_CLOSE: u32 = 129;
+const EOS: u32 = 130;
+/// The model's free (prose) pick — grammar-illegal as a first content token.
+const HELLO: u32 = b'h' as u32;
+/// In-vocab ids standing in for `</think>` / `<think>`. The matcher must
+/// never be fed either, so any id the grammar would refuse is a fair probe.
+const THINK_END: u32 = 127;
+const THINK_START: u32 = 126;
+
+fn required_tool_grammar() -> GrammarState {
+    let vocab = test_vocab();
+    let mut engine = GrammarEngine::new(&vocab, &[EOS as i32]).unwrap();
+    let compiled = engine
+        .compile_hermes_tool_grammar(&test_tool_defs(), false)
+        .unwrap();
+    GrammarState::new(&compiled, engine.vocab_size())
+        .unwrap()
+        .with_stop_tokens(&[EOS])
+}
+
+/// A sequence mid-reasoning with a `required` tool grammar armed.
+fn thinking_seq() -> ActiveSeq {
+    let (mut a, _rx) = test_seq(Vec::new(), 5000, None, 10);
+    a.finished = false;
+    a.inside_thinking = true;
+    a.enable_thinking = true;
+    a.think_end_token = Some(THINK_END);
+    a.think_start_token = Some(THINK_START);
+    a.tool_call_start_token = Some(TOOL_CALL_OPEN);
+    a.grammar_state = Some(required_tool_grammar());
+    a
+}
+
+/// One logits row: zeros except the named ids.
+fn row(hot: &[(u32, f32)]) -> Vec<f32> {
+    let mut r = vec![0.0f32; VOCAB];
+    for &(id, v) in hot {
+        r[id as usize] = v;
+    }
+    r
+}
+
+/// Rows → the little-endian BF16 `[K, vocab]` buffer the verify path D2H-copies.
+fn bf16_rows(rows: &[Vec<f32>]) -> Vec<u8> {
+    rows.iter()
+        .flat_map(|r| {
+            r.iter().flat_map(|&v| {
+                let b = v.to_bits();
+                [(b >> 16) as u8, (b >> 24) as u8]
+            })
+        })
+        .collect()
+}
+
+fn with_ctx<R>(f: impl FnOnce(&LogitsContext) -> R) -> R {
+    let scratch = crate::scheduler::sched_ctx::DecodeScratch::default();
+    let dumps = crate::scheduler::dumps::RunDumps::default();
+    let ctx = LogitsContext {
+        scratch: &scratch,
+        dumps: &dumps,
+        stats: std::sync::Arc::new(crate::scheduler::spec_stats::SpecStats::new()),
+        watchdog: crate::scheduler::helpers::WatchdogParams::default(),
+        boundary_mask: None,
+        mid_word_mask: None,
+        sampling: SamplingLevers::default(),
+        timing: std::sync::Arc::default(),
+        think_end_token: Some(THINK_END),
+        think_start_token: Some(THINK_START),
+        tool_call_start_token: Some(TOOL_CALL_OPEN),
+        tool_call_end_token: Some(TOOL_CALL_CLOSE),
+    };
+    f(&ctx)
+}
+
+#[test]
+fn verify_row_crossing_think_end_masks_the_first_post_think_position() {
+    let mut a = thinking_seq();
+    // Row 0: the model closes the span. Row 1: its free pick is prose, with
+    // `<tool_call>` a distant second — the unmasked draft X the old loop let
+    // through.
+    let buf = bf16_rows(&[
+        row(&[(THINK_END, 10.0)]),
+        row(&[(HELLO, 10.0), (TOOL_CALL_OPEN, 5.0)]),
+    ]);
+    let picks = with_ctx(|ctx| pick_positions_from_host(&buf, VOCAB, 2, 2, &mut a, ctx));
+    assert_eq!(picks[0], THINK_END, "position 0 closes the reasoning span");
+    assert_eq!(
+        picks[1], TOOL_CALL_OPEN,
+        "the first post-think position must be picked under the pristine grammar, not free-run"
+    );
+    // The loop only PICKS; `emit_token` owns the real transition and advance.
+    assert!(
+        a.inside_thinking && !a.think_ended,
+        "sequence state restored after the loop"
+    );
+    let gs = a
+        .grammar_state
+        .as_mut()
+        .expect("grammar untouched by the loop");
+    assert_eq!(
+        gs.num_history_steps(),
+        0,
+        "</think> never fed; speculative advances rolled back"
+    );
+}
+
+#[test]
+fn verify_row_that_stays_inside_thinking_is_not_masked() {
+    // Control: no `</think>` in the row → every position stays free-run and
+    // the grammar stays paused (no over-constraint of reasoning tokens).
+    let mut a = thinking_seq();
+    let buf = bf16_rows(&[
+        row(&[(HELLO, 10.0)]),
+        row(&[(HELLO, 10.0), (TOOL_CALL_OPEN, 5.0)]),
+    ]);
+    let picks = with_ctx(|ctx| pick_positions_from_host(&buf, VOCAB, 2, 2, &mut a, ctx));
+    assert_eq!(picks, vec![HELLO, HELLO]);
+    assert!(a.inside_thinking);
+    assert_eq!(a.grammar_state.as_ref().unwrap().num_history_steps(), 0);
+}

--- a/crates/spark-server/src/tool_parser/tests.rs
+++ b/crates/spark-server/src/tool_parser/tests.rs
@@ -13,6 +13,7 @@ mod group_f;
 mod group_g_parallel;
 mod group_h_salvage;
 mod group_i_poolside_safety;
+mod group_j_glm5_next;
 mod streaming_frag;
 mod streaming_frag_env;
 mod streaming_leak;

--- a/crates/spark-server/src/tool_parser/tests/group_j_glm5_next.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_j_glm5_next.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//!
+//! GLM-5.3-Flash (`model_type = "glm5_next"`) tool calling.
+//!
+//! The contract under test is quoted verbatim from the checkpoint's own
+//! `chat_template.jinja`, which tells the model exactly what to emit:
+//!
+//! ```text
+//! For each function call, output the function name and arguments within the
+//! following XML format:
+//! <tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>
+//! ```
+//!
+//! That is byte-for-byte the `poolside_v1` envelope, so GLM is mapped onto that
+//! parser in `tool_defaults.toml` rather than getting a duplicate
+//! implementation. These tests pin the mapping AND the wire contract, so if a
+//! future GLM revision diverges the mapping fails here instead of at serve time.
+//!
+//! 🔴 The bug these guard: with no `[model_type]` entry,
+//! `resolve_tool_call_parser` returns `None`, which makes `tools_active` false
+//! in `api/chat/prepare.rs` — Atlas then silently DROPS the caller's `tools`
+//! before rendering the chat template. The model is never told the tools exist
+//! and replies "I don't actually have any tools available in this
+//! conversation." No parse error, no warning, a 200, and a plausible answer.
+
+use super::super::*;
+
+/// The literal format line from GLM-5.3-Flash's `chat_template.jinja`, with the
+/// placeholders filled in. If this stops parsing, GLM tool calling is broken.
+const GLM_TWO_ARG: &str = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value><arg_key>unit</arg_key><arg_value>celsius</arg_value></tool_call>";
+
+fn weather_tool() -> ToolDefinition {
+    ToolDefinition {
+        tool_type: "function".to_string(),
+        function: FunctionDefinition {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "unit": {"type": "string"},
+                    "days": {"type": "integer"},
+                    "verbose": {"type": "boolean"}
+                },
+                "required": ["location"]
+            })),
+        },
+    }
+}
+
+fn args_of(call: &ToolCall) -> serde_json::Value {
+    serde_json::from_str(&call.function.arguments).expect("arguments are valid JSON")
+}
+
+/// The mapping itself. This is the entire fix — without the entry, every
+/// assertion below is unreachable in production because `tools` never ship.
+#[test]
+fn glm5_next_is_registered_to_the_poolside_v1_wire_format() {
+    let defaults: toml::Value =
+        toml::from_str(include_str!("../../../tool_defaults.toml")).expect("tool_defaults parses");
+    let fmt_str = defaults
+        .get("model_type")
+        .and_then(|t| t.get("glm5_next"))
+        .and_then(|s| s.as_str())
+        .expect("tool_defaults [model_type] must register glm5_next");
+    assert_eq!(
+        fmt_str, "poolside_v1",
+        "GLM-5.3 emits the poolside_v1 envelope; see chat_template.jinja"
+    );
+    let fmt: ToolCallFormat = fmt_str.parse().expect("glm5_next tool format parses");
+    assert_eq!(fmt.into_parser().name(), "poolside_v1");
+}
+
+/// The exact string from the template's format line round-trips to structure.
+#[test]
+fn glm_template_format_line_parses_to_a_structured_call() {
+    let (content, calls) = parse_tool_calls_promoting_bare_names(GLM_TWO_ARG);
+    assert_eq!(calls.len(), 1, "one call from the template's own example");
+    assert_eq!(calls[0].function.name, "get_weather");
+    assert_eq!(
+        args_of(&calls[0]),
+        serde_json::json!({"location": "Paris", "unit": "celsius"}),
+        "both arg_key/arg_value pairs, in order, as strings"
+    );
+    assert!(
+        content.as_deref().unwrap_or("").trim().is_empty(),
+        "the envelope is entirely consumed, leaving no stray content"
+    );
+}
+
+/// Prose before the call is normal GLM output and must survive as content
+/// while the call is still extracted.
+#[test]
+fn leading_prose_is_preserved_as_content() {
+    let text = format!("Let me check that for you.{GLM_TWO_ARG}");
+    let (content, calls) = parse_tool_calls_promoting_bare_names(&text);
+    assert_eq!(calls.len(), 1);
+    assert_eq!(content.as_deref().unwrap().trim(), "Let me check that for you.");
+}
+
+/// GLM emits reasoning in `<think>` tags; a call deliberated inside thinking is
+/// NOT an invocation, and only the post-`</think>` call counts.
+#[test]
+fn calls_inside_thinking_are_not_invocations() {
+    let text = format!(
+        "<think>I could call <tool_call>get_weather<arg_key>location</arg_key><arg_value>Berlin</arg_value></tool_call> but Paris was asked.</think>{GLM_TWO_ARG}"
+    );
+    let (_, calls) = parse_tool_calls_promoting_bare_names(&text);
+    assert_eq!(calls.len(), 1, "only the call after </think> is real");
+    assert_eq!(args_of(&calls[0])["location"], "Paris");
+}
+
+/// A zero-argument call is a bare name inside the envelope — what the template
+/// produces when `tc.arguments` is empty. This is why GLM must use the
+/// bare-name-promoting entry point, exactly as poolside does.
+#[test]
+fn zero_argument_call_is_a_bare_name_in_the_envelope() {
+    let (_, calls) = parse_tool_calls_promoting_bare_names("<tool_call>get_status</tool_call>");
+    assert_eq!(calls.len(), 1, "zero-arg call must not be dropped");
+    assert_eq!(calls[0].function.name, "get_status");
+    assert_eq!(args_of(&calls[0]), serde_json::json!({}));
+}
+
+/// Two calls in one assistant turn — the template's `{% for tc in m.tool_calls %}`
+/// loop concatenates envelopes with no separator.
+#[test]
+fn two_calls_in_one_turn_are_both_extracted() {
+    let text = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>Lyon</arg_value></tool_call>";
+    let (_, calls) = parse_tool_calls_promoting_bare_names(text);
+    assert_eq!(calls.len(), 2);
+    assert_eq!(args_of(&calls[0])["location"], "Paris");
+    assert_eq!(args_of(&calls[1])["location"], "Lyon");
+}
+
+/// `arg_value` is untyped on the wire: every value arrives as text. The schema
+/// is what says `days` is an integer and `verbose` a boolean, so the typed
+/// coercion must fire or the tool receives `"3"` where it demands `3`.
+#[test]
+fn untyped_wire_values_are_coerced_to_the_schema() {
+    let text = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value><arg_key>days</arg_key><arg_value>3</arg_value><arg_key>verbose</arg_key><arg_value>true</arg_value></tool_call>";
+    let (_, mut calls) = parse_tool_calls_promoting_bare_names(text);
+    assert_eq!(calls.len(), 1);
+    assert!(
+        PoolsideV1Parser.wants_typed_arguments(),
+        "GLM's wire format carries no types; coercion is mandatory"
+    );
+    coerce_all(&mut calls, &[weather_tool()]);
+    let args = args_of(&calls[0]);
+    assert_eq!(args["location"], serde_json::json!("Paris"), "stays a string");
+    assert_eq!(args["days"], serde_json::json!(3), "integer, not \"3\"");
+    assert_eq!(args["verbose"], serde_json::json!(true), "bool, not \"true\"");
+}
+
+/// Replay parity: what Atlas writes back into assistant history must be what
+/// the template itself would have written, or the second turn of every
+/// multi-turn tool scenario diverges from training. The template's rule
+/// (line 129 of chat_template.jinja) is: a string value is emitted raw, any
+/// other value goes through `tojson`.
+#[test]
+fn formatted_history_matches_the_templates_own_rendering_rule() {
+    let calls = vec![IncomingToolCall {
+        id: Some("call_1".to_string()),
+        function: IncomingFunction {
+            name: "get_weather".to_string(),
+            arguments: r#"{"location":"Paris","days":3}"#.to_string(),
+        },
+    }];
+    let rendered = PoolsideV1Parser.format_tool_calls(&calls);
+    assert_eq!(
+        rendered,
+        "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value><arg_key>days</arg_key><arg_value>3</arg_value></tool_call>",
+        "string raw, non-string via tojson — matches chat_template.jinja"
+    );
+    // And it survives a round trip back to the same structure.
+    let (_, reparsed) = parse_tool_calls_promoting_bare_names(&rendered);
+    assert_eq!(reparsed.len(), 1);
+    assert_eq!(reparsed[0].function.name, "get_weather");
+    assert_eq!(args_of(&reparsed[0])["location"], "Paris");
+}

--- a/crates/spark-server/src/tool_parser/tests/group_j_glm5_next.rs
+++ b/crates/spark-server/src/tool_parser/tests/group_j_glm5_next.rs
@@ -96,7 +96,10 @@ fn leading_prose_is_preserved_as_content() {
     let text = format!("Let me check that for you.{GLM_TWO_ARG}");
     let (content, calls) = parse_tool_calls_promoting_bare_names(&text);
     assert_eq!(calls.len(), 1);
-    assert_eq!(content.as_deref().unwrap().trim(), "Let me check that for you.");
+    assert_eq!(
+        content.as_deref().unwrap().trim(),
+        "Let me check that for you."
+    );
 }
 
 /// GLM emits reasoning in `<think>` tags; a call deliberated inside thinking is
@@ -147,9 +150,17 @@ fn untyped_wire_values_are_coerced_to_the_schema() {
     );
     coerce_all(&mut calls, &[weather_tool()]);
     let args = args_of(&calls[0]);
-    assert_eq!(args["location"], serde_json::json!("Paris"), "stays a string");
+    assert_eq!(
+        args["location"],
+        serde_json::json!("Paris"),
+        "stays a string"
+    );
     assert_eq!(args["days"], serde_json::json!(3), "integer, not \"3\"");
-    assert_eq!(args["verbose"], serde_json::json!(true), "bool, not \"true\"");
+    assert_eq!(
+        args["verbose"],
+        serde_json::json!(true),
+        "bool, not \"true\""
+    );
 }
 
 /// Replay parity: what Atlas writes back into assistant history must be what

--- a/crates/spark-server/tool_defaults.toml
+++ b/crates/spark-server/tool_defaults.toml
@@ -26,6 +26,15 @@ mistral     = "mistral"       # Mistral Small 4 — native [TOOL_CALLS]name[ARGS
 gemma4      = "gemma4"        # Gemma-4 — native format: <|tool_call>call:name{...}<tool_call|>
 minimax_m2  = "minimax_xml"    # MiniMax M2 — <minimax:tool_call><invoke name=""><parameter name="">...
 laguna      = "poolside_v1"     # Poolside — <tool_call>name<arg_key>k</arg_key><arg_value>v</arg_value>
+glm5_next   = "poolside_v1"     # GLM-5.3-Flash — SAME wire format, quoted verbatim from the
+                                # checkpoint's own chat_template.jinja:
+                                #   <tool_call>{function-name}<arg_key>{arg-key-1}</arg_key>
+                                #   <arg_value>{arg-value-1}</arg_value>...</tool_call>
+                                # Without this entry `resolve_tool_call_parser` logs "disabled
+                                # (no mapping for model_type 'glm5_next')", `tools_active` is
+                                # false in api/chat/prepare.rs, and the caller's `tools` are
+                                # DROPPED before the template renders — the model is told
+                                # nothing and answers "I have no tools available".
 deepseek_v4 = "deepseek_v4"    # DeepSeek-V4-Flash — checkpoint-native typed DSML
 
 # Default reasoning parser per model_type.


### PR DESCRIPTION
# scheduler (7/8, G1): tool-call parser registration for glm5_next; grammar constrains token 0 only outside <think>; MTP verify rows crossing </think>

_Review unit **G1** (7/8) of the GLM-5.3-Flash upstream re-cut. Stack: `b2a01747` → M1 → M2 → M3 → G2 → G3 → G4 → G1 → O1 = `be6862ab` tree. Class: tool/reasoning. Taxonomy: `correctness/tool-calling`._

| | |
|---|---|
| base | `e86f7879` (land/glm53-6-G4) |
| head | `b99804b7` (`land/glm53-7-G1`) |
| commits | 4 |
| files | 19 (19 files changed, 869 insertions(+), 120 deletions(-)) |
| allow-list entries added | 0 |

## Summary

Atlas was silently dropping `tools` for GLM-5.3 because no parser was mapped for `glm5_next` — registered, with the group-J parser tests. Then the generic token-0 boundary: a grammar constrains token 0 only when the sequence is born outside `<think>` (`first_token_policy.rs`), and an MTP verify row that crosses `</think>` picks its first content position under the pristine grammar (`pick_positions.rs`).

## Dependency

Files are exclusive to this unit; semantically generic. Placed after G3 because the scheduler `error: None` initialisers (G3) precede 3280112f's edits to the same files historically.

## Commits (stack order; origin = candidate commit it was cherry-picked from)

| stack | origin | subject |
|---|---|---|
| `352f4f26` | `71d5404b` | fix(glm5_next): register the tool-call parser — Atlas was dropping `tools` entirely |
| `fba62cbb` | `3280112f` | fix(scheduler): a grammar constrains token 0 only when the sequence is born outside <think> |
| `f5a5f444` | `41a24eb9` | fix(mtp): a verify row that crosses </think> picks its first content position under the pristine grammar |
| `b99804b7` | `recut` | recut(G1): upstream re-cut adaptations for the G1 files |

## Test plan

CPU (this head, CI-equivalent, run 2026-09-07):

- [x] cap: PASS
- [x] fmt: PASS
- [x] spdx: PASS
- [x] clippy: PASS (warnings=33) 10:44:20 — run on the pre-rebase head `slice/glm53-7-G1` (identical unit diff, patch-id equal; the rebase onto `b2a01747` was conflict-free and the 4 upstream commits touch none of this stack's files); re-run on the final landing head
- [x] `cargo test --workspace --locked`: PASS passed=5930 failed=0 ignored=84 suites=85 10:58:17 — run on the pre-rebase head `slice/glm53-7-G1` (identical unit diff, patch-id equal; the rebase onto `b2a01747` was conflict-free and the 4 upstream commits touch none of this stack's files); re-run on the final landing head

Required for this unit:

- `cargo test --workspace` (`first_token_policy_tests`, `pick_positions_tests`, `tool_parser/tests/group_j_glm5_next`)
- Runtime: 7/7 tool-and-grammar arms and tool-eval 100/100 on the candidate

**Validation label:** the runtime evidence cited is on the GPU-qualified candidate / the frozen integration tree `d5b44da1` (whose 248-file diff this landing stack carries unchanged onto `b2a01747`), not on this intermediate head. This head is **review-only** (`/stamp`-held; the certification lane runs once, on the integration PR whose tree equals `be6862ab` = the certification candidate `01e174ce` = merge(d5b44da1-content, origin/main `b2a01747`)).

## Certification evidence (on the integration PR, not this head)

- Certified candidate `01e174ce` (tree `be6862ab`) — 11/11 required gates PASS on GB10, 13 invocations, one signer `ed6bcdc50223ea40`.
- Records + signatures + signer key: commit `71ad0ba3` on branch `cert/glm53-records-20260907` (parent = `01e174ce`; adds 23 files, changes no source).
- This unit's tree is contained in that certified tree: `git merge-tree --write-tree b99804b7 origin/main` reproduces the same content (proof: `landing-proof.json`).
- Landing: this PR is **not merged on its own**. It is closed once the integration PR #965 squash-lands, with the containment proof, following the `#934` precedent.

## Notes for reviewers

- `tool_defaults.toml` gains the `glm5_next` mapping; without it the request's `tools` field is dropped before the model sees it.

## Files

<details><summary>19 files</summary>

- `crates/spark-server/src/grammar/mod.rs`
- `crates/spark-server/src/grammar/tests/mod.rs`
- `crates/spark-server/src/scheduler/first_token_policy.rs`
- `crates/spark-server/src/scheduler/first_token_policy_tests.rs`
- `crates/spark-server/src/scheduler/mod.rs`
- `crates/spark-server/src/scheduler/phase_continue_prefills.rs`
- `crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_mixed.rs`
- `crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs`
- `crates/spark-server/src/scheduler/phase_continue_prefills/run_standard.rs`
- `crates/spark-server/src/scheduler/phase_promote_prefills.rs`
- `crates/spark-server/src/scheduler/prefill_a_step.rs`
- `crates/spark-server/src/scheduler/prefill_b_step.rs`
- `crates/spark-server/src/scheduler/sample_step.rs`
- `crates/spark-server/src/scheduler/verify_pipeline_helper.rs`
- `crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions.rs`
- `crates/spark-server/src/scheduler/verify_pipeline_helper/pick_positions_tests.rs`
- `crates/spark-server/src/tool_parser/tests.rs`
- `crates/spark-server/src/tool_parser/tests/group_j_glm5_next.rs`
- `crates/spark-server/tool_defaults.toml`

</details>

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
