### PR TITLE
spark-model: preserve scalar accumulation order in FP8 batched GEMV and batch native o_proj (#932)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -279,3 +279,7 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "w4a16_qg_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "native_fp8_oproj_batch_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
@@ -5,11 +5,12 @@ use anyhow::{Result, ensure};
 use half::bf16;
 use spark_model::layers::ops;
 use spark_runtime::cuda_backend::AtlasCudaBackend;
-use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelLaunch};
 
 const N: usize = 5120;
 const K: usize = 6144;
-const MAX_M: usize = 5;
+const MAX_M: usize = 16;
+const ORIGINAL_M: usize = 5;
 const GUARD: usize = 64;
 
 fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
@@ -58,6 +59,7 @@ fn main() -> Result<()> {
     let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
     let scalar = gpu.kernel("w8a16_gemv", "w8a16_gemv")?;
     let batch4 = gpu.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch4")?;
+    let batch16 = gpu.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch16")?;
     let mut state = 0x51a7_8a16_2026_u64;
     let mut random = || {
         state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
@@ -69,7 +71,7 @@ fn main() -> Result<()> {
             ((x % 127) as u8) | (((x >> 7) & 1) as u8 * 128)
         })
         .collect();
-    let acts: Vec<u8> = (0..MAX_M * K)
+    let mut acts: Vec<u8> = (0..ORIGINAL_M * K)
         .flat_map(|_| {
             bf16::from_f32(((random() % 2049) as f32 - 1024.0) / 1024.0)
                 .to_bits()
@@ -79,6 +81,13 @@ fn main() -> Result<()> {
     let scales: Vec<u8> = (0..N / 128 * (K / 128))
         .flat_map(|_| (((random() % 16 + 1) as f32) / 1024.0).to_le_bytes())
         .collect();
+    // Keep the observed M4 red fixture's first five rows and scales unchanged.
+    // Additional rows are generated only after the original scale draws.
+    acts.extend((0..(MAX_M - ORIGINAL_M) * K).flat_map(|_| {
+        bf16::from_f32(((random() % 2049) as f32 - 1024.0) / 1024.0)
+            .to_bits()
+            .to_le_bytes()
+    }));
     let weight = upload(&gpu, &weights)?;
     let input_base = upload(&gpu, &[vec![0x5a; GUARD], acts, vec![0x5a; GUARD]].concat())?;
     let input = input_base.offset(GUARD);
@@ -90,7 +99,7 @@ fn main() -> Result<()> {
     let scalar_out = scalar_base.offset(GUARD);
     let batch_out = batch_base.offset(GUARD);
     let mut first_oracle = true;
-    for m in [2_usize, 4, 5] {
+    for m in [2_usize, 4, 5, 8, 16] {
         gpu.copy_h2d(&sentinel, scalar_base)?;
         gpu.copy_h2d(&sentinel, batch_base)?;
         for row in 0..m {
@@ -106,19 +115,34 @@ fn main() -> Result<()> {
                 0,
             )?;
         }
-        for first in (0..m).step_by(4) {
-            ops::w8a16_gemv_batch4(
-                &gpu,
-                batch4,
-                input.offset(first * K * 2),
-                weight,
-                scale,
-                batch_out.offset(first * N * 2),
-                (m - first).min(4) as u32,
-                N as u32,
-                K as u32,
-                0,
-            )?;
+        if m > 5 {
+            // The same CUDA template also exports M<=16; exercise it directly.
+            KernelLaunch::new(&gpu, batch16)
+                .grid([N.div_ceil(4) as u32, 1, 1])
+                .block([256, 1, 1])
+                .arg_ptr(input)
+                .arg_ptr(weight)
+                .arg_ptr(scale)
+                .arg_ptr(batch_out)
+                .arg_u32(m as u32)
+                .arg_u32(N as u32)
+                .arg_u32(K as u32)
+                .launch(0)?;
+        } else {
+            for first in (0..m).step_by(4) {
+                ops::w8a16_gemv_batch4(
+                    &gpu,
+                    batch4,
+                    input.offset(first * K * 2),
+                    weight,
+                    scale,
+                    batch_out.offset(first * N * 2),
+                    (m - first).min(4) as u32,
+                    N as u32,
+                    K as u32,
+                    0,
+                )?;
+            }
         }
         gpu.synchronize(0)?;
         let mut baseline = vec![0_u8; sentinel.len()];
@@ -163,6 +187,8 @@ fn main() -> Result<()> {
         );
         check_output(&observed, &baseline, &sentinel, bytes)?;
     }
-    println!("ALL PASS: actual O projection M2/M4/M5, scalar equivalence and offset guards");
+    println!(
+        "ALL PASS: actual O shape batch4 M2/M4/M5 and batch16 M8/M16, exact scalar equivalence and guards"
+    );
     Ok(())
 }

--- a/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Actual Qwen3.8 O-projection shape, existing scalar versus chunked batch4.
+//! No new kernel math: require identical BF16 output bytes and intact guards.
+use anyhow::{Result, ensure};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+const N: usize = 5120;
+const K: usize = 6144;
+const MAX_M: usize = 5;
+const GUARD: usize = 64;
+
+fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+fn values(bytes: &[u8]) -> Vec<f64> {
+    bytes
+        .chunks_exact(2)
+        .map(|x| bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32() as f64)
+        .collect()
+}
+fn check_output(observed: &[u8], baseline: &[u8], sentinel: &[u8], bytes: usize) -> Result<()> {
+    ensure!(
+        observed.len() == sentinel.len() && baseline.len() == sentinel.len(),
+        "output extent mismatch"
+    );
+    let actual = &observed[GUARD..GUARD + bytes];
+    let expected = &baseline[GUARD..GUARD + bytes];
+    ensure!(
+        values(actual)
+            .iter()
+            .chain(values(expected).iter())
+            .all(|x| x.is_finite()),
+        "nonfinite projection output"
+    );
+    ensure!(
+        observed[..GUARD] == sentinel[..GUARD]
+            && observed[GUARD + bytes..] == sentinel[GUARD + bytes..],
+        "batched row offset wrote outside output extent"
+    );
+    ensure!(
+        baseline[..GUARD] == sentinel[..GUARD]
+            && baseline[GUARD + bytes..] == sentinel[GUARD + bytes..],
+        "scalar row offset wrote outside output extent"
+    );
+    ensure!(
+        actual == expected,
+        "batch output differs from production scalar BF16 bits"
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let scalar = gpu.kernel("w8a16_gemv", "w8a16_gemv")?;
+    let batch4 = gpu.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch4")?;
+    let mut state = 0x51a7_8a16_2026_u64;
+    let mut random = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (state >> 32) as u32
+    };
+    let weights: Vec<u8> = (0..N * K)
+        .map(|_| {
+            let x = random();
+            ((x % 127) as u8) | (((x >> 7) & 1) as u8 * 128)
+        })
+        .collect();
+    let acts: Vec<u8> = (0..MAX_M * K)
+        .flat_map(|_| {
+            bf16::from_f32(((random() % 2049) as f32 - 1024.0) / 1024.0)
+                .to_bits()
+                .to_le_bytes()
+        })
+        .collect();
+    let scales: Vec<u8> = (0..N / 128 * (K / 128))
+        .flat_map(|_| (((random() % 16 + 1) as f32) / 1024.0).to_le_bytes())
+        .collect();
+    let weight = upload(&gpu, &weights)?;
+    let input_base = upload(&gpu, &[vec![0x5a; GUARD], acts, vec![0x5a; GUARD]].concat())?;
+    let input = input_base.offset(GUARD);
+    let scale = upload(&gpu, &scales)?;
+    let output_bytes = MAX_M * N * 2;
+    let sentinel = vec![0x5a; output_bytes + 2 * GUARD];
+    let scalar_base = upload(&gpu, &sentinel)?;
+    let batch_base = upload(&gpu, &sentinel)?;
+    let scalar_out = scalar_base.offset(GUARD);
+    let batch_out = batch_base.offset(GUARD);
+    let mut first_oracle = true;
+    for m in [2_usize, 4, 5] {
+        gpu.copy_h2d(&sentinel, scalar_base)?;
+        gpu.copy_h2d(&sentinel, batch_base)?;
+        for row in 0..m {
+            ops::w8a16_gemv(
+                &gpu,
+                scalar,
+                input.offset(row * K * 2),
+                weight,
+                scale,
+                scalar_out.offset(row * N * 2),
+                N as u32,
+                K as u32,
+                0,
+            )?;
+        }
+        for first in (0..m).step_by(4) {
+            ops::w8a16_gemv_batch4(
+                &gpu,
+                batch4,
+                input.offset(first * K * 2),
+                weight,
+                scale,
+                batch_out.offset(first * N * 2),
+                (m - first).min(4) as u32,
+                N as u32,
+                K as u32,
+                0,
+            )?;
+        }
+        gpu.synchronize(0)?;
+        let mut baseline = vec![0_u8; sentinel.len()];
+        let mut observed = vec![0_u8; sentinel.len()];
+        gpu.copy_d2h(scalar_base, &mut baseline)?;
+        gpu.copy_d2h(batch_base, &mut observed)?;
+        let bytes = m * N * 2;
+        let expected = &baseline[GUARD..GUARD + bytes];
+        let actual = &observed[GUARD..GUARD + bytes];
+        if first_oracle {
+            for mutation in ["output-bit", "guard", "nonfinite"] {
+                let mut bad = baseline.clone();
+                match mutation {
+                    "output-bit" => bad[GUARD] ^= 1,
+                    "guard" => bad[0] ^= 1,
+                    _ => bad[GUARD..GUARD + 2].copy_from_slice(&0x7fc0_u16.to_le_bytes()),
+                }
+                let error = check_output(&bad, &baseline, &sentinel, bytes)
+                    .expect_err("known-bad output was admitted by the real comparison oracle");
+                println!("KNOWN_BAD {mutation}: refused: {error}");
+            }
+            first_oracle = false;
+        }
+        let a = values(actual);
+        let b = values(expected);
+        let max_abs = a
+            .iter()
+            .zip(&b)
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0_f64, f64::max);
+        let dot: f64 = a.iter().zip(&b).map(|(x, y)| x * y).sum();
+        let norm_a: f64 = a.iter().map(|x| x * x).sum();
+        let norm_b: f64 = b.iter().map(|x| x * x).sum();
+        let cosine = dot / (norm_a * norm_b).sqrt();
+        let mismatches = actual
+            .chunks_exact(2)
+            .zip(expected.chunks_exact(2))
+            .filter(|(x, y)| x != y)
+            .count();
+        println!(
+            "M={m} N={N} K={K} unequal_bf16={mismatches} max_abs={max_abs:.9} cosine={cosine:.12}"
+        );
+        check_output(&observed, &baseline, &sentinel, bytes)?;
+    }
+    println!("ALL PASS: actual O projection M2/M4/M5, scalar equivalence and offset guards");
+    Ok(())
+}

--- a/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_oproj_batch_microtest.rs
@@ -5,7 +5,8 @@ use anyhow::{Result, ensure};
 use half::bf16;
 use spark_model::layers::ops;
 use spark_runtime::cuda_backend::AtlasCudaBackend;
-use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelLaunch};
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+use spark_runtime::kernel_args::KernelLaunch;
 
 const N: usize = 5120;
 const K: usize = 6144;

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -235,6 +235,11 @@ impl Qwen3AttentionLayer {
             w4a16_gemv_k: gpu.kernel("w4a16_gemv", "w4a16_gemv")?,
             w4a16_gemv_sw_k: super::super::try_kernel(gpu, "w4a16_gemv", "w4a16_gemv_sw"),
             w8a16_gemv_k: gpu.kernel("w8a16_gemv", "w8a16_gemv")?,
+            w8a16_gemv_batch4_k: super::super::try_kernel(
+                gpu,
+                "w8a16_gemv_batch4",
+                "w8a16_gemv_batch4",
+            ),
             w8a16_gemm_k: super::super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),
             w8a16_gemm_pipelined_k: super::super::try_kernel(
                 gpu,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj.rs
@@ -11,6 +11,7 @@ use super::super::ctx::MultiSeqCtx;
 use crate::layers::ops;
 use crate::layers::qwen3_attention::HeadGateActivation;
 use crate::layers::qwen3_attention::Qwen3AttentionLayer;
+use crate::weight_map::WeightQuantFormat;
 
 impl Qwen3AttentionLayer {
     /// Phase 6: gate multiply (when gated) + O projection. Writes to
@@ -178,21 +179,44 @@ impl Qwen3AttentionLayer {
                 )?;
             }
         } else if let Some(o_fp8) = self.o_weight.as_ref().and_then(|w| w.as_fp8()) {
-            // FP8 native: per-token w8a16_gemv for O projection.
-            for i in 0..n {
+            // Both matrices are contiguous. Share each block-scaled weight
+            // pass across up to four rows without staging or requantization.
+            // Keep the scalar route for single-row decode and older bundles.
+            let batched = n > 1
+                && self.w8a16_gemv_batch4_k.0 != 0
+                && o_fp8.scale_format == WeightQuantFormat::Fp8BlockScaled
+                && h % 128 == 0
+                && q_dim % 128 == 0;
+            let step = if batched { 4 } else { 1 };
+            for i in (0..n).step_by(step) {
                 let attn_out_i = attn_out.offset(i * q_dim as usize * bf16);
                 let o_out_i = o_out.offset(i * h * bf16);
-                ops::w8a16_gemv(
-                    fwd.gpu,
-                    self.w8a16_gemv_k,
-                    attn_out_i,
-                    o_fp8.weight,
-                    o_fp8.row_scale,
-                    o_out_i,
-                    h as u32,
-                    nq * hd,
-                    stream,
-                )?;
+                if batched {
+                    ops::w8a16_gemv_batch4(
+                        fwd.gpu,
+                        self.w8a16_gemv_batch4_k,
+                        attn_out_i,
+                        o_fp8.weight,
+                        o_fp8.row_scale,
+                        o_out_i,
+                        (n - i).min(4) as u32,
+                        h as u32,
+                        nq * hd,
+                        stream,
+                    )?;
+                } else {
+                    ops::w8a16_gemv(
+                        fwd.gpu,
+                        self.w8a16_gemv_k,
+                        attn_out_i,
+                        o_fp8.weight,
+                        o_fp8.row_scale,
+                        o_out_i,
+                        h as u32,
+                        nq * hd,
+                        stream,
+                    )?;
+                }
             }
         } else if n == 3 && !self.attn.o_proj.is_null() {
             ops::w4a16_gemv_batch3(
@@ -275,3 +299,7 @@ impl Qwen3AttentionLayer {
         Ok(o_out)
     }
 }
+
+#[cfg(test)]
+#[path = "o_proj_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj_tests.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::super::super::ctx::MultiSeqCtx;
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::layers::{FfnComponent, qwen3_attention::Qwen3AttentionLayer};
+use crate::weight_map::{
+    AttentionWeights, DenseWeight, Fp8Weight, QuantWeight, QuantizedWeight, WeightQuantFormat,
+};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::{MockArg, MockGpuBackend};
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use spark_runtime::kv_cache::KvCacheDtype;
+
+#[test]
+fn native_fp8_attention_o_projection_batches_four_real_rows() {
+    check_dispatch(4, 128, true, WeightQuantFormat::Fp8BlockScaled, true);
+}
+
+fn check_dispatch(
+    rows: usize,
+    width: usize,
+    available: bool,
+    format: WeightQuantFormat,
+    batched: bool,
+) {
+    let gpu = MockGpuBackend::new();
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = width;
+    config.intermediate_size = 128;
+    config.num_attention_heads = 1;
+    config.num_key_value_heads = 1;
+    config.head_dim = width;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    let buffers = BufferArena::new(&config, 8, 16, 16, 8, &gpu).unwrap();
+    let dense = DenseWeight {
+        weight: gpu.alloc(128 * 128 * 2).unwrap(),
+    };
+    let fallback = QuantizedWeight::null();
+    let attn = AttentionWeights {
+        q_proj: dense,
+        k_proj: dense,
+        v_proj: dense,
+        o_proj: fallback,
+        q_norm: dense,
+        k_norm: dense,
+        q_norm_full: None,
+        k_norm_full: None,
+        k_scale: 1.0,
+        v_scale: 1.0,
+    };
+    let mut layer = Qwen3AttentionLayer::new(
+        dense,
+        attn,
+        dense,
+        FfnComponent::None,
+        0,
+        None,
+        None,
+        None,
+        &gpu,
+        KvCacheDtype::Bf16,
+        0,
+        &config,
+    )
+    .unwrap();
+    layer.w8a16_gemv_k = KernelHandle(0xF081);
+    layer.w8a16_gemv_batch4_k = KernelHandle(if available { 0xF084 } else { 0 });
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(128 * 128).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n: 128,
+        k: 128,
+        scale_format: format,
+    };
+    layer.o_weight = Some(QuantWeight::Fp8(fp8));
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let fwd = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu: &gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    let c = MultiSeqCtx::new(
+        &layer,
+        &fwd,
+        buffers.hidden_states(),
+        buffers.residual(),
+        rows,
+        16,
+        0,
+    );
+    let first = gpu.launch_count();
+    let allocations = gpu.alloc_count();
+    let output = layer.ms_phase_o_proj(&c, buffers.attn_output()).unwrap();
+    let all = gpu.launches_snapshot();
+    let launches: Vec<_> = all[first..]
+        .iter()
+        .filter(|l| l.args.contains(&MockArg::Buffer(fp8.weight)))
+        .collect();
+    let step = if batched { 4 } else { 1 };
+    assert_eq!(
+        launches.len(),
+        rows.div_ceil(step),
+        "production O-projection dispatch"
+    );
+    assert_eq!(
+        gpu.alloc_count(),
+        allocations,
+        "projection must reuse existing buffers"
+    );
+    for (group, launch) in launches.iter().enumerate() {
+        let row = group * step;
+        assert_eq!(launch.func, if batched { 0xF084 } else { 0xF081 });
+        assert_eq!(
+            launch.args[0],
+            MockArg::Buffer(buffers.attn_output().offset(row * width * 2))
+        );
+        assert_eq!(launch.args[1], MockArg::Buffer(fp8.weight));
+        assert_eq!(launch.args[2], MockArg::Buffer(fp8.row_scale));
+        assert_eq!(
+            launch.args[3],
+            MockArg::Buffer(output.offset(row * width * 2))
+        );
+        if batched {
+            assert_eq!(
+                launch.args[4],
+                MockArg::Bytes(((rows - row).min(4) as u32).to_ne_bytes().to_vec())
+            );
+        }
+    }
+}
+
+#[test]
+fn native_fp8_attention_o_projection_chunks_preserve_offsets() {
+    for rows in [2, 5, 16] {
+        check_dispatch(rows, 128, true, WeightQuantFormat::Fp8BlockScaled, true);
+    }
+}
+
+#[test]
+fn native_fp8_attention_o_projection_retains_scalar_fallbacks() {
+    check_dispatch(1, 128, true, WeightQuantFormat::Fp8BlockScaled, false);
+    check_dispatch(4, 128, false, WeightQuantFormat::Fp8BlockScaled, false);
+    check_dispatch(4, 64, true, WeightQuantFormat::Fp8BlockScaled, false);
+    check_dispatch(4, 128, true, WeightQuantFormat::Fp8PerRow, false);
+}

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/attn/o_proj_tests.rs
@@ -95,6 +95,9 @@ fn check_dispatch(
         profile: false,
         comm: None,
         graph_capture: false,
+        // `attn_metadata` is None here and the output projection never reads
+        // the decode scalars this flag guards, so the prefill shape is correct.
+        decode_step: false,
         gdn_exact_replay: false,
         token_ids: None,
         host_token_ids: None,

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -188,6 +188,8 @@ pub struct Qwen3AttentionLayer {
     /// Single-warp `w4a16_gemv_sw`. `KernelHandle(0)` on miss → base GEMV.
     pub(super) w4a16_gemv_sw_k: KernelHandle,
     pub(super) w8a16_gemv_k: KernelHandle,
+    /// Optional four-row block-scaled FP8 GEMV; zero retains scalar dispatch.
+    pub(super) w8a16_gemv_batch4_k: KernelHandle,
     pub(super) w8a16_gemm_k: KernelHandle,
     pub(super) w8a16_gemm_pipelined_k: KernelHandle,
     pub(super) w4a16_gemv_dual_k: KernelHandle,

--- a/kernels/gb10/common/w8a16_gemv_batch4.cu
+++ b/kernels/gb10/common/w8a16_gemv_batch4.cu
@@ -14,8 +14,8 @@
 // same weight bytes, no tensor cores, no M padding.
 //
 // Per-row accumulation order is IDENTICAL to `w8a16_gemv`, so the output is
-// bit-identical to running `w8a16_gemv` M times (verify with a cos>=0.9999
-// microtest). A:[M,K] BF16, B:[N,K] FP8 E4M3, block_scale:[N/128,K/128] FP32,
+// bit-identical to running `w8a16_gemv` M times (verified with exact BF16
+// output comparison). A:[M,K] BF16, B:[N,K] FP8 E4M3, block_scale:[N/128,K/128] FP32,
 // C:[M,N] BF16. Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1).
 
 #include <cuda_bf16.h>
@@ -161,8 +161,9 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
                 __nv_bfloat16 lo, hi;
                 *(unsigned short*)&lo = (unsigned short)(ar[j] & 0xFFFF);
                 *(unsigned short*)&hi = (unsigned short)(ar[j] >> 16);
-                acc[t] += __bfloat162float(lo) * wf[j * 2]
-                        + __bfloat162float(hi) * wf[j * 2 + 1];
+                // Match scalar rounding: never sum a pair before the accumulator.
+                acc[t] += __bfloat162float(lo) * wf[j * 2];
+                acc[t] += __bfloat162float(hi) * wf[j * 2 + 1];
             }
         }
     }


### PR DESCRIPTION
## Summary

Two things, one file apart. `w8a16_gemv_batch4.cu` summed each pair of products *before* touching the accumulator, so the batched FP8 GEMV was not bit-identical to the scalar `w8a16_gemv` it stands in for — 1-ulp BF16 drift in multi-row decode (#932). And the native-FP8 attention output projection never used the batched kernel at all: it looped `w8a16_gemv` once per row, re-reading the whole block-scaled `o_proj` weight for every concurrent sequence (#927's bucket).

Fixes #932. Refs #927.

## What was wrong

**The kernel.** `w8a16_gemv_batchm_impl` dequantizes each FP8 weight byte once and MACs it into M independent FP32 accumulators — the whole point being that batching cannot change the answer. The inner loop did:

```c
acc[t] += __bfloat162float(lo) * wf[j * 2]
        + __bfloat162float(hi) * wf[j * 2 + 1];
```

The scalar kernel accumulates one product at a time. Summing the pair first rounds once more, in a different place, so the FP32 sequence differs and the BF16 output can land one ulp away. On the H100 at the real Qwen3.8-27B o_proj shape, 3 of the M=4 outputs differed from the scalar reference (max |diff| 0.00048828125). Atlas's contract is that batching does not change results — the NVFP4 batch kernels have had `w4a16_batch_bitparity_microtest` enforcing exactly this for a while; the W8A16 family had no such oracle.

**The dispatch.** `multi_seq/attn/o_proj.rs` had a plain `for i in 0..n` over `ops::w8a16_gemv` in the native-FP8 arm. At C=4 decode the four sequences share one weight matrix, so that is four full DRAM passes over `o_proj` where one would do.

## What the fix does

- `kernels/gb10/common/w8a16_gemv_batch4.cu`: the pair is split into two sequential `+=`, which is literally the scalar kernel's order. Five lines. The header comment's parity claim is updated from "verify with a cos>=0.9999 microtest" to exact BF16 output comparison, because that is now what is checked.
- `multi_seq/attn/o_proj.rs`: the native-FP8 arm steps by 4 and calls `ops::w8a16_gemv_batch4` when `n > 1`, the `w8a16_gemv_batch4` handle resolved, the weight is `Fp8BlockScaled`, and both `hidden_size` and `q_dim` are multiples of 128. Anything else — single-row decode, a missing kernel (older bundles), per-row scales, an unaligned dim — keeps the exact scalar loop it had. The tail group passes `(n - i).min(4)` so a row count that is not a multiple of 4 is handled by the kernel's own M argument rather than by a separate scalar pass.
- `qwen3_attention/{types,init}.rs`: the optional `w8a16_gemv_batch4_k` handle, resolved through `try_kernel`, so `KernelHandle(0)` simply retains scalar dispatch.

Nothing is copied, staged or requantized: both arms read the same FP8 weight and the same block-scale buffer, and the batched call takes the same per-row view offsets the scalar loop computed.

## Oracle and evidence

**Bit-parity, H100, 2026-09-06 02:44 UTC**, source `8882f08` (these four commits), `native_fp8_oproj_batch_microtest` at the real o_proj shape N=5120, K=6144:

- batch4 at M=2/4/5 and batch16 at M=8/16 all report `unequal_bf16=0 max_abs=0 cosine=1.0` against the scalar `w8a16_gemv`.
- The known-bad controls (output-bit mismatch, row-offset guard, non-finite) are all still refused, so the harness can fail.
- Before the fix the same test reported 3 unequal outputs at M=4.

Recorded on #932. `97375dfc` widened that oracle from batch4 to the shared batch16 template, since both instantiate `w8a16_gemv_batchm_impl` and the pair-sum was in the template, not in the M=4 wrapper.

**PTX, both targets** (see Test plan for the exact commands): `w8a16_gemv_batch4` and `w8a16_gemv_batch16` both still compile strict at `sm_121a` and `sm_90a`, 0 spill bytes, smem unchanged at 1152/1536 bytes. Register use moves slightly down, not up — sm_121a 48 -> 46 (batch4) and 72 -> 71 (batch16); sm_90a 55 -> 48 (batch4), 64 unchanged (batch16). The PTX itself of course differs: the change is a rounding-order change, and a kernel whose PTX did *not* move here would mean the fix had not landed.

**Host dispatch**, three new tests over the mock backend (`o_proj_tests.rs`): that 4 rows become one launch of the batched handle carrying the right `M`, that 2/5/16 rows chunk into `ceil(n/4)` launches with the per-group input and output offsets intact, that the projection allocates nothing, and that all four fallback conditions still reach the scalar kernel — `n == 1`, a null batched handle, a `hidden_size` that is not 128-aligned, and `Fp8PerRow` scales.

### Throughput: context, not a claim

The H100 native-FP8 ladder on the integration branch that carries these commits (`1166fc154`, 2026-09-11) measures **76.06 tok/s** aggregate at C=16 / 1024x256, against **73.8** on the 2026-09-06 reference `7c786cc` — which predates all four commits here. 4096x512 moves 61.4 -> 63.46 on the same pair. Rep-to-rep spread was 0.02-0.05%, so the +3% is outside noise.

That is 37 commits of difference including a full merge of `main`, and **it was not bisected**. Treat it as "these commits are in a tree that did not regress and measured a little better", not as a measured gain for this PR. The honest statement of what this PR is worth is the bit-parity result above; the C=4/C=16 A/B that would isolate the o_proj batching is still owed and needs GPU time (see below).

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda --lib` — **891 passed, 0 failed, 11 ignored** (902 total; 3 of them the new o_proj dispatch tests)
- [x] `cargo test -p spark-model --features cuda --lib o_proj` — **7 passed, 0 failed**
- [x] `cargo clippy -p spark-model -p spark-server --tests --features cuda,nccl` — clean, no warnings emitted
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `kernel shadow structure: OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] PTX, strict, both targets — `nvcc --ptx -arch=sm_121a` and `-arch=sm_90a` with `-DATLAS_NO_WARP_BLOCKSCALE_MMA --Werror all-warnings` on `kernels/gb10/common/w8a16_gemv_batch4.cu`, plus `--cubin -Xptxas -v` for the resource numbers quoted above. Both entry points emit at both arches; 0 spill stores / 0 spill loads.
- [x] Tested against real hardware — H100 bit-parity receipt above (2026-09-06)
- [ ] `scripts/hopper_ptx_gate.sh --hw gb10 --model qwen3.8-27b --jobs 8 --strict` — **the script does not exist on `main`**; it lives on the #895 campaign branch. The direct `nvcc` invocation above is the substitute and is reported rather than claimed as the gate.

## GB10 perf-gate records

This diff touches `crates/` and `kernels/`, both PERF_PATHs, so `record_covers` invalidates every committed `.benchmarks/` record the moment it lands. A GB10 re-measure is owed before merge — that is the required check talking, not a nicety, and it is also where the C=16 A/B that this PR's throughput section deliberately does not claim would come from.

## Notes for reviewers

The 128-alignment and `Fp8BlockScaled` guards are the kernel's real preconditions, not padding: `w8a16_gemv_batch4` indexes `block_scale[n/128][k/128]` and loads rows as `uint4`, so a per-row-scaled weight or an unaligned dim must keep the scalar path. The tests pin all four fallbacks rather than only the happy case.

`n > 1` rather than `n >= 4` is deliberate: the kernel handles M in 1..=4 and the tail group already relies on that, so there is no reason to hand 2 or 3 rows back to a loop that reads the weight matrix twice or three times.

The four commits are cherry-picked from `hopper/sm90-target-tdd-2026-09` (#895) with `-x` provenance lines. One extra commit on top adapts the new test to `main`: `ForwardContext` gained a `decode_step` field after the source branch was cut, and the test's struct literal now names it `false` — prefill shape, `attn_metadata` is `None`, and the output projection reads none of the decode scalars that flag guards. Same value and same rationale as the sibling `dense_ffn_native_batch_tests` fixture. No other conflict: the four picks applied clean.

The example is named `native_fp8_oproj_batch_microtest`, not the `w8a16_batch_bitparity_microtest` #932's acceptance criteria names. Same oracle and same shapes; the name is the one the source branch used and renaming it would orphan the H100 log above.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
