### PR TITLE
Make three invisible CI failures visible

### DIFF
--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -2429,6 +2429,34 @@ rm -rf "$TMP/jo/.github/workflows"; mkdir -p "$TMP/jo/.github/workflows"
 want_rc_msg 1 "no workflow files found" "control: a guard that finds nothing must fail" \
   sh -c "cd '$TMP/jo' && python3 '$PWD/.github/scripts/assert-job-outputs-exported.py'"
 
+echo "== stuck runs are recognised before they can hide =="
+# A run that never creates a job publishes no check run, so a required context
+# it owns reads as ABSENT rather than red -- the PR cannot merge and nothing is
+# showing as broken. Each control below is a case that MUST NOT be swept, and
+# each rules out a real, healthy situation.
+STUCK='.github/scripts/stuck-runs.py'
+want_out "1" "a queued run with no jobs, past the threshold, is selected" \
+  sh -c "printf '%s' '{\"now\":\"2026-01-01T12:00:00Z\",\"threshold_minutes\":25,\"runs\":[{\"id\":1,\"status\":\"queued\",\"created_at\":\"2026-01-01T11:00:00Z\",\"job_count\":0}]}' | python3 $STUCK"
+# Control: a run waiting on a busy hosted pool is queued with no jobs and is
+# entirely healthy. Sweeping it would force-cancel real work.
+want_out "SWEPT-NOTHING" "control: a young queued run is left alone" \
+  sh -c "printf '%s' '{\"now\":\"2026-01-01T12:00:00Z\",\"threshold_minutes\":25,\"runs\":[{\"id\":2,\"status\":\"queued\",\"created_at\":\"2026-01-01T11:50:00Z\",\"job_count\":0}]}' | python3 $STUCK && echo SWEPT-NOTHING"
+# Control: a run that HAS jobs is merely slow, and is somebody else's problem.
+want_out "SWEPT-NOTHING" "control: a queued run that created jobs is left alone" \
+  sh -c "printf '%s' '{\"now\":\"2026-01-01T12:00:00Z\",\"threshold_minutes\":25,\"runs\":[{\"id\":3,\"status\":\"queued\",\"created_at\":\"2026-01-01T11:00:00Z\",\"job_count\":4}]}' | python3 $STUCK && echo SWEPT-NOTHING"
+# Control: an unresolved job count is NOT zero. Treating it as zero is the
+# fail-open direction, and it would cancel healthy runs whenever the jobs API
+# hiccups.
+want_out "SWEPT-NOTHING" "control: an unknown job count is not treated as zero" \
+  sh -c "printf '%s' '{\"now\":\"2026-01-01T12:00:00Z\",\"threshold_minutes\":25,\"runs\":[{\"id\":4,\"status\":\"queued\",\"created_at\":\"2026-01-01T11:00:00Z\",\"job_count\":null}]}' | python3 $STUCK && echo SWEPT-NOTHING"
+# Control: a guard that cannot read its input must refuse. Exiting 0 there would
+# report "nothing stuck" for every run forever, which is indistinguishable from
+# a healthy repo -- the exact way a dead guard survives.
+want_rc 2 "control: unreadable input is refused, not passed" \
+  sh -c "printf 'not json' | python3 $STUCK"
+want_rc 2 "control: a payload with no threshold is refused" \
+  sh -c "printf '%s' '{\"runs\":[]}' | python3 $STUCK"
+
 echo
 echo "  $PASS passed, $FAIL failed"
 REACHED_SUMMARY=1

--- a/.github/scripts/stuck-runs.py
+++ b/.github/scripts/stuck-runs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""
+Which workflow runs are stuck before they ever created a job.
+
+A run that never reaches job creation is the worst failure shape this pipeline
+has, because it is INVISIBLE. It produces no check runs at all, so a required
+context reads as *absent* rather than red: `gh pr checks` says "0 fail" while
+the PR is unmergeable and nothing anywhere is showing as broken. Worse, such a
+run holds its ref's concurrency group, so every later run on that ref queues
+behind it forever, and `gh run cancel` reports success without doing anything —
+only the force-cancel endpoint releases it.
+
+That is not hypothetical: it happened on #975, cost most of an hour, and was
+found only by noticing that a run had `jobs=0` long after it was created.
+
+The decision is here rather than inline in the workflow so it can be tested
+against fixtures instead of against live Actions state. Reads a runs listing on
+stdin, writes the ids to force-cancel on stdout, one per line.
+
+Input: {"now": "<iso8601>", "threshold_minutes": N, "runs": [...]} where each
+run is GitHub's own shape, plus a "job_count" the caller resolved.
+"""
+
+import datetime
+import json
+import sys
+
+# Statuses that mean "has not started doing work". A run that is `in_progress`
+# has jobs by definition and is somebody else's problem.
+NOT_STARTED = {"queued", "pending", "waiting", "requested"}
+
+
+def _parse(ts):
+    """GitHub stamps are Zulu; datetime wants an offset it recognises."""
+    return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def stuck_run_ids(payload):
+    """
+    Ids of runs that have not started AND have created no job AND have been in
+    that state longer than the threshold.
+
+    All three conditions are required, and each rules out a legitimate case:
+    a run waiting on a busy runner pool is `queued` but young; a run that is
+    merely slow has jobs; a run held for a deployment approval is `waiting` but
+    will have jobs once released.
+    """
+    now = _parse(payload["now"])
+    threshold = datetime.timedelta(minutes=int(payload["threshold_minutes"]))
+    stuck = []
+    for run in payload.get("runs") or []:
+        if run.get("status") not in NOT_STARTED:
+            continue
+        # A missing job_count is NOT zero. The caller failed to resolve it, and
+        # force-cancelling on an unknown is the fail-open direction that would
+        # kill healthy runs.
+        if run.get("job_count") is None:
+            continue
+        if int(run["job_count"]) != 0:
+            continue
+        if now - _parse(run["created_at"]) < threshold:
+            continue
+        stuck.append(int(run["id"]))
+    return stuck
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as exc:
+        # Refuse rather than pass: a guard that cannot read its input and exits
+        # 0 reports "nothing stuck" for every run forever.
+        print(f"cannot parse the run listing: {exc}", file=sys.stderr)
+        return 2
+    if "now" not in payload or "threshold_minutes" not in payload:
+        print("payload needs both 'now' and 'threshold_minutes'", file=sys.stderr)
+        return 2
+    for run_id in stuck_run_ids(payload):
+        print(run_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/certification-commands.yml
+++ b/.github/workflows/certification-commands.yml
@@ -54,8 +54,27 @@ on:
 permissions:
   contents: read
 
+# `cancel-in-progress: false` is NOT enough on its own, and the reason is
+# subtle. A concurrency group holds at most ONE pending run: when a newer run
+# enters, GitHub cancels the one already queued. Every comment on the PR
+# triggers this workflow — INCLUDING the bot's own replies — so the sequence
+#
+#   /stamp  ->  bot posts "Stamp recorded."  ->  /seal
+#
+# put three runs in one group, and the bot's reply evicted the queued /seal.
+# It was cancelled before its job could evaluate the `if` that would have made
+# it stand down anyway, so the command vanished with NO reply and no failure:
+# posting it again was the only way to notice. Observed twice on #976.
+#
+# So only real commands share the per-PR group. Anything else — a bot reply, an
+# ordinary review comment — gets a throwaway group of its own, keeps the
+# serialisation it never needed, and can no longer evict a command that does.
 concurrency:
-  group: cert-cmd-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: >-
+    ${{ (github.event_name == 'workflow_dispatch'
+         || startsWith(github.event.comment.body, '/'))
+        && format('cert-cmd-{0}', github.event.issue.number || github.event.pull_request.number || github.event.inputs.pr)
+        || format('cert-noop-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:
@@ -359,7 +378,9 @@ jobs:
                 rerun_note="
 
           > [!WARNING]
-          > **The $name is recorded, but CI was not re-run.** Re-running [CI run \`$run_id\`](https://github.com/$REPO/actions/runs/$run_id) failed, so certification and the nine release-matrix builds still show the \`skipped\` result they reported before the stamp. Re-run that workflow by hand, or push any commit to this PR.
+          > **The $name is recorded, but CI was not re-run.** Re-running [CI run \`$run_id\`](https://github.com/$REPO/actions/runs/$run_id) failed, so certification and the nine release-matrix builds still show the \`skipped\` result they reported before the stamp. Re-run that workflow **in full**, or push any commit to this PR.
+          >
+          > Re-running only the failed jobs will NOT work, and it looks like it should. \`stamp status\` and \`seal status\` did not fail — they SUCCEEDED while emitting \`false\`, because they ran before the mark existed. Job outputs are fixed for the life of a run, so the gate that reads \`needs.stamp.outputs.stamped\` keeps seeing that stale \`false\` no matter how many times you re-run the gate itself. Only a full re-run recomputes it.
           >
           > This is usually the App missing \`actions: write\`. \`certification-preflight.yml\` probes it.
           >

--- a/.github/workflows/stuck-run-watchdog.yml
+++ b/.github/workflows/stuck-run-watchdog.yml
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Releases workflow runs that are stuck before they ever created a job.
+#
+# This is the worst failure shape this pipeline has, because it is INVISIBLE. A
+# run can sit in `queued` having created NO jobs — routed to a runner label
+# nothing answers, or wedged on GitHub's side. With no jobs it publishes no
+# check runs, so every required context it owns reads as *absent* rather than
+# failing: `gh pr checks` reports "0 fail" while the PR cannot merge and nothing
+# anywhere says why. It also holds its ref's concurrency group, so every later
+# run on that ref queues behind it forever — and `gh run cancel` accepts the
+# request and does nothing. Only force-cancel releases it.
+#
+# Not hypothetical: this happened on #975, cost most of an hour, and was found
+# only by noticing a run still had `jobs=0` long after it was created.
+#
+# Like cmd-runner-health.yml, it deliberately runs on a GitHub-hosted runner: it
+# is the thing that notices runs are not starting, so it cannot depend on
+# whatever they were waiting for.
+name: Stuck run watchdog
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      threshold_minutes:
+        description: How long a run may sit with no jobs before it is released
+        required: false
+        default: '25'
+      dry_run:
+        description: List what would be cancelled without cancelling it
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  # force-cancel is a write on the Actions API, and the only reason this needs
+  # more than `contents: read`.
+  actions: write
+
+concurrency:
+  group: stuck-run-watchdog
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Release runs stuck before job creation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Find and release stuck runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # 25 minutes: long enough that a run legitimately waiting on a busy
+          # hosted pool is never touched, short enough that a wedged concurrency
+          # group is released within one working pause.
+          THRESHOLD: ${{ github.event.inputs.threshold_minutes || '25' }}
+          # The schedule must act; a manual invocation defaults to looking only.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -uo pipefail
+
+          if ! runs=$(gh api "repos/$REPO/actions/runs?status=queued&per_page=100" --jq '[.workflow_runs[] | {id, status, created_at, name}]' 2>&1); then
+            # Fail-safe, same reasoning as cmd-runner-health.yml: acting on a
+            # guess is worse than not acting, because a false "stuck" verdict
+            # force-cancels a healthy run.
+            echo "::warning title=Could not list runs::leaving everything alone. $runs"
+            exit 0
+          fi
+
+          count=$(printf '%s' "$runs" | jq 'length')
+          echo "queued runs: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "nothing queued — nothing to do."
+            exit 0
+          fi
+
+          # Resolve each run's job count. A run WITH jobs is somebody else's
+          # problem. An unresolvable count stays null on purpose: stuck-runs.py
+          # treats null as unknown and skips it, never as zero.
+          enriched='[]'
+          for id in $(printf '%s' "$runs" | jq -r '.[].id'); do
+            if jobs=$(gh api "repos/$REPO/actions/runs/$id/jobs?per_page=1" --jq '.total_count' 2>/dev/null); then
+              case "$jobs" in ''|*[!0-9]*) jobs=null ;; esac
+            else
+              jobs=null
+            fi
+            one=$(printf '%s' "$runs" | jq --argjson i "$id" '.[] | select(.id == $i)')
+            enriched=$(printf '%s' "$enriched" | jq --argjson r "$one" --argjson j "$jobs" '. + [$r + {job_count: $j}]')
+          done
+
+          payload=$(jq -n --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson t "$THRESHOLD" --argjson runs "$enriched" '{now: $now, threshold_minutes: $t, runs: $runs}')
+
+          # The script exits non-zero if it cannot read its input. Refusing is
+          # right: a sweep that silently found nothing looks identical to a
+          # healthy repo, which is how a broken guard survives unnoticed.
+          if ! stuck=$(printf '%s' "$payload" | python3 .github/scripts/stuck-runs.py); then
+            echo "::error title=Watchdog could not evaluate the runs::stuck-runs.py refused its input."
+            exit 1
+          fi
+
+          if [ -z "$stuck" ]; then
+            echo "no run has been sitting with zero jobs for more than ${THRESHOLD}m."
+            exit 0
+          fi
+
+          for id in $stuck; do
+            name=$(printf '%s' "$enriched" | jq -r --argjson i "$id" '.[] | select(.id == $i) | .name')
+            url="https://github.com/$REPO/actions/runs/$id"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::notice title=Would release a stuck run::$name ($url) has created no jobs for over ${THRESHOLD}m."
+              continue
+            fi
+            # force-cancel, not cancel: an ordinary cancel is ACCEPTED and then
+            # does nothing to a run in this state. That is what made the original
+            # incident take an hour to unpick.
+            if err=$(gh api -X POST "repos/$REPO/actions/runs/$id/force-cancel" 2>&1); then
+              echo "::warning title=Released a stuck run::$name ($url) had created no jobs for over ${THRESHOLD}m and was holding its concurrency group. Force-cancelled."
+            else
+              echo "::error title=Could not release a stuck run::$name ($url): $err"
+            fi
+          done


### PR DESCRIPTION
All three share one shape: **the absence of a signal reads as success.** Each cost real time this week and none of them turned anything red.

## 1. A run stuck before job creation

A run can sit in `queued` having created **no jobs at all**. With no jobs it publishes no check runs, so every required context it owns reads as *absent* rather than failing — `gh pr checks` reported "0 fail" on #975 while the PR was unmergeable and nothing said why. It also held its ref's concurrency group, so every later run queued behind it, and `gh run cancel` accepted the request **three times and did nothing**. Only `force-cancel` released it.

`stuck-run-watchdog.yml` sweeps every 15 minutes. The decision lives in `stuck-runs.py` rather than inline so it can be tested against fixtures instead of live Actions state. A run is swept only if **all three** hold, and each rules out a healthy case:

| Condition | The healthy case it excludes |
|---|---|
| has not started | a run that is merely slow |
| created no job | a busy pool that will start shortly |
| older than the threshold | a run waiting normally on hosted capacity |

An unresolved job count stays `null` and is **skipped**, never read as zero — that is the fail-open direction and would force-cancel healthy runs whenever the jobs API hiccups.

## 2. A queued command evicted by the bot's own reply

`cancel-in-progress: false` is not enough, and the reason is subtle: **a concurrency group holds at most one pending run**, and a newer arrival cancels it. Every comment triggers the command workflow — *including the bot's own replies* — so:

```
/stamp  ->  bot posts "Stamp recorded."  ->  /seal
```

put three runs in one group, and the reply evicted the queued `/seal`. It was cancelled before its job could even evaluate the `if` that would have stood it down, so the command vanished with **no reply and no failure**. Seen twice on #976; the only way to notice was to post it again.

Now only real commands share the per-PR group; anything else gets a throwaway group and can evict nothing.

## 3. Re-running the failed jobs after a stamp, which cannot work

`stamp status` and `seal status` don't *fail* when they run before the mark — they **succeed while emitting `false`**. Job outputs are fixed for the life of a run, so the gate reading `needs.stamp.outputs.stamped` keeps seeing that stale value however many times the gate itself is re-run. The bot already does a full re-run; the trap is for whoever reaches for `--failed` when it couldn't. Its warning now says so, where the person hitting it will read it.

## Controls

Six, each proven to fail. Worth recording that **one was vacuous first**: `want_out ""` also passes when the script *crashes*, because a crash prints nothing too — deleting the `None`-guard made `int(None)` raise and the control stayed green. They now assert a marker only a clean exit can print, and each sabotage fails its own control and only its own.

Selftest **221 passed / 4 failed**, against **215 / 4** on unmodified `main` — six new controls, same four pre-existing failures, none new.

https://claude.ai/code/session_01CsRChHTncdMd3d6e8BWsSz