### PR TITLE
spark-server: size the SSM rollback ring from free memory instead of refusing (#915)

### DIFF
--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -275,8 +275,9 @@ impl TransformerModel {
         // therefore unreachable, and on this model it is NOT cheap: 8 slots x
         // max_batch x the full SSM blob (27B: 158.9 MB) = ~19.9 GB at batch 16,
         // allocated up front. Skip it when speculative decode is on.
-        // The ring-depth decision (env overrides + speculative/watchdog
-        // skip) is SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
+        // The ring-depth decision (the published `--ssm-decode-ring-slots` /
+        // #915 auto-fit depth, env overrides, speculative/watchdog skip) is
+        // SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
         // — spark-server's `preflight_reserve` calls the SAME helper, so the
         // GPU reservation and this allocation cannot drift. The scheduler
         // keys off `decode_rollback_ring_slots()`, so a 0 here disables save

--- a/crates/spark-model/src/ssm_reserve.rs
+++ b/crates/spark-model/src/ssm_reserve.rs
@@ -1,48 +1,32 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! SSOT for the Phase-C decode-rollback ring depth.
+//! SSOT for the SSM/linear-attention GPU reserve terms.
 //!
-//! Two call sites MUST agree on this number or a serve either
-//! under-reserves (runtime CUDA alloc failure after weights load) or
-//! over-reserves (preflight refuses batch sizes the runtime could fund):
+//! Every term here is computed TWICE — once by `spark-server`'s
+//! `preflight_reserve` before the weights load, once by the allocating call
+//! site (`SsmStatePool::new`, `TransformerModel::new`) after — and the two
+//! MUST agree or a serve either under-reserves (runtime CUDA alloc failure)
+//! or over-reserves (preflight refuses a configuration the runtime could
+//! fund). Each function below is the one place that decision is made.
 //!
-//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
-//!   reservation before weights load;
-//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
-//!
-//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
-//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
-//! speculative path does its rejection rollback through the verify snapshot,
-//! never this ring. Under `--speculative` the ring is unreachable, and it is
-//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
-//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
-//! while the runtime skipped it capped the native batch at ~20 on GB10
-//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
-//!
-//! Env contract (read HERE and nowhere else):
-//!
-//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
-//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
-//!   should keep loop re-steer); `=0` force-disables it even without spec.
-//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
-//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
-//!   never fire, so the ring is skipped.
+//! The Phase-C decode-rollback ring DEPTH — its publication cell, the
+//! `ATLAS_SSM_DECODE_RING` / `ATLAS_DISABLE_WATCHDOGS` contract and the #915
+//! auto-fit — lives in the `decode_ring` sibling module and is re-exported
+//! here, so every existing `ssm_reserve::decode_rollback_ring_slots` path is
+//! unchanged.
 
-/// Outcome of the ring-depth decision.
-///
-/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
-/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
-/// override — so the allocating call site can log the savings once.
-pub struct DecodeRingDecision {
-    pub slots: usize,
-    pub skip_reason: Option<&'static str>,
-}
+mod decode_ring;
+pub use decode_ring::{
+    DECODE_RING_FIT_LADDER, DecodeRingDecision, decode_rollback_ring_slots,
+    decode_rollback_ring_slots_with, fit_decode_ring_slots, parse_decode_ring_slots,
+    published_decode_ring_slots, set_decode_ring_slots, watchdogs_disabled_from_value,
+};
 
 /// Number of SSM-pool slots the MTP/DFlash VERIFY state pools (per-token
 /// intermediates + pre-verify checkpoints) must cover.
 ///
 /// Three call sites MUST agree on this number (same contract as the decode
-/// ring above):
+/// ring in `decode_ring`):
 ///
 /// * `spark-server` `preflight_reserve` — sizes the pre-load GPU reserve;
 /// * `SsmStatePool::new` — allocates the intermediate/checkpoint pools;
@@ -425,71 +409,6 @@ pub fn ssm_replay_ring_bytes(
     mtp_state_slots: usize,
 ) -> usize {
     mtp_state_slots * k_ceiling.saturating_sub(1) * num_ssm_layers * row_bytes
-}
-
-/// Decide the per-sequence decode-rollback ring depth.
-///
-/// `use_speculative` MUST be the same flag `factory::build_model` receives
-/// (`--speculative || --dflash` as plumbed by spark-server) at every call
-/// site, or preflight and allocation diverge.
-pub fn decode_rollback_ring_slots(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-) -> DecodeRingDecision {
-    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
-    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
-    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
-    decode_rollback_ring_slots_with(
-        num_ssm_layers,
-        use_speculative,
-        ring_override.as_deref(),
-        watchdogs_disabled,
-    )
-}
-
-fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
-    value
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v == "1" || v == "true"
-        })
-        .unwrap_or(false)
-}
-
-fn decode_rollback_ring_slots_with(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-    ring_override: Option<&str>,
-    watchdogs_disabled: bool,
-) -> DecodeRingDecision {
-    if num_ssm_layers == 0 {
-        return DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        };
-    }
-    match ring_override {
-        Some("1") => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-        Some("0") => DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        },
-        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
-            slots: 0,
-            skip_reason: Some(if use_speculative {
-                "speculative decode active"
-            } else {
-                "watchdogs disabled"
-            }),
-        },
-        _ => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-    }
 }
 
 /// Outcome of the Marconi snapshot-slot decision.

--- a/crates/spark-model/src/ssm_reserve/decode_ring.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT for the Phase-C decode-rollback ring DEPTH.
+//!
+//! A sibling of `ssm_reserve.rs` (which sits over the 500-line cap),
+//! following the `per_sequence_state.rs` precedent: the depth decision, its
+//! publication cell and the #915 auto-fit live here.
+//!
+//! Two call sites MUST agree on this number or a serve either under-reserves
+//! (runtime CUDA alloc failure after weights load) or over-reserves
+//! (preflight refuses batch sizes the runtime could fund):
+//!
+//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
+//!   reservation before weights load;
+//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
+//!
+//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
+//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
+//! speculative path does its rejection rollback through the verify snapshot,
+//! never this ring. Under `--speculative` the ring is unreachable, and it is
+//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
+//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
+//! while the runtime skipped it capped the native batch at ~20 on GB10
+//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
+//!
+//! ## Why the depth is now sized from free memory (#915)
+//!
+//! The depth was a CONSTANT (8) multiplied by `--max-batch-size`, so it grew
+//! with a flag that says nothing about what the card can hold. Serving
+//! Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) asked
+//! for 8 × 32 × 151.5 MiB = 37.88 GiB of ring alone — an inference reserve of
+//! 45,823 MiB against a 71.3 GiB budget with 57.2 GiB of weights — and the
+//! serve REFUSED to boot (rental H100, 2026-09-05). The recipe workaround was
+//! `--max-batch-size 4`, i.e. paying for rollback depth with four fifths of
+//! the serve's concurrency.
+//!
+//! The ring degrades gracefully with depth (fewer retained boundaries = fewer
+//! reachable re-steer anchors, never wrong output), so preflight now SHRINKS
+//! it down the [`DECODE_RING_FIT_LADDER`] until the reserve fits and publishes
+//! the chosen depth through [`set_decode_ring_slots`], instead of refusing.
+//! Refusal is kept only for the case where even depth 0 does not fit.
+//!
+//! Env contract (read HERE and nowhere else):
+//!
+//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
+//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
+//!   should keep loop re-steer); `=0` force-disables it even without spec.
+//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
+//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
+//!   never fire, so the ring is skipped.
+
+/// Outcome of the ring-depth decision.
+///
+/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
+/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
+/// override, a published `--ssm-decode-ring-slots N` or the #915 auto-fit —
+/// so the allocating call site can log the savings once.
+pub struct DecodeRingDecision {
+    pub slots: usize,
+    pub skip_reason: Option<&'static str>,
+}
+
+/// Depths preflight's #915 auto-fit may choose from, LARGEST FIRST.
+///
+/// Halving rather than decrementing: each rung halves the ring's share of
+/// the reserve, so at most four steps separate "the default" from "no ring",
+/// and every rung is a power of two — the ring's slot assignment is
+/// `(next_slot + 1) % capacity` (`SsmDecodeRing::record`), which is exact at
+/// any capacity but wraps most evenly at these.
+///
+/// 8 is [`atlas_kernels::DECODE_ROLLBACK_RING_SLOTS`] and covers the
+/// 3-repeat fuzzy loop detector with margin; 1 still anchors a single clean
+/// boundary; 0 means the sequence hard-stops instead of re-steering
+/// (`RollbackFallback::NoSsmSnapshot` — an honest decline, never a partial
+/// rewind).
+pub const DECODE_RING_FIT_LADDER: [usize; 5] = [8, 4, 2, 1, 0];
+
+/// The depth published by the serve command line (`--ssm-decode-ring-slots
+/// N`) or by preflight's auto-fit. Written once, read by BOTH sizing call
+/// sites — same first-write-wins cell pattern as
+/// [`super::set_ssm_rollback_mode`].
+///
+/// Absent is NOT a value: `--ssm-decode-ring-slots auto` publishes nothing,
+/// so the documented `ATLAS_SSM_DECODE_RING` fallback stays reachable and
+/// preflight can publish the auto-fit depth later in the same boot.
+static DECODE_RING_SLOTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Publish the decode-ring depth. Returns the value in force (first write
+/// wins, matching `gdn_flags::set_from_cli`): an explicit
+/// `--ssm-decode-ring-slots N` is published before preflight runs, so the
+/// auto-fit's later write is a no-op and an operator's explicit depth is
+/// never silently shrunk.
+pub fn set_decode_ring_slots(slots: usize) -> usize {
+    let _ = DECODE_RING_SLOTS.set(slots);
+    *DECODE_RING_SLOTS.get().expect("just set")
+}
+
+/// The published depth, or `None` when nothing has been published.
+///
+/// Does NOT initialize the cell — preflight asks this to tell an EXPLICIT
+/// depth (auto-fit disabled, refuse as before) from `auto` (auto-fit
+/// allowed), and asking must not itself seal the decision.
+pub fn published_decode_ring_slots() -> Option<usize> {
+    DECODE_RING_SLOTS.get().copied()
+}
+
+/// SSOT parse for the `--ssm-decode-ring-slots` value: `auto` (`None` — size
+/// it from free memory at preflight) or an explicit `0..=8`.
+///
+/// `validate_serve_args` and `publish_kernel_flags` both go through THIS, so
+/// what the CLI accepts and what it publishes cannot drift.
+pub fn parse_decode_ring_slots(s: &str) -> Result<Option<usize>, String> {
+    if s == "auto" {
+        return Ok(None);
+    }
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("unknown ssm-decode-ring-slots '{s}' (valid: auto, 0..=8)"))?;
+    if n > atlas_kernels::DECODE_ROLLBACK_RING_SLOTS {
+        return Err(format!(
+            "ssm-decode-ring-slots {n} exceeds the {} the ring is sized for",
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        ));
+    }
+    Ok(Some(n))
+}
+
+/// Decide the per-sequence decode-rollback ring depth.
+///
+/// `use_speculative` MUST be the same flag `factory::build_model` receives
+/// (`--speculative || --dflash` as plumbed by spark-server) at every call
+/// site, or preflight and allocation diverge.
+pub fn decode_rollback_ring_slots(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+) -> DecodeRingDecision {
+    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
+    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
+    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
+    decode_rollback_ring_slots_with(
+        num_ssm_layers,
+        use_speculative,
+        published_decode_ring_slots(),
+        ring_override.as_deref(),
+        watchdogs_disabled,
+    )
+}
+
+/// `ATLAS_DISABLE_WATCHDOGS` truthiness — trimmed, case-insensitive, `1` or
+/// `true` only (mirrors spark-server's `parse_disable_watchdogs`).
+pub fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
+    value
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        })
+        .unwrap_or(false)
+}
+
+/// Pure core of [`decode_rollback_ring_slots`] (env-free, unit-testable).
+///
+/// Precedence, highest first:
+///
+/// 1. no SSM layers — there is no recurrent state to snapshot;
+/// 2. `published` — `--ssm-decode-ring-slots N`, or the depth preflight's
+///    auto-fit chose. It outranks the env override AND the implicit skips for
+///    the same reason `ATLAS_SSM_DECODE_RING=1` always has: an operator (or a
+///    reserve that has already been sized against free memory) asking for a
+///    specific depth must get that depth on BOTH sides, or the two diverge;
+/// 3. `ATLAS_SSM_DECODE_RING=1|0` — the legacy spelling of "8" and "0";
+/// 4. the implicit skips (speculative decode, watchdogs off);
+/// 5. the default depth.
+pub fn decode_rollback_ring_slots_with(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+    published: Option<usize>,
+    ring_override: Option<&str>,
+    watchdogs_disabled: bool,
+) -> DecodeRingDecision {
+    if num_ssm_layers == 0 {
+        return DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        };
+    }
+    if let Some(slots) = published {
+        return DecodeRingDecision {
+            slots,
+            skip_reason: None,
+        };
+    }
+    match ring_override {
+        Some("1") => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+        Some("0") => DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        },
+        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
+            slots: 0,
+            skip_reason: Some(if use_speculative {
+                "speculative decode active"
+            } else {
+                "watchdogs disabled"
+            }),
+        },
+        _ => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+    }
+}
+
+/// Largest [`DECODE_RING_FIT_LADDER`] depth `<= start_slots` whose ring term
+/// still fits in `free_mem` alongside everything else the reserve needs
+/// (#915). Pure — preflight owns the bytes, this owns the ladder.
+///
+/// `bytes_per_ring_slot` is ONE depth unit: `max_batch_size × the per-seq SSM
+/// state blob`, the same product `ssm_snapshot_bytes` multiplies the depth by.
+///
+/// Returns 0 when nothing fits — including the case where the rest of the
+/// reserve ALONE exceeds `free_mem`, which is the caller's cue to refuse with
+/// the existing suggested-batch text rather than to boot a ringless serve.
+pub fn fit_decode_ring_slots(
+    start_slots: usize,
+    reserve_without_ring: usize,
+    bytes_per_ring_slot: usize,
+    free_mem: usize,
+) -> usize {
+    DECODE_RING_FIT_LADDER
+        .iter()
+        .copied()
+        .filter(|&slots| slots <= start_slots)
+        .find(|&slots| {
+            reserve_without_ring.saturating_add(slots.saturating_mul(bytes_per_ring_slot))
+                <= free_mem
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod decode_ring_tests;

--- a/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`ssm_reserve::decode_ring`). A sibling file via
+//! `#[path]` — the `ssm_reserve_tests.rs` idiom — so both stay under the
+//! 500-line cap.
+//!
+//! Every byte figure below is the 2026-09-05 rental-H100 configuration from
+//! issue #915 (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe): 48 GDN
+//! layers, 151.5 MiB of SSM state per sequence, `--max-batch-size 32`,
+//! inference reserve 45,823 MiB, 57.2 GiB of weights inside a 71.3 GiB
+//! budget. Pinning the arithmetic here is what stops the fit and the reserve
+//! from drifting apart.
+use super::*;
+
+/// Per-sequence SSM state blob: 48 GDN layers x (h + conv) = 158,859,264 B,
+/// the "151.5 MiB/seq" every #915 log line quotes. Same derivation as the
+/// `H_BLOB`/`CONV_BLOB` constants in `ssm_reserve_tests.rs`.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// One unit of ring depth at `--max-batch-size 32`.
+const SLOT_BYTES: usize = 32 * PER_SEQ_BLOB;
+/// The 45,823 MiB inference reserve MINUS its 8-slot ring (38,784 MiB): the
+/// part of the #915 reserve that does not scale with ring depth.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+#[test]
+fn decode_ring_decision_matrix() {
+    let decide = |layers, spec, override_value, watchdogs| {
+        let decision =
+            decode_rollback_ring_slots_with(layers, spec, None, override_value, watchdogs);
+        (decision.slots, decision.skip_reason)
+    };
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+
+    for value in ["1", "true", " TRUE "] {
+        assert!(
+            watchdogs_disabled_from_value(Some(value)),
+            "value={value:?}"
+        );
+    }
+    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
+        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
+    }
+
+    assert_eq!(decide(0, false, Some("1"), false), (0, None));
+    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
+    assert_eq!(decide(48, false, Some("0"), false), (0, None));
+    assert_eq!(
+        decide(48, true, None, false),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(
+        decide(48, false, None, true),
+        (0, Some("watchdogs disabled"))
+    );
+    assert_eq!(
+        decide(48, true, Some("invalid"), true),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(decide(48, false, None, false), (ring, None));
+}
+
+/// A published depth is what BOTH sizing call sites must see — preflight
+/// sized the reserve against it, so `TransformerModel::new` allocating
+/// anything else re-opens the divergence this module exists to close.
+#[test]
+fn a_published_depth_outranks_the_default_the_env_and_the_skips() {
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+    let d = decode_rollback_ring_slots_with(48, false, Some(2), None, false);
+    assert_eq!((d.slots, d.skip_reason), (2, None));
+    // Against the legacy env spelling of "8" ...
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, false, Some(2), Some("1"), false).slots,
+        2
+    );
+    // ... and against BOTH implicit skips, exactly as ATLAS_SSM_DECODE_RING=1
+    // already did: an explicit depth is an explicit depth.
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, true, Some(4), None, true).slots,
+        4
+    );
+    // A published 0 is an explicit off, not an implicit skip: no skip_reason,
+    // so the allocating call site does not log a saving nobody asked for.
+    let zero = decode_rollback_ring_slots_with(48, false, Some(0), None, false);
+    assert_eq!((zero.slots, zero.skip_reason), (0, None));
+    // No SSM layers still outranks everything — no recurrent state to snapshot.
+    assert_eq!(
+        decode_rollback_ring_slots_with(0, false, Some(ring), None, false).slots,
+        0
+    );
+}
+
+/// The value the CLI accepts and the value it publishes come from ONE parse.
+#[test]
+fn parse_accepts_auto_and_zero_through_eight() {
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("0"), Ok(Some(0)));
+    assert_eq!(
+        parse_decode_ring_slots("8"),
+        Ok(Some(atlas_kernels::DECODE_ROLLBACK_RING_SLOTS))
+    );
+    // Above the ceiling the ring is sized for, and anything non-numeric, is a
+    // startup refusal — never a silent clamp to 8.
+    assert!(parse_decode_ring_slots("9").is_err());
+    assert!(parse_decode_ring_slots("AUTO").is_err());
+    assert!(parse_decode_ring_slots("").is_err());
+    assert!(parse_decode_ring_slots("-1").is_err());
+}
+
+/// The #915 boot: 7,039 MiB of non-ring reserve, 14.1 GiB free after 57.2 GiB
+/// of weights inside a 71.3 GiB budget. Depth 8 asks 37.88 GiB and refuses;
+/// depth 1 fits and boots.
+#[test]
+fn autofit_picks_the_largest_fitting_depth() {
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+    let fitted = fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free);
+    assert_eq!(fitted, 1, "largest ladder depth that fits in 14.1 GiB");
+    assert!(RESERVE_WITHOUT_RING + fitted * SLOT_BYTES <= free);
+    assert!(
+        RESERVE_WITHOUT_RING + 2 * SLOT_BYTES > free,
+        "and 2 does not"
+    );
+
+    // With more room the ladder lands on 4 — it never picks 5, 6 or 7, so a
+    // fitted depth is always a rung the operator can recognise.
+    let roomier = 30 * 1024 * 1024 * 1024;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, roomier),
+        4
+    );
+    // Already fitting at the requested depth is left alone.
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        8
+    );
+    // The fit never RAISES a depth: a request below the ladder top is a
+    // ceiling, not a target.
+    assert_eq!(
+        fit_decode_ring_slots(2, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        2
+    );
+}
+
+/// When the rest of the reserve alone exceeds free memory the ring is not the
+/// problem: the fit bottoms out at 0 and the caller must still refuse.
+#[test]
+fn autofit_is_zero_when_even_a_ringless_reserve_does_not_fit() {
+    let free = RESERVE_WITHOUT_RING - 1;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free),
+        0
+    );
+    assert!(
+        RESERVE_WITHOUT_RING > free,
+        "0 slots is still over budget — the caller refuses rather than booting ringless"
+    );
+    // A zero-byte ring (pure-attention model) is a no-op, not a division trap.
+    assert_eq!(fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, 0, free), 0);
+}
+
+#[test]
+fn the_fit_ladder_is_descending_and_starts_at_the_wired_default() {
+    assert_eq!(
+        DECODE_RING_FIT_LADDER[0],
+        atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+    );
+    assert_eq!(*DECODE_RING_FIT_LADDER.last().unwrap(), 0);
+    assert!(
+        DECODE_RING_FIT_LADDER.windows(2).all(|w| w[0] > w[1]),
+        "`fit_decode_ring_slots` returns the FIRST fitting rung, so the ladder \
+         must be strictly descending or it would return a smaller depth than fits"
+    );
+}

--- a/crates/spark-model/src/ssm_reserve_tests.rs
+++ b/crates/spark-model/src/ssm_reserve_tests.rs
@@ -383,41 +383,9 @@ fn rollback_mode_parses_and_rejects() {
     assert!(SsmRollbackMode::from_str("").is_err());
 }
 
-#[test]
-fn decode_ring_decision_matrix() {
-    let decide = |layers, spec, override_value, watchdogs| {
-        let decision = decode_rollback_ring_slots_with(layers, spec, override_value, watchdogs);
-        (decision.slots, decision.skip_reason)
-    };
-    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
-
-    for value in ["1", "true", " TRUE "] {
-        assert!(
-            watchdogs_disabled_from_value(Some(value)),
-            "value={value:?}"
-        );
-    }
-    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
-        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
-    }
-
-    assert_eq!(decide(0, false, Some("1"), false), (0, None));
-    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
-    assert_eq!(decide(48, false, Some("0"), false), (0, None));
-    assert_eq!(
-        decide(48, true, None, false),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(
-        decide(48, false, None, true),
-        (0, Some("watchdogs disabled"))
-    );
-    assert_eq!(
-        decide(48, true, Some("invalid"), true),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(decide(48, false, None, false), (ring, None));
-}
+// The decode-rollback ring's depth decision, its publication cell and the
+// #915 auto-fit are tested in `ssm_reserve/decode_ring_tests.rs`, next to the
+// module that owns them.
 
 // ─────────────────── Marconi snapshot-slot gate (2026-08-31) ───────────────────
 //

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -514,7 +514,9 @@ pub trait Model: Send + Sync {
     /// model keeps no decode-rollback snapshots — appropriate for
     /// pure-attention models and for SSM models when the snapshot pool
     /// has no capacity reserved. SSM models with a populated pool
-    /// override to `ROLLBACK_RESTEER_CAP + 1`.
+    /// override to the depth `ssm_reserve::decode_rollback_ring_slots`
+    /// decided — 8 by default, or whatever `--ssm-decode-ring-slots` /
+    /// preflight's free-memory fit published (#915).
     fn decode_rollback_ring_slots(&self) -> usize {
         0
     }

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -246,6 +246,36 @@ pub struct ServeArgs {
     #[arg(long, default_value = "snapshot")]
     pub ssm_rollback_mode: String,
 
+    /// Phase-C SSM decode-rollback ring depth: `auto` (default) or an
+    /// explicit slot count in `0..=8`.
+    ///
+    /// The ring retains boundary SSM-state snapshots so a watchdog re-steer
+    /// can rewind the recurrent state; its cost is `depth x
+    /// --max-batch-size x the per-sequence SSM state blob`, which on the 27B
+    /// (151.5 MiB/seq) at the default depth 8 and `--max-batch-size 32` is
+    /// 37.88 GiB — the whole reason an 80 GB H100 refused the hopper recipe
+    /// (#915, rental H100 2026-09-05: inference reserve 45,823 MiB against a
+    /// 71.3 GiB budget carrying 57.2 GiB of weights).
+    ///
+    /// `auto` keeps the depth at 8 (or the existing skips — the ring is
+    /// unreachable under `--speculative`/`--dflash` and with watchdogs off)
+    /// and lets preflight SHRINK it down `8, 4, 2, 1, 0` until the reserve
+    /// fits, logging the formula at WARN. Depth degrades gracefully: fewer
+    /// retained boundaries means fewer reachable re-steer anchors, and a
+    /// sequence that finds none hard-stops instead of re-steering — never a
+    /// partial SSM rewind.
+    ///
+    /// An explicit `N` pins the depth on BOTH sides (reserve and allocation)
+    /// and disables the fit: a serve that does not fit at `N` is REFUSED with
+    /// the formula, rather than booted at a depth the recipe does not record.
+    /// `0` disables the ring outright; 8 is the wired default and the
+    /// arithmetic ceiling.
+    ///
+    /// Legacy: `ATLAS_SSM_DECODE_RING=1|0` still means depth 8 and 0. It is
+    /// only consulted when this flag is `auto` — absent is not a value.
+    #[arg(long, default_value = "auto", value_name = "AUTO_OR_N")]
+    pub ssm_decode_ring_slots: String,
+
     /// Fused GDN output-norm kernel on the decode path (default: off).
     ///
     /// Required by `--ssm-h-dtype f16`: the FP16 h-state twins live on the

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -180,6 +180,19 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
             "use snapshot (default, wired) or replay (experimental scaffold).",
         ));
     }
+    // `--ssm-decode-ring-slots`: same SSOT rule — the parse that validates is
+    // the parse `publish_kernel_flags` publishes through (#915).
+    if let Err(why) = spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+    {
+        v.push(Violation::new(
+            format!(
+                "--ssm-decode-ring-slots '{}' is not a valid value.",
+                args.ssm_decode_ring_slots
+            ),
+            why,
+            "use auto (default: preflight sizes the ring from free memory) or 0..=8.",
+        ));
+    }
     // #435: the exact-verify arm's kernels are FP32 readers, so an FP16
     // h-state pool disables it (`GdnFlags::verify_exact_active`). Honouring
     // `--ssm-h-dtype f16` by SILENTLY ignoring an explicit `--exact-verify`

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -234,6 +234,27 @@ fn ssm_rollback_mode_values_and_typos() {
 }
 
 #[test]
+fn ssm_decode_ring_slots_values_and_typos() {
+    // `auto` is the default and must validate: it is what lets preflight size
+    // the ring from free memory instead of refusing the boot (#915).
+    let a = parse(&[]);
+    assert_eq!(a.ssm_decode_ring_slots, "auto");
+    assert!(validate_serve_args(&a).is_ok());
+    for depth in ["0", "1", "2", "4", "8"] {
+        assert!(
+            validate_serve_args(&parse(&["--ssm-decode-ring-slots", depth])).is_ok(),
+            "depth {depth} is inside the ring's range"
+        );
+    }
+    // Above the wired ceiling, and anything non-numeric, is refused through
+    // the model-side parse (SSOT with the publication parse) — never clamped.
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "9"])).unwrap_err();
+    assert!(err.contains("--ssm-decode-ring-slots"), "{err}");
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "AUTO"])).unwrap_err();
+    assert!(err.contains("auto"), "names the valid values: {err}");
+}
+
+#[test]
 fn a_mistyped_mtp_gate_is_still_caught() {
     // Making the flag optional must not make its typo check optional.
     let err = validate_serve_args(&parse(&["--mtp-gate", "always"])).unwrap_err();

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -81,6 +81,24 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
              line's ({rollback:?}) did NOT take effect"
         );
     }
+    // `--ssm-decode-ring-slots`: ABSENT IS NOT A VALUE. `auto` (the clap
+    // default) publishes NOTHING, so the documented `ATLAS_SSM_DECODE_RING`
+    // fallback stays reachable AND preflight can publish the depth it fitted
+    // to free memory later in the same boot (#915). An explicit N is
+    // published here, before preflight runs, which is exactly what makes the
+    // auto-fit's later write a no-op — an operator's pinned depth is refused
+    // rather than silently shrunk.
+    if let Some(slots) =
+        spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+            .expect("validated by validate_serve_args")
+    {
+        let in_force = spark_model::ssm_reserve::set_decode_ring_slots(slots);
+        if in_force != slots {
+            tracing::warn!(
+                "ssm-decode-ring-slots was already resolved ({in_force}); the command                  line's ({slots}) did NOT take effect"
+            );
+        }
+    }
     // `--prefill-varlen-batch`: its own single-value cell, so it publishes
     // independently of the GDN trio. Absent publishes nothing and the
     // documented `ATLAS_PREFILL_VARLEN` fallback stays reachable.
@@ -116,7 +134,7 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
          exact_verify={} ssm_tail_midchunk={} mtp_gate={} ssm_rollback_mode={:?} \
-         prefill_varlen_batch={}",
+         ssm_decode_ring_slots={} prefill_varlen_batch={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
@@ -130,6 +148,12 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
             "auto"
         },
         spark_model::ssm_reserve::ssm_rollback_mode(),
+        // RESOLVED: `auto` until something publishes a depth. Preflight logs
+        // the fitted depth (and the formula behind it) when it shrinks one.
+        match spark_model::ssm_reserve::published_decode_ring_slots() {
+            Some(slots) => slots.to_string(),
+            None => "auto".to_string(),
+        },
         // RESOLVED, not the raw argument — may come from the environment.
         spark_model::layers::ops::prefill_varlen_enabled(),
     );

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -8,7 +8,9 @@ use atlas_core::config::ModelConfig;
 
 use crate::cli;
 
+mod decode_ring;
 mod per_sequence_state;
+mod refusal;
 mod ssm_h_fp16;
 use {per_sequence_state::per_sequence_reserve, ssm_h_fp16::ssm_h_fp16_preconditions};
 
@@ -156,35 +158,6 @@ pub(crate) fn preflight_reserve(
         args.max_batch_size,
     )
     .total_bytes();
-    // SSM snapshot pool = Marconi prefix-cache region + Phase-C
-    // decode-rollback ring. The decode ring is sized per active
-    // sequence (ring slots × `max_batch_size`) and only allocated for SSM
-    // models. SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots`
-    // makes the SAME decision (same env vars, same constant) the runtime
-    // allocation in `TransformerModel::new` makes — including the skip under
-    // `--speculative`/`--dflash` (the ring's save/rollback path only runs on
-    // plain decode; the spec path rolls back through the verify snapshot).
-    // Reserving the ring unconditionally while the runtime skipped it
-    // stranded ~38 GB at bs32 on the 27B (75.2 GB SSM reserve vs an 85.2 GB
-    // budget at util 0.70) and capped the native batch at ~20.
-    // `use_speculative` here MUST mirror what `build_model` passes:
-    // `args.speculative || args.dflash`.
-    // Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present ⇒ restore the old
-    // unconditional reservation (accounting-only, safe over-reserve;
-    // presence-style — `=0` is NOT "off").
-    let decode_ring_slots = if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
-        if config.num_ssm_layers() > 0 {
-            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
-        } else {
-            0
-        }
-    } else {
-        spark_model::ssm_reserve::decode_rollback_ring_slots(
-            config.num_ssm_layers(),
-            args.speculative || args.dflash,
-        )
-        .slots
-    };
     // Marconi snapshot region. SSOT:
     // `spark_model::ssm_reserve::marconi_snapshot_slots` makes the SAME
     // decision (same env var, same predicate) the runtime allocation in
@@ -212,9 +185,12 @@ pub(crate) fn preflight_reserve(
                 / (1024 * 1024),
         );
     }
-    let ssm_snapshot_bytes = (marconi.slots + decode_ring_slots * args.max_batch_size)
-        * config.num_ssm_layers()
-        * (h_state_bytes + conv_state_bytes);
+    // The per-sequence SSM state blob — `num_ssm_layers x (h + conv)`, 151.5
+    // MiB on the 27B. Both snapshot regions are whole multiples of it:
+    // Marconi reserves one per cache slot, the decode ring one per active
+    // sequence per ring slot.
+    let per_seq_blob = config.num_ssm_layers() * (h_state_bytes + conv_state_bytes);
+    let marconi_bytes = marconi.slots * per_seq_blob;
     // Same predicate as the pool term: DFlash IS a speculative serve and
     // pays the same graph/JIT/scratch overheads the 4 GB headroom exists for.
     let cuda_headroom: usize = if spec_on_pool {
@@ -234,59 +210,60 @@ pub(crate) fn preflight_reserve(
             0
         }
     };
-    let inference_reserve: usize = ssm_pool_bytes
+    // Everything the reserve needs that does NOT scale with ring depth. The
+    // ring is separated out because it is the only term preflight is allowed
+    // to shrink (#915): rollback depth degrades gracefully, the batch and the
+    // pools it sizes do not.
+    let fixed_reserve: usize = ssm_pool_bytes
         + ssm_h_stage_bytes
         + ssm_replay_ring
-        + ssm_snapshot_bytes
+        + marconi_bytes
         + gdn_two_phase_bytes
         + cuda_headroom
         + per_sequence_reserve(args, config);
+    // Phase-C decode-rollback ring: the depth the flags/env ask for, then the
+    // largest depth that actually fits alongside everything above. Both steps
+    // are SSOT'd in `decode_ring` (which publishes the fitted depth so
+    // `TransformerModel::new` allocates exactly what was reserved).
+    let ring_requested = decode_ring::requested_slots(args, config);
+    let ring_slot_bytes = decode_ring::slot_bytes(args, per_seq_blob);
+    let fit = decode_ring::autofit(
+        args,
+        ring_requested,
+        ring_slot_bytes,
+        per_seq_blob,
+        fixed_reserve + buffer_arena_bytes,
+        free_mem,
+    );
+    if let Some(warning) = &fit.warning {
+        tracing::warn!("SSM decode-rollback ring auto-fit — {}", warning);
+    }
+    let ssm_snapshot_bytes = marconi_bytes + fit.slots * ring_slot_bytes;
+    let inference_reserve: usize = fixed_reserve + fit.slots * ring_slot_bytes;
     let total_reserve = inference_reserve + buffer_arena_bytes;
     if total_reserve > free_mem {
-        let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
-        let free_gb = free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
-        let fixed = ssm_pool_bytes + ssm_h_stage_bytes + ssm_snapshot_bytes + cuda_headroom;
-        let budget_for_seq_term = free_mem.saturating_sub(fixed) / 2;
-        let per_tok_bytes = {
-            let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
-            let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
-            let nv = config.linear_num_value_heads;
-            let conv_dim = key_dim * 2 + value_dim;
-            if conv_dim > 0 && config.num_ssm_layers() > 0 {
-                (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
-            } else {
-                0
-            }
-        };
-        let suggested = budget_for_seq_term
-            .checked_div(per_tok_bytes)
-            .map(|q| q.max(2048))
-            .unwrap_or(0);
-        let hint = if suggested > 0 && suggested < args.max_seq_len {
-            format!(
-                " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
-                suggested
-            )
-        } else if args.max_batch_size > 1 {
-            " Reduce --max-batch-size.".to_string()
-        } else {
-            " Use a smaller model or a GPU with more memory.".to_string()
-        };
-        anyhow::bail!(
-            "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
-             (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}",
-            need_gb,
-            free_gb,
-            args.max_seq_len,
-            args.max_batch_size,
-            hint,
-        );
+        return Err(refusal::reserve_refusal(
+            args,
+            config,
+            refusal::Refusal {
+                total_reserve,
+                free_mem,
+                seq_len_independent: ssm_pool_bytes
+                    + ssm_h_stage_bytes
+                    + ssm_snapshot_bytes
+                    + cuda_headroom,
+                ring_requested,
+                ring_slots: fit.slots,
+                per_seq_blob,
+            },
+        ));
     }
     tracing::info!(
-        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB)",
+        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB); {}",
         inference_reserve / (1024 * 1024),
         buffer_arena_bytes / (1024 * 1024),
         free_mem as f64 / (1024.0 * 1024.0 * 1024.0),
+        decode_ring::formula(fit.slots, args.max_batch_size, per_seq_blob),
     );
     // Q09: per-component breakdown so future MTP/spec-decode reserve
     // jumps are diagnosable from the log alone. Each line is dropped at

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The decode-rollback ring reserve term and its #915 auto-fit.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), following
+//! the `per_sequence_state.rs` precedent: the term, the formula it prints and
+//! the shrink decision live here; `preflight.rs` gains only the calls.
+//!
+//! # Why this term needed a fit and not just a number
+//!
+//! `ssm_snapshot_bytes` multiplies a CONSTANT ring depth (8) by
+//! `--max-batch-size`, a flag that says nothing about what the card can hold.
+//! Serving Qwen/Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) that
+//! is 8 x 32 x 151.5 MiB = 37.88 GiB of ring inside a 45,823 MiB inference
+//! reserve, against a 71.3 GiB budget already carrying 57.2 GiB of weights —
+//! and the serve REFUSED to boot (rental H100, 2026-09-05, evidence cell
+//! `qwen38.atlas.a.lat.c1`). The shipped workaround was `--max-batch-size 4`
+//! (cell `qwen38.atlas.c.lat.c1`, reserve 8.54 GiB, GO in 22 s): paying for
+//! rollback depth with four fifths of the serve's concurrency.
+//!
+//! Ring depth degrades GRACEFULLY (fewer retained boundaries = fewer
+//! reachable re-steer anchors; a sequence that finds none hard-stops through
+//! `RollbackFallback::NoSsmSnapshot`, which is an honest decline, never a
+//! partial SSM rewind). Batch does not: it is the serve's concurrency. So the
+//! term that yields is the ring, and it yields down
+//! `ssm_reserve::DECODE_RING_FIT_LADDER` until the whole reserve fits.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+const MIB: f64 = 1024.0 * 1024.0;
+const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// The ring depth preflight will reserve for, and the warning the operator
+/// must see when it is not the depth the flags asked for.
+pub(super) struct RingFit {
+    pub(super) slots: usize,
+    /// `Some` only when the auto-fit SHRANK the ring — logged at WARN by the
+    /// caller, because a serve that quietly kept less rollback depth than its
+    /// recipe records is a serve whose re-steer behaviour cannot be
+    /// reproduced from the recipe.
+    pub(super) warning: Option<String>,
+}
+
+/// The ring depth the flags and environment ask for, before any fit.
+///
+/// SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots` makes the
+/// SAME decision (same published cell, same env vars, same constant) the
+/// runtime allocation in `TransformerModel::new` makes — including the skip
+/// under `--speculative`/`--dflash` (the ring's save/rollback path only runs
+/// on plain decode; the spec path rolls back through the verify snapshot).
+/// Reserving the ring unconditionally while the runtime skipped it stranded
+/// ~38 GB at bs32 on the 27B and capped the native batch at ~20.
+/// `use_speculative` here MUST mirror what `build_model` passes:
+/// `args.speculative || args.dflash`.
+///
+/// Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present => restore the old
+/// unconditional reservation (accounting-only, safe over-reserve;
+/// presence-style — `=0` is NOT "off").
+pub(super) fn requested_slots(args: &cli::ServeArgs, config: &ModelConfig) -> usize {
+    if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
+        return if config.num_ssm_layers() > 0 {
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        } else {
+            0
+        };
+    }
+    spark_model::ssm_reserve::decode_rollback_ring_slots(
+        config.num_ssm_layers(),
+        args.speculative || args.dflash,
+    )
+    .slots
+}
+
+/// Bytes ONE unit of ring depth costs: `--max-batch-size` x the per-sequence
+/// SSM state blob. The same product `ssm_snapshot_bytes` multiplies the depth
+/// by, factored out so the fit and the reserve cannot use different arithmetic.
+pub(super) fn slot_bytes(args: &cli::ServeArgs, per_seq_blob: usize) -> usize {
+    args.max_batch_size * per_seq_blob
+}
+
+/// `snapshots x batch x per-seq state bytes`, spelled out (issue #915's third
+/// bullet: preflight must print the formula so an operator can see why the
+/// reserve asked for what it asked for). SSOT for the INFO line, the shrink
+/// WARN and the refusal text, so all three quote the same arithmetic.
+pub(super) fn formula(slots: usize, max_batch: usize, per_seq_blob: usize) -> String {
+    format!(
+        "ring: {slots} slots x {max_batch} seqs x {:.1} MB/seq = {:.2} GB",
+        per_seq_blob as f64 / MIB,
+        (slots * max_batch * per_seq_blob) as f64 / GIB,
+    )
+}
+
+/// Shrink the ring until the reserve fits, or leave it alone.
+///
+/// `reserve_without_ring` is the WHOLE reserve minus the ring term
+/// (`inference_reserve + buffer_arena_bytes`), so the caller adds exactly
+/// `slots * slot_bytes` back.
+///
+/// Leaves the depth untouched — returning no warning — when the reserve
+/// already fits, when there is no ring to shrink, or when the depth is
+/// EXPLICIT (`--ssm-decode-ring-slots N`, published before preflight runs):
+/// an operator who named a depth gets that depth or a refusal, never a
+/// silent third answer.
+pub(super) fn autofit(
+    args: &cli::ServeArgs,
+    requested: usize,
+    slot_bytes: usize,
+    per_seq_blob: usize,
+    reserve_without_ring: usize,
+    free_mem: usize,
+) -> RingFit {
+    let asked = reserve_without_ring.saturating_add(requested.saturating_mul(slot_bytes));
+    let explicit = spark_model::ssm_reserve::published_decode_ring_slots().is_some();
+    if asked <= free_mem || requested == 0 || slot_bytes == 0 || explicit {
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    let fitted = spark_model::ssm_reserve::fit_decode_ring_slots(
+        requested,
+        reserve_without_ring,
+        slot_bytes,
+        free_mem,
+    );
+    let fitted_total = reserve_without_ring.saturating_add(fitted.saturating_mul(slot_bytes));
+    if fitted_total > free_mem {
+        // Even a ringless serve does not fit: the ring is not the problem, so
+        // do not shrink it behind the operator's back — the caller refuses
+        // and quotes the formula for the depth that was actually asked for.
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    // Published so `TransformerModel::new` allocates the SAME depth this
+    // reserve was sized for. Both sides read the one cell; without this the
+    // runtime would allocate 8 slots against a reserve that funded fewer.
+    spark_model::ssm_reserve::set_decode_ring_slots(fitted);
+    RingFit {
+        slots: fitted,
+        warning: Some(format!(
+            "{} (was {:.2} GB); reserve {:.2} of {:.2} GB. Sized from free memory, not from \
+             --max-batch-size {} (#915): rollback depth yields, concurrency does not. Pass \
+             --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).",
+            formula(fitted, args.max_batch_size, per_seq_blob),
+            (requested * slot_bytes) as f64 / GIB,
+            fitted_total as f64 / GIB,
+            free_mem as f64 / GIB,
+            args.max_batch_size,
+        )),
+    }
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact-integer pins for the preflight ring term and its #915 auto-fit. No
+//! GPU, no model, no checkpoint — which is the point: this decision is made
+//! before the weights exist.
+//!
+//! The numbers are the 2026-09-05 rental-H100 boot from issue #915
+//! (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe, evidence cell
+//! `qwen38.atlas.a.lat.c1`): 48 GDN layers, 151.5 MiB of SSM state per
+//! sequence, `--max-batch-size 32`, inference reserve 45,823 MiB of which
+//! 37.88 GiB was ring, 57.2 GiB of weights inside a 71.3 GiB budget.
+use super::*;
+use clap::Parser as _;
+
+/// 48 GDN layers x (h 48*128*128*4 + conv (16*128*2 + 48*128)*4*4) =
+/// 158,859,264 B = exactly 151.5 MiB.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// The 45,823 MiB inference reserve minus its 38,784 MiB 8-slot ring.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+fn args() -> cli::ServeArgs {
+    cli::ServeArgs::parse_from(["spark", "Qwen/Qwen3.8-27B-FP8", "--max-batch-size", "32"])
+}
+
+/// The formula issue #915's third bullet asks preflight to print: an operator
+/// staring at 45.8 GiB could not see it was 8 snapshots x batch 32.
+#[test]
+fn the_formula_spells_out_snapshots_times_batch_times_per_seq_state() {
+    assert_eq!(
+        formula(8, 32, PER_SEQ_BLOB),
+        "ring: 8 slots x 32 seqs x 151.5 MB/seq = 37.88 GB"
+    );
+    // The same arithmetic at the depth the fit chose — one function, so the
+    // INFO line, the shrink WARN and the refusal cannot quote three answers.
+    assert_eq!(
+        formula(1, 32, PER_SEQ_BLOB),
+        "ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"
+    );
+    assert_eq!(
+        formula(0, 32, PER_SEQ_BLOB),
+        "ring: 0 slots x 32 seqs x 151.5 MB/seq = 0.00 GB"
+    );
+}
+
+/// The #915 boot itself: 14.1 GiB free (71.3 GiB budget less 57.2 GiB of
+/// weights) against a reserve whose ring alone wants 37.88 GiB. It must
+/// shrink to depth 1 and boot, not refuse.
+#[test]
+fn the_915_boot_shrinks_to_the_largest_fitting_depth_instead_of_refusing() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    assert_eq!(slot, 32 * PER_SEQ_BLOB);
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 1, "8 -> 4 -> 2 -> 1 is the first rung that fits");
+    assert!(
+        RESERVE_WITHOUT_RING + fit.slots * slot <= free,
+        "the depth it kept must actually fit"
+    );
+
+    let warning = fit.warning.expect("a shrink must be logged, never silent");
+    assert!(
+        warning.contains("ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"),
+        "{warning}"
+    );
+    assert!(warning.contains("(was 37.88 GB)"), "{warning}");
+    assert!(warning.contains("reserve 11.61 of 14.10 GB"), "{warning}");
+    assert!(warning.contains("#915"), "{warning}");
+    assert!(
+        warning.contains("--ssm-decode-ring-slots"),
+        "the warning must name the flag that pins a depth: {warning}"
+    );
+}
+
+/// A reserve that already fits is left exactly as the flags asked for, and
+/// says nothing — the WARN is reserved for the case where the serve is
+/// running at a depth its recipe does not record.
+#[test]
+fn a_reserve_that_fits_is_not_touched() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let free = 64 * 1024 * 1024 * 1024;
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// Nothing to shrink is not a shrink: a ringless serve (`--speculative`,
+/// watchdogs off, `--ssm-decode-ring-slots 0`, or a pure-attention model)
+/// goes straight to the refusal with no warning of its own.
+#[test]
+fn a_ringless_serve_is_left_to_the_refusal() {
+    let args = args();
+    let free = RESERVE_WITHOUT_RING / 2;
+    let fit = autofit(
+        &args,
+        0,
+        slot_bytes(&args, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        free,
+    );
+    assert_eq!(fit.slots, 0);
+    assert!(fit.warning.is_none());
+    // Same when the model has no SSM state at all: a zero-byte depth unit.
+    let fit = autofit(&args, 8, 0, 0, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// When even depth 0 is over budget the ring is not what is wrong. Shrinking
+/// it behind the operator's back would swap a clear refusal for a serve with
+/// no rollback depth that still cannot boot, so the depth is returned
+/// UNCHANGED and the caller refuses quoting the full formula.
+#[test]
+fn an_unfittable_reserve_keeps_the_requested_depth_for_the_refusal() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let fit = autofit(
+        &args,
+        8,
+        slot,
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        RESERVE_WITHOUT_RING - 1,
+    );
+    assert_eq!(fit.slots, 8, "the refusal must quote what was asked for");
+    assert!(fit.warning.is_none());
+}
+
+/// `--ssm-decode-ring-slots 0` is a real value the CLI accepts, and the
+/// requested-depth path must honour a published depth rather than the
+/// constant 8 — the allocation side reads the same cell.
+#[test]
+fn the_flag_parses_through_the_model_side_ssot() {
+    use spark_model::ssm_reserve::parse_decode_ring_slots;
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("2"), Ok(Some(2)));
+    assert!(parse_decode_ring_slots("12").is_err());
+    // The clap default is the `auto` this module's fit depends on.
+    assert_eq!(args().ssm_decode_ring_slots, "auto");
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The pre-load reserve REFUSAL: what it suggests, and why it asked for what
+//! it asked for.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), same
+//! precedent as `per_sequence_state.rs` and `decode_ring.rs`.
+//!
+//! Refusal is now the LAST resort, not the first answer: the decode-rollback
+//! ring shrinks to fit before this runs (#915), so reaching here means the
+//! configuration does not fit even with no rollback depth at all. That makes
+//! the text load-bearing — it is the only thing an operator has to act on —
+//! which is why it carries the ring formula as well as a suggested batch.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+use super::decode_ring;
+
+/// The terms the refusal text needs that are not derivable from `args` /
+/// `config`. Grouped so the call site stays one statement.
+pub(super) struct Refusal {
+    /// `inference_reserve + buffer_arena_bytes`.
+    pub(super) total_reserve: usize,
+    pub(super) free_mem: usize,
+    /// The terms that do NOT scale with `--max-seq-len`: SSM pools, h stage,
+    /// both snapshot regions, CUDA headroom. What is left of `free_mem` after
+    /// them is what the suggested sequence length is derived from.
+    pub(super) seq_len_independent: usize,
+    /// Ring depth the flags asked for, and the depth actually reserved for
+    /// (they differ only when an explicit depth was pinned — the auto-fit
+    /// path never reaches this refusal).
+    pub(super) ring_requested: usize,
+    pub(super) ring_slots: usize,
+    pub(super) per_seq_blob: usize,
+}
+
+/// Build the refusal error. Pure formatting over already-computed bytes.
+pub(super) fn reserve_refusal(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    r: Refusal,
+) -> anyhow::Error {
+    let need_gb = r.total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
+    let free_gb = r.free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
+    let budget_for_seq_term = r.free_mem.saturating_sub(r.seq_len_independent) / 2;
+    let per_tok_bytes = {
+        let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
+        let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+        let nv = config.linear_num_value_heads;
+        let conv_dim = key_dim * 2 + value_dim;
+        if conv_dim > 0 && config.num_ssm_layers() > 0 {
+            (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
+        } else {
+            0
+        }
+    };
+    let suggested = budget_for_seq_term
+        .checked_div(per_tok_bytes)
+        .map(|q| q.max(2048))
+        .unwrap_or(0);
+    let hint = if suggested > 0 && suggested < args.max_seq_len {
+        format!(
+            " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
+            suggested
+        )
+    } else if args.max_batch_size > 1 {
+        " Reduce --max-batch-size.".to_string()
+    } else {
+        " Use a smaller model or a GPU with more memory.".to_string()
+    };
+    anyhow::anyhow!(
+        "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
+         (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}{}",
+        need_gb,
+        free_gb,
+        args.max_seq_len,
+        args.max_batch_size,
+        hint,
+        ring_note(args, &r),
+    )
+}
+
+/// Issue #915's third bullet: an operator staring at a 45.8 GiB refusal could
+/// not see that 37.9 GiB of it was 8 rollback snapshots x batch 32. Print the
+/// arithmetic, and say why shrinking the ring did not rescue the boot.
+fn ring_note(args: &cli::ServeArgs, r: &Refusal) -> String {
+    if r.ring_requested == 0 {
+        return String::new();
+    }
+    format!(
+        " {} — {}.",
+        decode_ring::formula(r.ring_slots, args.max_batch_size, r.per_seq_blob),
+        if spark_model::ssm_reserve::published_decode_ring_slots().is_some() {
+            "an explicit --ssm-decode-ring-slots pins the depth, so it was not shrunk"
+        } else {
+            "even 0 ring slots does not fit, so shrinking it cannot rescue this boot"
+        },
+    )
+}

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -224,9 +224,15 @@ pub fn rollback_to_boundary(
     };
 
     // A hybrid model needs the SSM state rewound too — restrict boundary
-    // selection to one with a live snapshot. `has_ssm_layers()` false
-    // (pure attention) keeps the original any-boundary search.
-    let hybrid = model.has_ssm_layers() && a.ssm_rollback_ring.is_enabled();
+    // selection to one with a live snapshot. A DISABLED ring is a DECLINE,
+    // not the pure-attention any-boundary path: depth 0 (spec on, watchdogs
+    // off, or the #915 auto-fit floor) means no snapshot exists, and rewinding
+    // tokens while the recurrent state stays conditioned on the discarded tail
+    // is silent corruption. This is the fail-open the ring's SSOT documents.
+    let hybrid = model.has_ssm_layers();
+    if hybrid && !a.ssm_rollback_ring.is_enabled() {
+        return RollbackOutcome::Fallback(RollbackFallback::NoSsmSnapshot);
+    }
     let (boundary_idx, ssm_slot) = if hybrid {
         match find_last_boundary_with_snapshot(
             &a.output_tokens,

--- a/crates/spark-server/src/scheduler/ssm_decode_ring.rs
+++ b/crates/spark-server/src/scheduler/ssm_decode_ring.rs
@@ -21,9 +21,11 @@
 //! cost bounded: at most `capacity` D2D copies are live per sequence,
 //! and the ring evicts oldest-first so a long generation never grows
 //! the set. `capacity` is the model's
-//! `decode_rollback_ring_slots()` — sized `ROLLBACK_RESTEER_CAP + 1`
-//! so every permitted rollback has a distinct snapshot plus the current
-//! boundary.
+//! `decode_rollback_ring_slots()` — 8 by default, so every permitted
+//! rollback has a distinct snapshot plus the current boundary, but as
+//! low as 0 when `--ssm-decode-ring-slots` or preflight's free-memory
+//! fit (#915) says so. A smaller ring retains fewer boundaries and so
+//! reaches fewer re-steer anchors; 0 declines every rollback.
 //!
 //! Memory cost: each slot stores `h_state + conv_state` for **all** SSM
 //! layers. Per marconi.md that is ~77 MB/slot for a 122B/36-layer model;


### PR DESCRIPTION
## Summary

The Phase-C SSM decode-rollback ring was reserved as a **constant** depth (8) times `--max-batch-size`, a flag that says nothing about what the card can hold. On one 80 GB H100 with the Qwen3.8-27B hopper recipe that is 8 x 32 x 151.5 MiB = 37.88 GiB of ring inside a 45,823 MiB inference reserve, against a 71.3 GiB budget already carrying the weights — and the serve refused to boot. The shipped workaround was `--max-batch-size 4`: paying for rollback depth with four fifths of the concurrency.

This makes the depth a real flag with a printed formula, and lets preflight shrink it instead of refusing.

Refs #915. **Deliberately not `Fixes`** — see "What this does not fix", which is the most important section here.

## What changed

- **`--ssm-decode-ring-slots <auto|N>`** (N in 0..=8, default `auto`) pins the depth on *both* sides — the preflight reserve and `TransformerModel::new`'s allocation — and disables the fit. A serve that does not fit at the pinned N is **refused rather than booted at a depth its recipe does not record**. `ATLAS_SSM_DECODE_RING=1|0` keeps meaning 8 and 0, and is consulted only when the flag is `auto`.
- **Preflight auto-fit**: on `auto`, walks the depth down 8 -> 4 -> 2 -> 1 -> 0 until the reserve fits, publishes the chosen depth so the allocation matches the reservation exactly, and logs the formula at WARN.
- **The refusal carries the formula too**, so an operator reading only the failure can see where the reserve went instead of inferring it.
- **Depth-0 correctness fix**, which the auto-fit is what makes reachable: an SSM model with the ring disabled fell into `rollback_to_boundary`'s pure-attention any-boundary arm, rewinding tokens while the recurrent state stayed conditioned on the discarded tail. It now declines with `NoSsmSnapshot` — the fail-open the ring's SSOT already documented. Without this, turning the ring off would have been a silent correctness bug rather than a capacity trade.
- **Docs**: `SsmDecodeRing`'s module doc and `Model::decode_rollback_ring_slots` both still quoted `ROLLBACK_RESTEER_CAP + 1` as the depth. That was already wrong when the depth became 8; it is doubly wrong now that the depth is whatever the flag or the fit published. Doc-only commit.
- **File splits**, mechanical: `preflight.rs` (515 LoC, over the cap) into `preflight/{decode_ring,refusal}.rs`, and `ssm_reserve.rs` (608) into `ssm_reserve/decode_ring.rs`. Every public path is unchanged by re-export.

## What this does not fix

A batch-16 and batch-32 boot were attempted on an 80 GB H100 on **2026-09-11** against a tree carrying these commits. **Both still refused**, and the probe explains why. This is a real negative result and it belongs in the body, not in a follow-up issue nobody reads.

The fitter runs at preflight, ~1 s into boot, and sizes the reserve against **pre-load free memory**. Its own WARN says so:

```
SSM decode-rollback ring auto-fit — ring: 4 slots x 64 seqs x 151.5 MB/seq = 37.88 GB
(was 75.75 GB); reserve 54.13 of 78.57 GB. Sized from free memory, not from
--max-batch-size 64 (#915): rollback depth yields, concurrency does not.
Pass --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).
```

`reserve 54.13 of 78.57 GB` — 78.57 GB is free memory *before* the weights load. The quantity that actually has to accommodate the reserve is the **post-load KV headroom**, which the same boot measures four minutes later as `71.3 GB budget − 58.1 GB already live = 13.2 GB`. The fitter is sizing against a number ~6x larger than the real constraint. Direct sweep of preflight (each point ~20 s, since preflight logs long before the load finishes):

| `--max-batch-size` | depth chosen | ring GB | inference reserve | fired? |
|---|---|---|---|---|
| 4 | 8 | 4.73 | 8,745 MB | no |
| 16 | 8 | 18.94 | 25,107 MB | no |
| 32 | 8 | 37.88 | 46,923 MB | no |
| 40 | 8 | 47.34 | 57,831 MB | no |
| **64** | **8 -> 4** | 37.88 | 51,771 MB | **yes** |
| **128** | **8 -> 2** | 37.88 | 61,467 MB | **yes** |

So the mechanism works and the plumbing is correct — the depth it picks is honoured end to end — but it stays silent for every batch size from 4 to 40, and even when it fires at 64/128 it targets ~37.88 GB of ring against the 13.2 GB that exists, so the shrunk configuration is still unbootable. **At this tree the auto-fit cannot produce a bootable configuration at any `--max-batch-size` above ~4 on an 80 GB H100.**

Against #915's three asks, honestly scored:

| #915 asks | state |
|---|---|
| Make ring depth a first-class flag with a documented memory formula | **done**, verified on hardware |
| Preflight prints the formula so the operator sees why N GiB was asked for | **done**, verified on hardware |
| Size the ring from **post-weights** free memory, shrink instead of refusing | **partial** — shrinks, but against the pre-load number, which is the wrong yardstick |

Fixing the yardstick means either moving the fit to after the weight load (where the 58.1 GB live figure exists) or teaching preflight to predict it — the gap is the load's transient/duplicate allocations, ~29 GB on this boot, not the resident weights. That is a separate change with its own hardware bill, and stacking it under a review of this one would hide both.

## What it did buy, measured

The flag half is not theoretical: it is what made any batch-16 or batch-32 H100 number exist at all on 2026-09-11. With `--ssm-decode-ring-slots 1` at `--max-batch-size 16`, the same recipe that refused now boots in 253 s and reports the pin taking, with **no** ring WARN — the documented behaviour for an explicit depth:

```
kernel flags: ... ssm_rollback_mode=Snapshot ssm_decode_ring_slots=1 ...
Preflight reserve: inference=8139 MB, buffer_arena=3658 MB (pre-load free: 78.6 GB);
  ring: 1 slots x 16 seqs x 151.5 MB/seq = 2.37 GB
KV cache: 79.2 GB total x 90% util = 71.3 GB budget; 58.1 GB pre-KV + 7.9 GB
  reserve -> 5.2 GB for KV -> 8585 blocks x 16 tok/block = 137360 max KV tokens
```

That serve then ran a clean ladder (`LADDER_EXIT=0`, zero errors on 12 recorded reps) and a 16-way concurrent arithmetic probe at **16/16 correct**. Before this PR the only way to reach that state was to cut the batch by 4x.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda --lib ssm_reserve` — **25 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda --lib` — **893 passed, 0 failed, 11 ignored**
- [x] `cargo test -p spark-server --bins --features cuda,nccl preflight` — **26 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl rollback` — **26 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl ssm_decode_ring` — **14 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl flag` — **48 passed, 0 failed**
- [x] `cargo clippy -p spark-model -p spark-server --tests --features cuda,nccl` — clean, no warnings emitted
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] Tested against real hardware — 80 GB H100, 2026-09-11: the negative result and the pinned-depth boot above
- [ ] PTX gate — not applicable, no `kernels/` file is touched

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates every committed `.benchmarks/` record on landing. A GB10 re-measure is owed before merge.

## Notes for reviewers

The depth-0 rollback fix is the part to read closest. It is a correctness change riding along with a capacity change, and it is only in scope because the auto-fit is what makes depth 0 reachable in the first place — before this PR nothing could put an SSM model in that state. If you would rather see it split, say so and it can lead its own PR; the rest of this stack does not depend on it.

`--ssm-decode-ring-slots N` refusing rather than shrinking is deliberate and is the asymmetry worth arguing about: `auto` may silently give you a shallower ring, an explicit N may not. The reasoning is that a recipe that records a depth should either get that depth or fail loudly, since a serve quietly running at a different rollback depth than its recipe claims is unreproducible.

Both commits are cherry-picked from `fix/915-ring-autofit` on the fork with `-x` provenance lines. Both applied to current `main` with **no conflicts**; nothing was adapted.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
