### PR TITLE
The avarok mirror was never running, and said so nowhere

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -276,6 +276,19 @@ jobs:
             --commit-dirty=true
 
   deploy-origin:
+    # The environment is what makes DEPLOY_SSH_* visible: environment secrets
+    # reach ONLY jobs that declare the environment holding them. Splitting the
+    # rsync into its own job dropped this block, so every `secrets.DEPLOY_*`
+    # read as empty, the presence check took its "not configured" branch, and
+    # the mirror soft-skipped every step while the job reported success. The
+    # standby was not stale because the box was down — it was never written to
+    # at all, and the run said nothing was wrong.
+    #
+    # No `url:` here on purpose: the Cloudflare job owns the deployment URL for
+    # this environment, and two jobs claiming it would make the standby look
+    # like the thing serving traffic.
+    environment:
+      name: production-docs
     name: Mirror docs to avarok (standby)
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
@@ -338,6 +351,15 @@ jobs:
           DEPLOY_PATH:      ${{ secrets.DEPLOY_PATH }}
         run: |
           PORT="${DEPLOY_SSH_PORT:-22}"
-          rsync -az --delete --chmod=D755,F644 \
-            -e "ssh -p ${PORT}" \
-            site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"
+          # `continue-on-error` on this job keeps a dead origin from blocking the
+          # edge deploy — but a green job with no annotation looks exactly like a
+          # mirror that worked, which is the failure shape this change is about.
+          # Say which it was.
+          if rsync -az --delete --chmod=D755,F644 \
+               -e "ssh -p ${PORT}" \
+               site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"
+          then
+            echo "mirrored the docs to ${DEPLOY_SSH_HOST}"
+          else
+            echo "::warning title=avarok mirror did not run::rsync of the docs to ${DEPLOY_SSH_HOST} failed. The standby is STALE. Cloudflare Pages is unaffected and still serving."
+          fi

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -431,6 +431,19 @@ jobs:
             --commit-dirty=true
 
   deploy-origin:
+    # The environment is what makes DEPLOY_SSH_* visible: environment secrets
+    # reach ONLY jobs that declare the environment holding them. Splitting the
+    # rsync into its own job dropped this block, so every `secrets.DEPLOY_*`
+    # read as empty, the presence check took its "not configured" branch, and
+    # the mirror soft-skipped every step while the job reported success. The
+    # standby was not stale because the box was down — it was never written to
+    # at all, and the run said nothing was wrong.
+    #
+    # No `url:` here on purpose: the Cloudflare job owns the deployment URL for
+    # this environment, and two jobs claiming it would make the standby look
+    # like the thing serving traffic.
+    environment:
+      name: production-site
     name: Mirror to avarok via rsync (standby)
     needs: [build, unit]
     if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
@@ -503,9 +516,18 @@ jobs:
           # a 404 on a lazily-imported chunk, mid-session, for the duration of a
           # deploy. Deferring the deletions to the end means the old bundle stays
           # whole until the new one is entirely in place.
-          rsync -az --delete-delay --chmod=D755,F644 \
-            -e "ssh -p ${PORT} -o ConnectTimeout=20" \
-            site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"
+          # `continue-on-error` on this job keeps a dead origin from blocking the
+          # edge deploy — but a green job with no annotation looks exactly like a
+          # mirror that worked, which is the failure shape this change is about.
+          # Say which it was.
+          if rsync -az --delete-delay --chmod=D755,F644 \
+               -e "ssh -p ${PORT} -o ConnectTimeout=20" \
+               site/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_PATH}/"
+          then
+            echo "mirrored the marketing site to ${DEPLOY_SSH_HOST}"
+          else
+            echo "::warning title=avarok mirror did not run::rsync of the marketing site to ${DEPLOY_SSH_HOST} failed. The standby is STALE. Cloudflare Pages is unaffected and still serving."
+          fi
 
       - name: Mirror blog
         if: steps.secret_check.outputs.configured == 'true'
@@ -524,9 +546,18 @@ jobs:
             exit 1
           fi
           PORT="${DEPLOY_SSH_PORT:-22}"
-          rsync -az --delete-delay --chmod=D755,F644 \
-            -e "ssh -p ${PORT} -o ConnectTimeout=20" \
-            blog/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_BLOG_PATH}/"
+          # `continue-on-error` on this job keeps a dead origin from blocking the
+          # edge deploy — but a green job with no annotation looks exactly like a
+          # mirror that worked, which is the failure shape this change is about.
+          # Say which it was.
+          if rsync -az --delete-delay --chmod=D755,F644 \
+               -e "ssh -p ${PORT} -o ConnectTimeout=20" \
+               blog/ "${DEPLOY_SSH_USER}@${DEPLOY_SSH_HOST}:${DEPLOY_BLOG_PATH}/"
+          then
+            echo "mirrored the blog to ${DEPLOY_SSH_HOST}"
+          else
+            echo "::warning title=avarok mirror did not run::rsync of the blog to ${DEPLOY_SSH_HOST} failed. The standby is STALE. Cloudflare Pages is unaffected and still serving."
+          fi
 
 
   verify:


### PR DESCRIPTION
Splitting the rsync into its own `deploy-origin` job (#975, #978) dropped the `environment:` block. **Environment secrets reach only jobs that declare the environment holding them**, so every `secrets.DEPLOY_SSH_*` read as empty, the presence check took its "not configured" branch, and all six mirror steps skipped. The job then reported **success**.

```
  Check deploy secret presence: success
  Download site artifact:       skipped
  Install rsync:                skipped
  Load SSH key:                 skipped
  Mirror:                       skipped
  Mirror blog:                  skipped
  job conclusion:               success
```

So the standby was not stale because the origin is down — **it was never written to at all**, on either property, and both post-migration runs looked clean. I described avarok as staying "byte-current"; it was not, and nothing in the run said otherwise. Found by reading the mirror job's *steps* rather than its conclusion, which is the only place the difference shows.

## Two halves, because fixing one alone replaces a silence with a silence

**1. Declare the environment.** Both `deploy-origin` jobs now declare `production-site` / `production-docs`, with no `url:` — the Cloudflare job owns the deployment URL for each environment, and two jobs claiming it would make the standby look like the thing serving traffic.

**2. Announce the outcome.** Once the secrets resolve, the rsync will genuinely run and genuinely *fail* while the origin is down — and `continue-on-error`, which exists so a dead origin cannot block the edge deploy, would still report the job green. Each rsync now prints a line naming the host on success, and a `::warning::` on failure saying the standby is STALE and that Cloudflare is unaffected and still serving.

## Verification

- `bash -n` over every changed `run:` block — this matters, because a first attempt at the wrapper silently ate the rsync source/destination arguments and would have mirrored nothing.
- Both workflows parse; every rsync still names a source and a destination.
- `assert-cmd-runner-safe.py` and `assert-job-outputs-exported.py` pass.

https://claude.ai/code/session_01CsRChHTncdMd3d6e8BWsSz