### PR TITLE
Serve atlasinference.io and the blog from Cloudflare Pages, mirror to avarok

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -322,8 +322,15 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # Two publish targets, deliberately two jobs.
+  #
+  # Cloudflare Pages is what the DNS points at, so it is the one that gates
+  # `verify`. avarok is kept byte-current as a warm standby but must never be
+  # able to stop a publish: the origin went down entirely once, and with both
+  # legs in one job that outage would also have blocked the edge deploy that
+  # exists precisely to survive it. Hence a separate job, `continue-on-error`.
   deploy:
-    name: Deploy to avarok via rsync
+    name: Deploy to Cloudflare Pages
     # `unit` as well as `build`: a red site test has to stop the deploy, not
     # just report next to it (#810). Both jobs are unconditional, so this adds
     # no path on which deploy is skipped for want of a dependency.
@@ -340,17 +347,106 @@ jobs:
       configured: ${{ steps.secret_check.outputs.configured }}
     steps:
       - name: Check deploy secret presence
-        # Skip deploy entirely when DEPLOY_SSH_PRIVATE_KEY isn't
-        # configured on the `production-site` environment. The job
-        # still exits success — the marketing-site artifact uploaded
-        # by the build job remains downloadable for inspection.
+        # Skip the publish entirely when the Cloudflare credentials are not
+        # configured on the `production-site` environment. The job still exits
+        # success — the artifacts uploaded by the build job remain downloadable
+        # for inspection.
+        id: secret_check
+        env:
+          CF_API_TOKEN:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set on the production-site environment — skipping the Pages deploy. Configure both to enable."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download site artifact
+        if: steps.secret_check.outputs.configured == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: marketing-site
+          path: site
+
+      - name: Download blog artifact
+        if: steps.secret_check.outputs.configured == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: blog-site
+          path: blog
+
+      # Explicit, because nothing else in this repo needs Node — every other job
+      # runs on bun — so this job would otherwise inherit whatever the runner
+      # image ships. wrangler v4 refuses to start below Node 22 ("Wrangler
+      # requires at least Node.js v22.0.0"), which makes the runner's default an
+      # undeclared dependency of the deploy: the day the image moves, the
+      # publish breaks and nothing in the repo changed. 24 is the current LTS.
+      #
+      # A major, not `lts/*`: a floating version is the same class of dependency
+      # that turns an unrelated upstream release into a red deploy.
+      - name: Install Node
+        if: steps.secret_check.outputs.configured == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      # Direct Upload, not Pages' own git integration. The build above needs an
+      # atlas-recipes checkout and a GH token, and carries four gates a
+      # Pages-native build would bypass — the flagship recipe check, both
+      # per-route title checks, and the blog/site cross-link check. Uploading
+      # the already-gated output keeps every one of them.
+      #
+      # `--branch` must match the project's production branch: a deployment on
+      # any other branch gets a preview URL and does NOT move the custom domain,
+      # which fails silently as "the deploy went green and the site is stale".
+      #
+      # wrangler is pinned to a major. Unlike the actions above it is not
+      # content-addressable through npm, and a floating `wrangler@latest` is the
+      # kind of dependency that turns an unrelated upstream release into a red
+      # deploy — the lesson already recorded for the UI Docker build.
+      - name: Publish atlasinference.io
+        if: steps.secret_check.outputs.configured == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4 pages deploy site \
+            --project-name=atlas-site \
+            --branch=main \
+            --commit-dirty=true
+
+      - name: Publish blog.atlasinference.io
+        if: steps.secret_check.outputs.configured == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4 pages deploy blog \
+            --project-name=atlas-blog \
+            --branch=main \
+            --commit-dirty=true
+
+  deploy-origin:
+    name: Mirror to avarok via rsync (standby)
+    needs: [build, unit]
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    # The origin no longer serves atlasinference.io — DNS points at Pages — so a
+    # failure here means the standby is stale, not that the site is down. That
+    # is worth a visible warning and not worth failing the run: when the box was
+    # unreachable, a blocking rsync would have taken the edge deploy with it.
+    continue-on-error: true
+    steps:
+      - name: Check deploy secret presence
         id: secret_check
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
         run: |
           if [ -z "$DEPLOY_KEY" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::DEPLOY_SSH_PRIVATE_KEY not set on production-site environment — skipping rsync deploy. Configure the environment secrets to enable."
+            echo "::warning::DEPLOY_SSH_PRIVATE_KEY not set on production-site environment — skipping rsync mirror."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
@@ -390,7 +486,7 @@ jobs:
           printf '%s\n' "$KNOWN_HOSTS" >> ~/.ssh/known_hosts
           chmod 644 ~/.ssh/known_hosts
 
-      - name: Deploy
+      - name: Mirror
         if: steps.secret_check.outputs.configured == 'true'
         env:
           DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
@@ -405,23 +501,11 @@ jobs:
           # a 404 on a lazily-imported chunk, mid-session, for the duration of a
           # deploy. Deferring the deletions to the end means the old bundle stays
           # whole until the new one is entirely in place.
-          #
-          # It does not make the deploy atomic, and the ordering does not help:
-          # `--itemize-changes` shows rsync sending `index.html` BEFORE the
-          # `_app/` chunks it references, so a visitor can still fetch a document
-          # naming a chunk that has not landed. What the service worker's
-          # network-first documents plus its previous cache cover, they cover;
-          # this flag closes the half that is ours to close — never deleting the
-          # old bundle out from under a session before the new one exists.
           rsync -az --delete-delay --chmod=D755,F644 \
-            -e "ssh -p ${PORT}" \
+            -e "ssh -p ${PORT} -o ConnectTimeout=20" \
             site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"
 
-      # blog.atlasinference.io, in the same job and over the same connection.
-      # rsync is already a diff: when the built blog is byte-identical to what
-      # is deployed it transfers nothing and deletes nothing, so a push that
-      # only touched site/ costs one no-op sync rather than a redeploy.
-      - name: Deploy blog
+      - name: Mirror blog
         if: steps.secret_check.outputs.configured == 'true'
         env:
           DEPLOY_SSH_HOST:  ${{ secrets.DEPLOY_SSH_HOST }}
@@ -429,21 +513,17 @@ jobs:
           DEPLOY_SSH_PORT:  ${{ secrets.DEPLOY_SSH_PORT }}
           DEPLOY_BLOG_PATH: ${{ secrets.DEPLOY_BLOG_PATH }}
         run: |
-          # Deliberately a hard failure rather than the soft skip the whole
-          # deploy job takes when DEPLOY_SSH_PRIVATE_KEY is absent. That skip is
-          # for an environment with no deploy configured at all; this is an
-          # environment that DOES deploy, where one target has been forgotten.
-          # Skipping quietly there means the blog silently stops updating while
-          # every run stays green.
+          # Still a hard failure rather than a quiet skip: this is an environment
+          # that DOES mirror, with one target forgotten. The job's
+          # continue-on-error keeps that from blocking the publish while leaving
+          # it visible in the run.
           if [ -z "${DEPLOY_BLOG_PATH}" ]; then
             echo "::error::DEPLOY_BLOG_PATH is not set on the production-site environment."
-            echo "The marketing site deployed; the blog did not. Set it to the blog docroot"
-            echo "on the origin (/var/www/blog.atlasinference.io/html) and re-run."
             exit 1
           fi
           PORT="${DEPLOY_SSH_PORT:-22}"
           rsync -az --delete-delay --chmod=D755,F644 \
-            -e "ssh -p ${PORT}" \
+            -e "ssh -p ${PORT} -o ConnectTimeout=20" \
             blog/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_BLOG_PATH}/"
 
 

--- a/blog/e2e/check-headers.mjs
+++ b/blog/e2e/check-headers.mjs
@@ -42,6 +42,20 @@ async function get(path) {
   return { res, h: (n) => res.headers.get(n) ?? '' };
 }
 
+/**
+ * Cloudflare Pages CONCATENATES a header re-declared by a later `_headers`
+ * rule rather than replacing it, so a misconfigured file yields
+ * "public, max-age=300, public, max-age=31536000, immutable". Browsers read the
+ * first max-age, so the assets meant to be held for a year are held for five
+ * minutes — and every substring assertion in this file passes anyway, because
+ * both values are present. That is exactly how it shipped once. Assert the
+ * directive appears once.
+ */
+function expectOneMaxAge(label, value) {
+  const n = (value.match(/max-age=/g) ?? []).length;
+  check(`${label}: one max-age, not a concatenation`, n === 1, `${n} in "${value}"`);
+}
+
 function expectSecurityHeaders(label, h) {
   for (const [name, value] of Object.entries(SECURITY)) {
     check(`${label}: ${name}`, h(name).toLowerCase() === value.toLowerCase(), h(name) || 'absent');
@@ -57,6 +71,7 @@ console.log(`checking ${base}`);
   check('document: 200', res.status === 200, `status ${res.status}`);
   check('document: cache-control is short', /max-age=300/.test(h('cache-control')), h('cache-control') || 'absent');
   check('document: not cached forever', !/immutable/.test(h('cache-control')), h('cache-control'));
+  expectOneMaxAge('document', h('cache-control'));
   expectSecurityHeaders('document', h);
 }
 
@@ -72,6 +87,7 @@ console.log(`checking ${base}`);
     check(`asset ${m[0]}: 200`, res.status === 200, `status ${res.status}`);
     check('asset: immutable', /immutable/.test(h('cache-control')), h('cache-control') || 'absent');
     check('asset: year-long max-age', /max-age=31536000/.test(h('cache-control')), h('cache-control'));
+    expectOneMaxAge('asset', h('cache-control'));
     expectSecurityHeaders('asset', h);
   }
 }
@@ -100,6 +116,26 @@ for (const [path, type] of [['/rss.xml', 'application/rss+xml'], ['/sitemap.xml'
 {
   const { res } = await get('/.env');
   check('dotfile: refused', res.status === 404 || res.status === 403, `status ${res.status}`);
+}
+
+/* 6. Every document the sitemap advertises. On nginx the cache policy had a
+      `default` arm, so a new route inherited it; a Pages `_headers` file has no
+      else-branch, and a route added without a rule silently falls back to the
+      host default. This walks what the build itself says it published, so the
+      list cannot drift out of step with the routes. */
+{
+  const xml = await (await fetch(base + '/sitemap.xml')).text();
+  const paths = [...new Set(
+    [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1]).pathname)
+  )];
+  check('sitemap: lists documents to check', paths.length > 0, `${paths.length} URLs`);
+  for (const path of paths) {
+    const { res, h } = await get(path);
+    const cc = h('cache-control');
+    check(`sitemap ${path}: 200`, res.status === 200, `status ${res.status}`);
+    check(`sitemap ${path}: declares a short cache`, /max-age=300/.test(cc), cc || 'absent');
+    expectOneMaxAge(`sitemap ${path}`, cc);
+  }
 }
 
 console.log(log.join('\n'));

--- a/blog/static/_headers
+++ b/blog/static/_headers
@@ -1,0 +1,59 @@
+# Cloudflare Pages equivalent of the nginx vhost alongside this file.
+#
+# WHY Cache-Control IS NOT ON `/*`, WHICH LOOKS LIKE THE OBVIOUS PLACE FOR IT:
+# Pages CONCATENATES a header that a later rule re-declares, it does not replace
+# it. With `Cache-Control: public, max-age=300` on `/*`, a hashed asset came back
+# as "public, max-age=300, public, max-age=31536000, immutable" — and a browser
+# reads the first max-age, so the year-long assets were being held for five
+# minutes. Measured on the deployed site; the header gate could not see it,
+# because it tests with a substring match. `! Cache-Control` is not the fix
+# either: in the same block it suppresses the value being set, and the asset
+# falls back to `no-store`. So each cache class names its own paths, and
+# blog/e2e/check-headers.mjs walks the sitemap to catch a route that grew a
+# document without growing a rule.
+#
+# Security headers DO belong on `/*`: they are declared once and never
+# overridden, so nothing concatenates. This is the inverse of the nginx defect
+# these guard — there, one location-level Cache-Control silently discarded every
+# add_header above it.
+
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# Documents, and the feed/sitemap/llms files served alongside them.
+/
+  Cache-Control: public, max-age=300
+/index.html
+  Cache-Control: public, max-age=300
+/404.html
+  Cache-Control: public, max-age=300
+/posts/*
+  Cache-Control: public, max-age=300
+/tags/*
+  Cache-Control: public, max-age=300
+/authors/*
+  Cache-Control: public, max-age=300
+/robots.txt
+  Cache-Control: public, max-age=300
+
+# Content types the vhost set with `location =` blocks. Pages would otherwise
+# serve rss.xml as application/xml.
+/rss.xml
+  Cache-Control: public, max-age=300
+  Content-Type: application/rss+xml
+/sitemap.xml
+  Cache-Control: public, max-age=300
+  Content-Type: application/xml
+/llms.txt
+  Cache-Control: public, max-age=300
+  Content-Type: text/plain; charset=utf-8
+
+# Content-hashed by the build: the URL changes when the bytes do.
+/_app/immutable/*
+  Cache-Control: public, max-age=31536000, immutable
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+/images/*
+  Cache-Control: public, max-age=2592000

--- a/site/deploy/cloudflare/README.md
+++ b/site/deploy/cloudflare/README.md
@@ -8,7 +8,7 @@ host went down and took both properties with it.
 
 | Project | Serves | pages.dev |
 | --- | --- | --- |
-| `atlas-site` | `atlasinference.io`, `www.atlasinference.io` | `atlas-site-80h.pages.dev` |
+| `atlas-site` | `atlasinference.io` | `atlas-site-80h.pages.dev` |
 | `atlas-blog` | `blog.atlasinference.io` | `atlas-blog-3ja.pages.dev` |
 
 Both are **Direct Upload** projects, not Pages' git integration. The build in
@@ -35,22 +35,35 @@ to as a warm standby. On Pages the same behaviour comes from:
   with index.html and a **200**, so broken links return the front page and
   crawlers index unbounded soft-404s.
 
-## www -> apex is NOT in this repo, and cannot be
+## www -> apex, and why `www` is deliberately NOT a custom domain
 
-The nginx `if ($host = www...)` block has no Pages equivalent. `_redirects`
-supports path rules (verified: a path-only rule redirects correctly) but the
-documented absolute-URL form does **not** match on these projects (verified:
-`https://www.atlasinference.io/* ...` never fires). A path rule cannot be used
-because both hostnames are the same project, so it would bounce the apex too.
+The nginx `if ($host = www...)` block has no in-repo Pages equivalent.
+`_redirects` path rules work (verified: a path-only rule redirects correctly)
+but the documented absolute-URL form does **not** match on these projects
+(verified: `https://www.atlasinference.io/* ...` never fired). A path rule is
+useless here anyway, since it would bounce the apex too.
 
-It lives as a zone-level Redirect Rule on `atlasinference.io`:
+So it is a zone-level Redirect Rule on `atlasinference.io`:
 
     expression: (http.host eq "www.atlasinference.io")
     action:     redirect, 301
     target:     concat("https://atlasinference.io", http.request.uri.path)
     preserve query string: yes
 
-Creating it over the API needs a token with **Zone -> Dynamic Redirect -> Edit**
-(neither of the tokens used for the migration had it; both could only list
-rulesets). Until it exists, `www` serves the site directly on a 200 rather than
-redirecting — functional, but duplicate content for crawlers.
+**`www.atlasinference.io` must stay OFF the Pages project for that rule to
+run.** It was attached at first, and the rule — stored, enabled, correct
+expression — did nothing: every request still returned 200 with the site.
+A Pages custom domain is served by the Pages edge and never reaches the zone's
+ruleset engine. The tell is in the response headers: the apex returns
+`cf-cache-status: DYNAMIC` and `www` returned no `cf-cache-status` at all.
+Detaching it made the redirect fire on the first request afterwards.
+
+The `www` DNS record stays a proxied CNAME to the apex. It needs no origin and
+no Pages binding, because a redirect rule is evaluated before Cloudflare
+resolves one — the request never looks for something to serve.
+
+Creating or editing the rule over the API needs a token with **Zone -> Dynamic
+Redirect -> Edit**, on top of the Pages, DNS and Cache Purge permissions the
+rest of this setup uses. A token holding only some of those fails with
+`request is not authorized` on the ruleset write while still listing rulesets
+happily, which reads like a bug and is not one.

--- a/site/deploy/cloudflare/README.md
+++ b/site/deploy/cloudflare/README.md
@@ -1,0 +1,56 @@
+# Cloudflare Pages hosting
+
+atlasinference.io and blog.atlasinference.io are served by Cloudflare Pages.
+There is no origin server in the request path, which is the point: the previous
+host went down and took both properties with it.
+
+## Projects
+
+| Project | Serves | pages.dev |
+| --- | --- | --- |
+| `atlas-site` | `atlasinference.io`, `www.atlasinference.io` | `atlas-site-80h.pages.dev` |
+| `atlas-blog` | `blog.atlasinference.io` | `atlas-blog-3ja.pages.dev` |
+
+Both are **Direct Upload** projects, not Pages' git integration. The build in
+`.github/workflows/site.yml` needs an `atlas-recipes` checkout and a GitHub
+token, and it carries four gates a Pages-native build would bypass — the
+flagship-recipe check, the per-route `<title>` checks on both properties, and
+the blog/site cross-link check. CI builds, CI uploads the gated output.
+
+`--branch=main` on the upload is load-bearing: a deployment on any other branch
+gets a preview URL and does not move the custom domain. That fails as "the
+deploy went green and the site is stale".
+
+## What replaced the nginx config
+
+`../nginx/atlasinference.io.conf` is kept because the origin is still mirrored
+to as a warm standby. On Pages the same behaviour comes from:
+
+- **`static/_headers`** — the security headers and the cache policy. Read the
+  note at the top of that file before editing it; Pages concatenates a
+  re-declared header rather than replacing it, which silently cost the hashed
+  assets their year-long cache once already.
+- **`src/routes/404/+page.svelte`** — prerenders to `build/404.html`. Pages has
+  no `try_files ... =404`; with no such file it answers every unmatched path
+  with index.html and a **200**, so broken links return the front page and
+  crawlers index unbounded soft-404s.
+
+## www -> apex is NOT in this repo, and cannot be
+
+The nginx `if ($host = www...)` block has no Pages equivalent. `_redirects`
+supports path rules (verified: a path-only rule redirects correctly) but the
+documented absolute-URL form does **not** match on these projects (verified:
+`https://www.atlasinference.io/* ...` never fires). A path rule cannot be used
+because both hostnames are the same project, so it would bounce the apex too.
+
+It lives as a zone-level Redirect Rule on `atlasinference.io`:
+
+    expression: (http.host eq "www.atlasinference.io")
+    action:     redirect, 301
+    target:     concat("https://atlasinference.io", http.request.uri.path)
+    preserve query string: yes
+
+Creating it over the API needs a token with **Zone -> Dynamic Redirect -> Edit**
+(neither of the tokens used for the migration had it; both could only list
+rulesets). Until it exists, `www` serves the site directly on a 200 rather than
+redirecting — functional, but duplicate content for crawlers.

--- a/site/src/lib/sw/strategy.js
+++ b/site/src/lib/sw/strategy.js
@@ -12,6 +12,24 @@
 /** Paths that must never be served or stored by the worker. */
 export const NEVER_CACHED = ['/install.sh', '/install.ps1', '/quickstart.sh'];
 
+/**
+ * Files the host reads as configuration and never serves back.
+ *
+ * `_headers` and `_redirects` live in `static/`, so SvelteKit lists them in
+ * `$service-worker`'s `files` and they would otherwise be precached. Cloudflare
+ * Pages consumes both at deploy time and answers 404 for them — measured, not
+ * assumed — and `cache.addAll()` rejects ATOMICALLY on a single non-2xx, so one
+ * 404 here costs the site its entire worker: no precache and no offline, on
+ * every visit, silently.
+ *
+ * Worth knowing how narrowly that was true: before this site shipped a
+ * `404.html`, Pages answered every unmatched path with index.html and a 200,
+ * and these two would have been cached as copies of the front page instead —
+ * wasteful rather than fatal. The 404 document is what makes the failure mode
+ * the dangerous one, so the two changes belong to the same commit.
+ */
+export const HOST_CONFIG_FILES = ['/_headers', '/_redirects'];
+
 /** Assets whose filenames carry a content hash, so their bytes never change. */
 const IMMUTABLE_PREFIX = '/_app/immutable/';
 
@@ -48,5 +66,6 @@ export function shouldPrecache(path) {
   // feature is used, not at install for everyone.
   if (path.includes('og-image')) return false;
   if (path.startsWith('/lattice/')) return false;
+  if (HOST_CONFIG_FILES.includes(path)) return false;
   return !NEVER_CACHED.includes(path);
 }

--- a/site/src/lib/sw/strategy.test.js
+++ b/site/src/lib/sw/strategy.test.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { describe, expect, it } from 'bun:test';
-import { NEVER_CACHED, shouldPrecache, strategyFor } from './strategy.js';
+import { HOST_CONFIG_FILES, NEVER_CACHED, shouldPrecache, strategyFor } from './strategy.js';
 
 describe('strategyFor', () => {
   // The rule with a consequence outside the browser: a cached installer is a
@@ -59,5 +59,27 @@ describe('shouldPrecache', () => {
     for (const p of ['/logo.svg', '/favicon.ico', '/site.webmanifest', '/llms.txt']) {
       expect(shouldPrecache(p)).toBe(true);
     }
+  });
+});
+
+// The host's own config files. These sit in `static/`, so SvelteKit hands them
+// to the worker in `files`, and Cloudflare Pages answers 404 for them because
+// it consumed them at deploy time. `cache.addAll()` rejects atomically, so a
+// single 404 in the precache list costs the site its entire service worker —
+// no offline, no precache, on every visit. The cost is total and the symptom is
+// silent, which is why this is asserted rather than left to review.
+describe('host configuration files', () => {
+  it('keeps _headers and _redirects out of the precache', () => {
+    for (const p of HOST_CONFIG_FILES) {
+      expect(shouldPrecache(p)).toBe(false);
+    }
+  });
+
+  // Discrimination control: an exclusion written as a substring or prefix would
+  // also drop real routes. `/_headers` must not shadow a page that merely
+  // starts with the same letters.
+  it('excludes them exactly, not by prefix', () => {
+    expect(shouldPrecache('/_headers-guide.html')).toBe(true);
+    expect(shouldPrecache('/docs/_redirects')).toBe(true);
   });
 });

--- a/site/src/routes/404/+page.svelte
+++ b/site/src/routes/404/+page.svelte
@@ -1,0 +1,69 @@
+<!--
+  The PRERENDERED 404 document. adapter-static writes this route to
+  `build/404.html`, and both hosts reach for that exact filename: nginx through
+  `error_page 404`, Cloudflare Pages by convention.
+
+  It is not cosmetic. Pages has no `try_files ... =404` — with no 404.html in
+  the output it answers EVERY unmatched path with index.html and a 200, so a
+  typo'd link returns the front page as though it were the page asked for, and
+  crawlers index an unbounded set of soft-404 URLs. Measured on the first
+  deployment: /definitely-not-a-real-path-zzz came back 200 with the homepage
+  title. The blog never had this problem because it already ships a /404 route;
+  this is the marketing site catching up to it.
+-->
+<script>
+  import { githubUrl } from '$lib/data.js';
+</script>
+
+<svelte:head>
+  <title>Not found — Atlas</title>
+  <meta name="robots" content="noindex" />
+  <!-- `noindex` keeps the page out of results; it does not excuse it from a
+       description. Lighthouse audits the tag's presence, not indexability, so
+       without this the 404 scores below 100 on SEO while every other page
+       passes — the same reasoning as the blog's 404. -->
+  <meta
+    name="description"
+    content="That page is not here. Atlas is a pure-Rust inference engine for DGX Spark and Strix Halo; the front page has the install command and the benchmarks."
+  />
+</svelte:head>
+
+<div class="nf">
+  <p class="code">404</p>
+  <h1>That page is not here.</h1>
+  <p class="lede">
+    It may have been renamed, or it may never have existed. The
+    <a href="/">front page</a> has the install command, the measured benchmarks and
+    the model ladder; <a href="/control">the control plane</a> is where a running
+    fleet shows up. The source is on <a href={githubUrl}>GitHub</a>.
+  </p>
+</div>
+
+<style>
+  .nf {
+    max-width: 44rem;
+    margin: 0 auto;
+    padding: clamp(96px, 18vh, 200px) 24px 160px;
+  }
+  .code {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.14em;
+    color: var(--t3);
+    margin: 0 0 12px;
+  }
+  h1 {
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    line-height: 1.15;
+    margin: 0 0 20px;
+    color: var(--t1);
+  }
+  .lede {
+    color: var(--t2);
+    line-height: 1.7;
+    margin: 0;
+  }
+  .lede a {
+    color: var(--accent);
+  }
+</style>

--- a/site/static/_headers
+++ b/site/static/_headers
@@ -1,0 +1,83 @@
+# Cloudflare Pages equivalent of the nginx vhost alongside this file.
+#
+# WHY Cache-Control IS NOT ON `/*`, WHICH LOOKS LIKE THE OBVIOUS PLACE FOR IT:
+# Pages CONCATENATES a header that a later rule re-declares, it does not replace
+# it. With `Cache-Control: public, max-age=300` on `/*`, a hashed asset came back
+# as "public, max-age=300, public, max-age=31536000, immutable" — and a browser
+# reads the first max-age, so the year-long assets were being held for five
+# minutes. Measured on the deployed site; the header gate could not see it,
+# because it tests with a substring match. `! Cache-Control` is not the fix
+# either: in the same block it suppresses the value being set, and the asset
+# falls back to `no-store`. So each cache class names its own paths, and
+# blog/e2e/check-headers.mjs walks the sitemap to catch a route that grew a
+# document without growing a rule.
+#
+# Security headers DO belong on `/*`: they are declared once and never
+# overridden, so nothing concatenates. This is the inverse of the nginx defect
+# these guard — there, one location-level Cache-Control silently discarded every
+# add_header above it.
+
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  X-XSS-Protection: 0
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# Documents. Both spellings of each route: Pages serves control.html at
+# /control, and a visitor or a link can ask for either.
+/
+  Cache-Control: public, max-age=300
+/index.html
+  Cache-Control: public, max-age=300
+/control
+  Cache-Control: public, max-age=300
+/control.html
+  Cache-Control: public, max-age=300
+/diligence
+  Cache-Control: public, max-age=300
+/diligence.html
+  Cache-Control: public, max-age=300
+/robots.txt
+  Cache-Control: public, max-age=300
+/site.webmanifest
+  Cache-Control: public, max-age=300
+/llms.txt
+  Cache-Control: public, max-age=300
+  Content-Type: text/plain; charset=utf-8
+/sitemap.xml
+  Cache-Control: public, max-age=300
+  Content-Type: application/xml
+
+/_app/immutable/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# The 763 KB LatticeDB wasm, sha256-pinned and re-vendored per build, so a
+# change arrives as different bytes at the same URL — a month, not a year.
+/lattice/*
+  Cache-Control: public, max-age=2592000
+
+/*.png
+  Cache-Control: public, max-age=2592000
+/*.webp
+  Cache-Control: public, max-age=2592000
+/*.svg
+  Cache-Control: public, max-age=2592000
+/*.ico
+  Cache-Control: public, max-age=2592000
+
+# Keyed to the build version, and the mechanism by which a deploy is noticed.
+# Cached at all, it pins visitors to the worker that shipped before it.
+/service-worker.js
+  Cache-Control: no-cache
+
+# Piped straight into a shell. Whoever runs this must get what the server holds
+# at that moment, never an edge copy — the same rule NEVER_CACHED enforces in
+# the service worker (site/src/lib/sw/strategy.js).
+/install.sh
+  Cache-Control: no-store
+  Content-Type: text/x-shellscript; charset=utf-8
+/install.ps1
+  Cache-Control: no-store
+/quickstart.sh
+  Cache-Control: no-store
+  Content-Type: text/x-shellscript; charset=utf-8


### PR DESCRIPTION
The origin went down and took both properties with it — 522 at the edge, every port closed. Both are static SvelteKit builds, so neither needed an origin.

**Both sites are already live on Pages** (projects `atlas-site` / `atlas-blog`, custom domains active, DNS repointed). This PR is the pipeline and the fixes the migration surfaced.

## Publishing

Two jobs, deliberately. `deploy` uploads to Pages and gates `verify`; `deploy-origin` rsyncs to avarok and is `continue-on-error` — with both legs in one job, the outage that motivated this would also have blocked the edge deploy that exists to survive it.

Direct Upload rather than Pages' git integration: the build needs an `atlas-recipes` checkout and a `GH_TOKEN`, and carries four gates a Pages-native build would bypass (flagship-recipe check, per-route title checks on both properties, cross-link check).

## Three things the move broke

All measured on the deployed site, not reasoned about.

| | Symptom | Fix |
|---|---|---|
| **Soft-404s** | No `try_files ... =404` on Pages. With no `404.html`, every unmatched path returned index.html with **200** — `/definitely-not-a-real-path-zzz` came back as the homepage. | `site/src/routes/404/+page.svelte`, mirroring the blog's existing `/404` route |
| **Assets cached 5 min, not a year** | Pages *concatenates* a re-declared header. `Cache-Control` on `/*` plus an asset rule gave `public, max-age=300, public, max-age=31536000, immutable`; browsers read the first `max-age`. **All 28 header checks passed**, because they match substrings. | each cache class names its own paths. `! Cache-Control` is not the fix — in the same block it suppresses the set and the asset falls back to `no-store` |
| **Service worker could not install** | `_headers`/`_redirects` live in `static/`, so SvelteKit precached them, and Pages 404s them. `cache.addAll()` rejects *atomically* — one 404 costs the site its whole worker, silently, every visit | excluded in `strategy.js`, with a test and a proven negative control |

## Gate changes

`check-headers.mjs` gains two guards for the failures it could not see:

- **one `max-age` per header** — run against the preserved first deployment, which still carries the concatenated value; it fails there and passes on current.
- **a sweep of every document the sitemap advertises** — nginx's cache map had a `default` arm a new route inherited; a `_headers` file has no else-branch, so a route added without a rule silently falls back to the host default.

58/58 checks pass against the deployed blog.

## Node

The deploy job pins **Node 24**. Nothing else in this repo needs Node — every other job is bun — so it would have inherited the runner image's default, and wrangler v4 refuses to start below Node 22. That would have failed on the first run.

## Not in this repo

`www` → apex has no Pages equivalent: `_redirects` path rules work (verified), the absolute-URL form does not match (verified), and a path rule would bounce the apex too since both hostnames are one project. Documented in `site/deploy/cloudflare/README.md` as a zone Redirect Rule.

## Requires

`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` on the `production-site` environment (or as org secrets). Without them the Pages job soft-skips with a warning, exactly as the rsync job does today.

https://claude.ai/code/session_01CsRChHTncdMd3d6e8BWsSz