### PR TITLE
Serve docs.atlasinference.io from Cloudflare Pages, mirror to avarok

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -153,6 +153,14 @@ jobs:
       # cannot: a canonical URL derived from the file path, and a description
       # taken from each chapter's own first paragraph. The script is its own
       # assertion and exits non-zero if any page ends up without a full card.
+      # The Pages control file. It is not part of the mdBook output, so it is
+      # copied in here the same way the brand assets above are. Read the note at
+      # the top of it before editing: Pages concatenates a re-declared header
+      # rather than replacing it, so every rule in there is scoped not to
+      # overlap another.
+      - name: Cloudflare Pages headers
+        run: cp book/deploy/cloudflare/_headers book/output/_headers
+
       - name: Inject per-page social meta
         run: node book/scripts-inject-meta.mjs book/output
 
@@ -204,14 +212,76 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # Cloudflare Pages is what docs.atlasinference.io resolves to, so this is the
+  # job that publishes. The rsync to avarok follows as its own job and cannot
+  # block it: the origin went down once and took the docs with it, and with both
+  # legs in one job that outage would also have stopped the edge deploy that
+  # exists to survive it.
+  #
+  # Direct Upload rather than Pages' git integration — the build above needs a
+  # Rust toolchain, mdBook and a full `cargo doc --workspace`, and it carries
+  # checks (llms.txt currency, the social-card assertion) that a Pages-native
+  # build would bypass.
   deploy:
-    name: Deploy to avarok via rsync
+    name: Deploy docs to Cloudflare Pages
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     environment:
       name: production-docs
       url: https://docs.atlasinference.io/
+    steps:
+      - name: Check deploy secret presence
+        id: cf_check
+        env:
+          CF_API_TOKEN:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — skipping the Pages deploy."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download site artifact
+        if: steps.cf_check.outputs.configured == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: docs-site
+          path: docs-site
+
+      # Explicit, because nothing else in this workflow needs Node, so the job
+      # would otherwise inherit whatever the runner image ships. wrangler v4
+      # refuses to start below Node 22.
+      - name: Install Node
+        if: steps.cf_check.outputs.configured == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      # `--branch=main` is load-bearing: a deployment on any other branch gets a
+      # preview URL and does NOT move the custom domain, which fails silently as
+      # "the deploy went green and the docs are stale".
+      - name: Publish docs.atlasinference.io
+        if: steps.cf_check.outputs.configured == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN:  ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4 pages deploy docs-site \
+            --project-name=atlas-docs \
+            --branch=main \
+            --commit-dirty=true
+
+  deploy-origin:
+    name: Mirror docs to avarok (standby)
+    needs: build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+    # The origin no longer serves docs.atlasinference.io, so a failure here means
+    # the standby is stale, not that the docs are down.
+    continue-on-error: true
     steps:
       - name: Check deploy secret presence
         # Skip deploy entirely when DEPLOY_SSH_PRIVATE_KEY is not

--- a/book/deploy/cloudflare/_headers
+++ b/book/deploy/cloudflare/_headers
@@ -1,0 +1,33 @@
+# Cloudflare Pages equivalent of book/deploy/nginx/docs.atlasinference.io.conf.
+#
+# Cache-Control is NOT on `/*`: Pages concatenates a header a later rule
+# re-declares rather than replacing it, and a browser reads the first max-age —
+# so a catch-all silently caps every override. Every rule below is scoped so no
+# two match the same path: there is no .html under /api/static.files, and the
+# hashed rustdoc bundle is the only content-addressed tree.
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/
+  Cache-Control: public, max-age=300
+/*.html
+  Cache-Control: public, max-age=300
+
+# rustdoc's content-hashed bundle: the filename carries the digest.
+/api/static.files/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+/FontAwesome/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# mdBook's own stylesheets are NOT hashed, so they must revalidate.
+/css/*
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=300


### PR DESCRIPTION
docs.atlasinference.io was the last property still pointing at the box that went down — it had been answering nothing at all. **It is already live on Cloudflare Pages** (`atlas-docs`, custom domain active, DNS repointed); this PR is the pipeline.

## Why not GitHub Pages

A repo gets **one** Pages site, and this repo's is owned by `coderag.yml`, which force-pushes `gh-pages` as an *orphan single-commit branch* on every run and documents itself as "its sole owner".

- Docs onto `gh-pages` → **deleted by the next corpus build**.
- Docs as the sole publisher → **the corpus disappears** and the marketing site's chat breaks (`site/src/lib/chat/config.js:8` fetches `avarok-cybersecurity.github.io/atlas/coderag/`).

So the docs join the other two properties on Cloudflare Pages and `gh-pages` is left entirely to CodeRAG.

## Shape

Same split as #975: `deploy` publishes to Pages and gates nothing behind the origin; `deploy-origin` rsyncs to avarok as a `continue-on-error` mirror. With both legs in one job, the outage that motivated this would also have blocked the edge deploy meant to survive it.

Direct Upload rather than Pages' git integration — the build needs a Rust toolchain, mdBook and a full `cargo doc --workspace`, and carries checks (llms.txt currency, the social-card assertion) a Pages-native build would bypass. Node is pinned to 24; wrangler v4 refuses to start below 22 and nothing else in this workflow needs Node.

## `_headers`

`book/deploy/cloudflare/_headers` reproduces the vhost's cache map and its three security headers. **Every rule is scoped not to overlap another** — Pages concatenates a re-declared header instead of replacing it, and a browser reads the first `max-age`, so an overlap silently caps the value it was meant to raise. There is no `.html` under `/api/static.files`, which is what makes the split clean.

Measured on the deployed site:

| Path | Cache-Control | |
|---|---|---|
| `/` | `public, max-age=300` | ✅ |
| `/api/static.files/normalize-9960930a.css` | `public, max-age=31536000, immutable` | ✅ |
| `/css/chrome.css` | `public, max-age=3600, must-revalidate` | ✅ |
| `/llms.txt` | `public, max-age=300` + `text/plain` | ✅ |
| `/nope-zzz-missing` | 404 (real, not a soft-404) | ✅ |

All three security headers present; exactly one `max-age` per response.

## One zone setting changed

`browser_cache_ttl` was `14400`, which rewrote the unhashed css from 3600 to 4 hours. It is now `0` (respect existing headers) — correct once every property states its own policy, and it removes a class of edge-caching surprise that already masked one deploy during this migration. Verified the apex and blog are unaffected.

https://claude.ai/code/session_01CsRChHTncdMd3d6e8BWsSz