### PR TITLE
spark-model: batch native FP8 Q/K/V projections across decode rows (#927)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -283,3 +283,7 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "native_fp8_oproj_batch_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "native_fp8_qkv_batch_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/native_fp8_qkv_batch_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_qkv_batch_microtest.rs
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Actual Qwen3.8-27B Q/K/V projection shapes: the production per-sequence
+//! scalar `w8a16_gemv` loop versus ONE strided batched launch per projection
+//! (`w8a16_gemv_batch{4,16}_strided`, issue #927 / O13).
+//!
+//! No new kernel math is claimed, so the bar is exact: identical BF16 output
+//! bytes, and every byte the batched path must NOT touch still holding its
+//! sentinel (the rows past M, the unused K/V region of a Q-only run, and the
+//! guard bands either side of every buffer).
+//!
+//! Shapes come from `kernels/gb10/qwen3.8-27b/MODEL.toml`: hidden_dim 5120,
+//! head_dim 256, q_heads 24, kv_heads 4, attn_output_gate = true. So
+//! K = 5120, q_dim = 6144, q_proj_dim = 2*q_dim = 12288 (interleaved [Q|gate]),
+//! kv_dim = 1024, and one sequence's [Q|K|V] block is 14336 BF16 elements —
+//! the `per_seq_qkv` row stride the batched kernels have to honour.
+//!
+//! Run (H100):
+//!   cargo run --release -p spark-model --features cuda,gpu-examples \
+//!     --example native_fp8_qkv_batch_microtest
+use anyhow::{Result, ensure};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+const K: usize = 5120; // hidden_dim
+const Q_PROJ_DIM: usize = 12288; // 2 * q_heads * head_dim (gated)
+const KV_DIM: usize = 1024; // kv_heads * head_dim
+const PER_SEQ_QKV: usize = Q_PROJ_DIM + 2 * KV_DIM; // 14336 BF16 elements
+const MAX_M: usize = 8;
+const GUARD: usize = 64; // bytes of sentinel either side of every buffer
+const SENTINEL: u8 = 0x5a;
+
+/// One projection's slot inside a sequence's [Q|K|V] block.
+struct Proj {
+    name: &'static str,
+    weight: DevicePtr,
+    scale: DevicePtr,
+    /// Element offset of this projection inside the row.
+    offset: usize,
+    /// Output width (N).
+    n: usize,
+}
+
+fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+
+fn values(bytes: &[u8]) -> Vec<f64> {
+    bytes
+        .chunks_exact(2)
+        .map(|x| bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32() as f64)
+        .collect()
+}
+
+/// The real comparison oracle, exercised against deliberately-corrupted input
+/// below so a green run cannot be a vacuous one.
+fn check(observed: &[u8], baseline: &[u8], sentinel: &[u8], live: &[(usize, usize)]) -> Result<()> {
+    ensure!(
+        observed.len() == sentinel.len() && baseline.len() == sentinel.len(),
+        "output extent mismatch"
+    );
+    // Every byte outside the live extents must still be sentinel, on BOTH runs.
+    let mut mask = vec![false; sentinel.len()];
+    for &(start, len) in live {
+        mask[GUARD + start..GUARD + start + len].fill(true);
+    }
+    for i in 0..sentinel.len() {
+        if !mask[i] {
+            ensure!(
+                observed[i] == sentinel[i],
+                "batched projection wrote outside its extent at byte {i}"
+            );
+            ensure!(
+                baseline[i] == sentinel[i],
+                "scalar projection wrote outside its extent at byte {i}"
+            );
+        }
+    }
+    for &(start, len) in live {
+        let a = &observed[GUARD + start..GUARD + start + len];
+        let b = &baseline[GUARD + start..GUARD + start + len];
+        ensure!(
+            values(a)
+                .iter()
+                .chain(values(b).iter())
+                .all(|x| x.is_finite()),
+            "nonfinite projection output"
+        );
+        ensure!(
+            a == b,
+            "batch output differs from production scalar BF16 bits"
+        );
+    }
+    Ok(())
+}
+
+/// The shared shape of the two strided wrappers, so picking MAX_M is one
+/// branch rather than two duplicated 12-argument calls.
+type StridedBatchGemv = fn(
+    &dyn GpuBackend,
+    KernelHandle,
+    DevicePtr,
+    DevicePtr,
+    DevicePtr,
+    DevicePtr,
+    u32,
+    u32,
+    u32,
+    u32,
+    u32,
+    u64,
+) -> Result<()>;
+
+fn run_batched(
+    gpu: &dyn GpuBackend,
+    batch4: KernelHandle,
+    batch16: KernelHandle,
+    input: DevicePtr,
+    out: DevicePtr,
+    p: &Proj,
+    m: usize,
+) -> Result<()> {
+    let (launch, kernel): (StridedBatchGemv, KernelHandle) = if m <= 4 {
+        (ops::w8a16_gemv_batch4_strided, batch4)
+    } else {
+        (ops::w8a16_gemv_batch16_strided, batch16)
+    };
+    launch(
+        gpu,
+        kernel,
+        input,
+        p.weight,
+        p.scale,
+        out.offset(p.offset * 2),
+        m as u32,
+        p.n as u32,
+        K as u32,
+        K as u32,
+        PER_SEQ_QKV as u32,
+        0,
+    )
+}
+
+fn run_scalar(
+    gpu: &dyn GpuBackend,
+    scalar: KernelHandle,
+    input: DevicePtr,
+    out: DevicePtr,
+    p: &Proj,
+    m: usize,
+) -> Result<()> {
+    for row in 0..m {
+        ops::w8a16_gemv(
+            gpu,
+            scalar,
+            input.offset(row * K * 2),
+            p.weight,
+            p.scale,
+            out.offset((row * PER_SEQ_QKV + p.offset) * 2),
+            p.n as u32,
+            K as u32,
+            0,
+        )?;
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let scalar = gpu.kernel("w8a16_gemv", "w8a16_gemv")?;
+    let batch4 = gpu.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch4_strided")?;
+    let batch16 = gpu.kernel("w8a16_gemv_batch4", "w8a16_gemv_batch16_strided")?;
+
+    let mut state = 0x0132_8a16_2026_u64;
+    let mut random = move || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (state >> 32) as u32
+    };
+    let mut fp8_weight = |n: usize| -> Vec<u8> {
+        (0..n * K)
+            .map(|_| {
+                let x = random();
+                ((x % 127) as u8) | (((x >> 7) & 1) as u8 * 128)
+            })
+            .collect()
+    };
+    let q_bytes = fp8_weight(Q_PROJ_DIM);
+    let k_bytes = fp8_weight(KV_DIM);
+    let v_bytes = fp8_weight(KV_DIM);
+    let mut scales = |n: usize| -> Vec<u8> {
+        (0..(n / 128) * (K / 128))
+            .flat_map(|_| (((random() % 16 + 1) as f32) / 1024.0).to_le_bytes())
+            .collect()
+    };
+    let q_scale = scales(Q_PROJ_DIM);
+    let k_scale = scales(KV_DIM);
+    let v_scale = scales(KV_DIM);
+    // Activations: contiguous [MAX_M, K], the `normed` layout decode hands in.
+    let acts: Vec<u8> = (0..MAX_M * K)
+        .flat_map(|_| {
+            bf16::from_f32(((random() % 2049) as f32 - 1024.0) / 1024.0)
+                .to_bits()
+                .to_le_bytes()
+        })
+        .collect();
+
+    let input_base = upload(
+        &gpu,
+        &[vec![SENTINEL; GUARD], acts, vec![SENTINEL; GUARD]].concat(),
+    )?;
+    let input = input_base.offset(GUARD);
+    let projections = [
+        Proj {
+            name: "q_proj",
+            weight: upload(&gpu, &q_bytes)?,
+            scale: upload(&gpu, &q_scale)?,
+            offset: 0,
+            n: Q_PROJ_DIM,
+        },
+        Proj {
+            name: "k_proj",
+            weight: upload(&gpu, &k_bytes)?,
+            scale: upload(&gpu, &k_scale)?,
+            offset: Q_PROJ_DIM,
+            n: KV_DIM,
+        },
+        Proj {
+            name: "v_proj",
+            weight: upload(&gpu, &v_bytes)?,
+            scale: upload(&gpu, &v_scale)?,
+            offset: Q_PROJ_DIM + KV_DIM,
+            n: KV_DIM,
+        },
+    ];
+
+    let output_bytes = MAX_M * PER_SEQ_QKV * 2;
+    let sentinel = vec![SENTINEL; output_bytes + 2 * GUARD];
+    let scalar_base = upload(&gpu, &sentinel)?;
+    let batch_base = upload(&gpu, &sentinel)?;
+    let scalar_out = scalar_base.offset(GUARD);
+    let batch_out = batch_base.offset(GUARD);
+    let mut first_oracle = true;
+    let mut failures = 0usize;
+
+    for m in [2_usize, 3, 4, 5, 8] {
+        // ── Pass 1: each projection ALONE. Everything else in the row — the
+        // other two projections' slots — is a gap that must stay sentinel, so
+        // this is the direct test of the c_row_stride arithmetic.
+        for p in &projections {
+            gpu.copy_h2d(&sentinel, scalar_base)?;
+            gpu.copy_h2d(&sentinel, batch_base)?;
+            run_scalar(&gpu, scalar, input, scalar_out, p, m)?;
+            run_batched(&gpu, batch4, batch16, input, batch_out, p, m)?;
+            gpu.synchronize(0)?;
+            let mut baseline = vec![0_u8; sentinel.len()];
+            let mut observed = vec![0_u8; sentinel.len()];
+            gpu.copy_d2h(scalar_base, &mut baseline)?;
+            gpu.copy_d2h(batch_base, &mut observed)?;
+            let live: Vec<(usize, usize)> = (0..m)
+                .map(|r| ((r * PER_SEQ_QKV + p.offset) * 2, p.n * 2))
+                .collect();
+
+            if first_oracle {
+                for mutation in ["output-bit", "gap", "guard", "nonfinite"] {
+                    let mut bad = baseline.clone();
+                    match mutation {
+                        "output-bit" => bad[GUARD] ^= 1,
+                        "gap" => bad[GUARD + (Q_PROJ_DIM + 1) * 2] ^= 1,
+                        "guard" => bad[0] ^= 1,
+                        _ => bad[GUARD..GUARD + 2].copy_from_slice(&0x7fc0_u16.to_le_bytes()),
+                    }
+                    let err = check(&bad, &baseline, &sentinel, &live)
+                        .expect_err("known-bad output was admitted by the real oracle");
+                    println!("KNOWN_BAD {mutation}: refused: {err}");
+                }
+                first_oracle = false;
+            }
+
+            let (mismatches, max_abs) = compare(&observed, &baseline, &live);
+            let kernel = if m <= 4 { "batch4" } else { "batch16" };
+            println!(
+                "{} M={m} N={} K={K} stride={PER_SEQ_QKV} kernel={kernel} \
+                 unequal_bf16={mismatches} max_abs={max_abs:.9}",
+                p.name, p.n
+            );
+            if let Err(e) = check(&observed, &baseline, &sentinel, &live) {
+                println!("FAIL {} M={m}: {e}", p.name);
+                failures += 1;
+            }
+        }
+
+        // ── Pass 2: the real thing — all three projections into one strided
+        // buffer, exactly as `ms_qkv_batchm_fp8` issues them.
+        gpu.copy_h2d(&sentinel, scalar_base)?;
+        gpu.copy_h2d(&sentinel, batch_base)?;
+        for p in &projections {
+            run_scalar(&gpu, scalar, input, scalar_out, p, m)?;
+            run_batched(&gpu, batch4, batch16, input, batch_out, p, m)?;
+        }
+        gpu.synchronize(0)?;
+        let mut baseline = vec![0_u8; sentinel.len()];
+        let mut observed = vec![0_u8; sentinel.len()];
+        gpu.copy_d2h(scalar_base, &mut baseline)?;
+        gpu.copy_d2h(batch_base, &mut observed)?;
+        // Rows m..MAX_M are the gap here: a clamped or over-wide M would fill
+        // them, and that is the silent-corruption mode this pass exists for.
+        let live: Vec<(usize, usize)> = (0..m)
+            .map(|r| (r * PER_SEQ_QKV * 2, PER_SEQ_QKV * 2))
+            .collect();
+        let (mismatches, max_abs) = compare(&observed, &baseline, &live);
+        println!(
+            "full-qkv M={m} row_elems={PER_SEQ_QKV} K={K} \
+             unequal_bf16={mismatches} max_abs={max_abs:.9}"
+        );
+        if let Err(e) = check(&observed, &baseline, &sentinel, &live) {
+            println!("FAIL full-qkv M={m}: {e}");
+            failures += 1;
+        }
+    }
+
+    ensure!(failures == 0, "{failures} case(s) failed");
+    println!(
+        "ALL PASS: Qwen3.8-27B q/k/v shapes, strided batch4 M2/M3/M4 and batch16 M5/M8, \
+         exact scalar equivalence, gaps and guards intact"
+    );
+    Ok(())
+}
+
+/// Unequal BF16 elements and max absolute delta over the live extents only.
+fn compare(observed: &[u8], baseline: &[u8], live: &[(usize, usize)]) -> (usize, f64) {
+    let mut mismatches = 0;
+    let mut max_abs = 0.0_f64;
+    for &(start, len) in live {
+        let a = &observed[GUARD + start..GUARD + start + len];
+        let b = &baseline[GUARD + start..GUARD + start + len];
+        mismatches += a
+            .chunks_exact(2)
+            .zip(b.chunks_exact(2))
+            .filter(|(x, y)| x != y)
+            .count();
+        max_abs = values(a)
+            .iter()
+            .zip(values(b).iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(max_abs, f64::max);
+    }
+    (mismatches, max_abs)
+}

--- a/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
+++ b/crates/spark-model/src/layers/ops/fp8_gemv_batch.rs
@@ -178,3 +178,145 @@ pub fn w8a16_gemv_batch2(
         .arg_u32(k)
         .launch(stream)
 }
+
+/// Strided sibling of [`w8a16_gemv_batch4`] (M<=4).
+///
+/// WHY: the multi-sequence decode Q/K/V buffer is `[n, per_seq_qkv]` with Q at
+/// offset 0, K after Q and V after K inside every row, so the contiguous
+/// `[M, N]` writer cannot address one projection across rows. Without a
+/// strided writer the native-FP8 attention projections fell back to three
+/// scalar `w8a16_gemv` launches PER ROW at decode concurrency 2..=8 — the
+/// third-largest bucket in the C=4 decode profile (issue #927). This writes one
+/// projection for all M rows in ONE launch.
+///
+/// LAYOUT: `input` `[M, a_row_stride]` BF16, only the first `k` elements of
+/// each row read; `weight`/`block_scale` are the raw `w8a16_gemv` pointers
+/// (`[N, K]` FP8 E4M3 and `[N/128, K/128]` FP32); `output`
+/// `[M, c_row_stride]` BF16, only the first `n` elements of each row written.
+/// Both strides are in ELEMENTS. `a_row_stride` must keep each activation row
+/// 16-byte aligned (multiple of 8) — the kernel's activation loads are `uint4`.
+///
+/// Bit-identical per row to `w8a16_gemv`: same template body, same K-iteration
+/// order and same reduction tree as [`w8a16_gemv_batch4`]; only the row pitches
+/// change. Verified by `examples/native_fp8_qkv_batch_microtest`.
+///
+/// Kernel: `w8a16_gemv_batch4_strided` (module `w8a16_gemv_batch4`).
+/// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
+#[allow(clippy::too_many_arguments)]
+pub fn w8a16_gemv_batch4_strided(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: DevicePtr,
+    block_scale: DevicePtr,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    a_row_stride: u32,
+    c_row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        (1..=4).contains(&m),
+        "w8a16_gemv_batch4_strided: m={m} outside 1..=4 (kernel MAX_M)"
+    );
+    strided_batch_launch(
+        gpu,
+        kernel,
+        input,
+        weight,
+        block_scale,
+        output,
+        m,
+        n,
+        k,
+        a_row_stride,
+        c_row_stride,
+        stream,
+    )
+}
+
+/// MAX_M=16 sibling of [`w8a16_gemv_batch4_strided`], for decode concurrency
+/// 5..=16. Same template, same launch geometry, same per-row accumulation
+/// order; the wider register array is the only difference.
+///
+/// Kernel: `w8a16_gemv_batch16_strided` (module `w8a16_gemv_batch4`).
+/// Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1)
+#[allow(clippy::too_many_arguments)]
+pub fn w8a16_gemv_batch16_strided(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: DevicePtr,
+    block_scale: DevicePtr,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    a_row_stride: u32,
+    c_row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        (1..=16).contains(&m),
+        "w8a16_gemv_batch16_strided: m={m} outside 1..=16 (kernel MAX_M)"
+    );
+    strided_batch_launch(
+        gpu,
+        kernel,
+        input,
+        weight,
+        block_scale,
+        output,
+        m,
+        n,
+        k,
+        a_row_stride,
+        c_row_stride,
+        stream,
+    )
+}
+
+/// Shared launch body for the two `_strided` entry points — identical argument
+/// order and geometry, so the only thing that differs above is the MAX_M bound
+/// the caller must respect.
+#[allow(clippy::too_many_arguments)]
+fn strided_batch_launch(
+    gpu: &dyn GpuBackend,
+    kernel: KernelHandle,
+    input: DevicePtr,
+    weight: DevicePtr,
+    block_scale: DevicePtr,
+    output: DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    a_row_stride: u32,
+    c_row_stride: u32,
+    stream: u64,
+) -> Result<()> {
+    ensure!(
+        a_row_stride >= k && c_row_stride >= n,
+        "w8a16_gemv batch strided: row pitches (a={a_row_stride}, c={c_row_stride}) \
+         must cover the used extents (k={k}, n={n})"
+    );
+    ensure!(
+        a_row_stride.is_multiple_of(8),
+        "w8a16_gemv batch strided: a_row_stride={a_row_stride} must keep rows \
+         16B-aligned (uint4 activation loads)"
+    );
+    KernelLaunch::new(gpu, kernel)
+        .grid([div_ceil(n, 4), 1, 1])
+        .block([256, 1, 1])
+        .arg_ptr(input)
+        .arg_ptr(weight)
+        .arg_ptr(block_scale)
+        .arg_ptr(output)
+        .arg_u32(m)
+        .arg_u32(n)
+        .arg_u32(k)
+        .arg_u32(a_row_stride)
+        .arg_u32(c_row_stride)
+        .launch(stream)
+}

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -240,6 +240,16 @@ impl Qwen3AttentionLayer {
                 "w8a16_gemv_batch4",
                 "w8a16_gemv_batch4",
             ),
+            w8a16_gemv_batch4_strided_k: super::super::try_kernel(
+                gpu,
+                "w8a16_gemv_batch4",
+                "w8a16_gemv_batch4_strided",
+            ),
+            w8a16_gemv_batch16_strided_k: super::super::try_kernel(
+                gpu,
+                "w8a16_gemv_batch4",
+                "w8a16_gemv_batch16_strided",
+            ),
             w8a16_gemm_k: super::super::try_kernel(gpu, "w8a16_gemm", "w8a16_gemm"),
             w8a16_gemm_pipelined_k: super::super::try_kernel(
                 gpu,

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/mod.rs
@@ -5,6 +5,7 @@
 //! Split into phase modules under the `_inner` delegation pattern:
 //! - `ctx`  — `MultiSeqCtx` shared scalars + buffer pointers
 //! - `qkv`  — phase 2: per-token Q/K/V projections (batch3/batch2/seq)
+//! - `qkv_fp8_batch` — phase 2 tier: batched native-FP8 Q/K/V (n in 2..=8)
 //! - `attn` — phases 3-6: RoPE → cache write → paged decode → O proj
 //! - `ffn`  — phase 7: residual + post-norm + MoE/dense FFN
 //!
@@ -26,6 +27,7 @@ mod ffn;
 mod mla;
 mod mla_gemv;
 mod qkv;
+mod qkv_fp8_batch;
 
 impl Qwen3AttentionLayer {
     #[allow(clippy::too_many_arguments)]

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Phase 2: per-token Q/K/V projection. Three branches:
+//! Phase 2: per-token Q/K/V projection. Branches:
 //! - n=3 + NVFP4 → batch3 GEMV path
 //! - n=2 + NVFP4 → batch2 GEMV path
+//! - n>3 + NVFP4 → wide-verify batched GEMM
+//! - n in 2..=8 + native FP8 → strided batched GEMV (`qkv_fp8_batch`)
+//! - n in 2..=8 + dense BF16 → `ms_qkv_batchm_bf16`
 //! - else        → sequential per-token GEMV (FP8/NVFP4/BF16 fallback)
 //!
 //! Both batch paths read each weight once for N tokens and then scatter
@@ -72,6 +75,14 @@ impl Qwen3AttentionLayer {
             // weight loop in the wide verify — one GEMM per Q/K/V reads each
             // weight ONCE for all n rows instead of n× (mirrors batch3 with M=n).
             self.ms_qkv_batchn(c)?;
+        } else if self.ms_qkv_batchm_fp8_selected(c, super::qkv_fp8_batch::fp8_batchm_enabled()) {
+            // BATCHED NATIVE-FP8 QKV (O13, issue #927). Mutually exclusive with
+            // both the NVFP4 tiers above (they require `as_nvfp4()`) and the
+            // dense-BF16 tier below (it requires no quantized sidecar at all),
+            // so tier order here is readability, not precedence. See
+            // `qkv_fp8_batch.rs` for the launch-count argument and the
+            // graph-capture note on branching with the padded ctx `n`.
+            self.ms_qkv_batchm_fp8(c)?;
         } else if (2..=8).contains(&n)
             && !self.gated
             && self.dense_gemv_batchm_k.0 != 0
@@ -191,7 +202,7 @@ impl Qwen3AttentionLayer {
         Ok(())
     }
 
-    fn q_lora_active(&self) -> bool {
+    pub(super) fn q_lora_active(&self) -> bool {
         self.lora.as_ref().and_then(|lw| lw.q.as_ref()).is_some()
     }
 

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv_fp8_batch.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv_fp8_batch.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched native-FP8 (W8A16 block-scaled) Q/K/V projections for multi-seq
+//! decode — the FP8 sibling of `qkv::ms_qkv_batchm_bf16`.
+//!
+//! WHY (issue #927, O13). The FP8 attention projections had no batched tier:
+//! `w8a16_gemv_batch4`/`_batch16` write a CONTIGUOUS `[M, N]` output, while the
+//! multi-seq QKV buffer is `[n, per_seq_qkv]` (14336 BF16 elements per row on
+//! Qwen3.8-27B) with Q at offset 0, K after Q and V after K inside each row. So
+//! every concurrent decode row re-read the whole q/k/v weight through three
+//! scalar `w8a16_gemv` launches — 3n launches and n full weight passes per
+//! attention layer per step. In the C=4 decode profile that bucket
+//! (qkvz/out_proj) is ~6.3 ms of a 44.7 ms step, the third largest.
+//!
+//! The `_strided` kernel entry points added alongside this module take the A
+//! and C row pitches, so one launch per projection writes all `n` rows straight
+//! into their slots. Pure launch-count change: same kernel body, same
+//! K-iteration order, same reduction tree, hence bit-identical to the scalar
+//! path it replaces (oracle: `examples/native_fp8_qkv_batch_microtest`).
+
+use anyhow::Result;
+
+use super::ctx::MultiSeqCtx;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+use crate::layers::ops;
+use crate::layers::qwen3_attention::Qwen3AttentionLayer;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// The shared shape of `ops::w8a16_gemv_batch{4,16}_strided`, so the MAX_M
+/// choice is one branch instead of two duplicated call sites.
+type StridedBatchGemv = fn(
+    &dyn GpuBackend,
+    KernelHandle,
+    DevicePtr,
+    DevicePtr,
+    DevicePtr,
+    DevicePtr,
+    u32,
+    u32,
+    u32,
+    u32,
+    u32,
+    u64,
+) -> Result<()>;
+
+/// Kill switch for this tier: PRESENCE of `ATLAS_NO_FP8_QKV_BATCH` (any value)
+/// restores the per-sequence scalar loop. Read ONCE, never per layer per step,
+/// so it cannot vary across CUDA-graph replays — same contract as
+/// `qkv::bf16_batchm_enabled`.
+pub(super) fn fp8_batchm_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ATLAS_NO_FP8_QKV_BATCH").is_none())
+}
+
+impl Qwen3AttentionLayer {
+    /// Tier selection predicate. `enabled` is the kill switch, passed in rather
+    /// than read here so tests can drive both arms without racing the
+    /// process-global `OnceLock` in [`fp8_batchm_enabled`].
+    ///
+    /// GRAPH-CAPTURE: `c.n` is the ctx n, which IS `padded_n` (decode_a2.rs
+    /// pads to [2,4,8] and keys the graph cache on it), so branching on it
+    /// bakes exactly the value the graph is keyed by — the same contract the
+    /// n==2 / n==3 NVFP4 branches rely on. Never branch on the unpadded
+    /// `seqs.len()` here.
+    pub(super) fn ms_qkv_batchm_fp8_selected(&self, c: &MultiSeqCtx<'_>, enabled: bool) -> bool {
+        if !enabled || !(2..=8).contains(&c.n) {
+            return false;
+        }
+        if self.w8a16_gemv_batch4_strided_k.0 == 0 || self.w8a16_gemv_batch16_strided_k.0 == 0 {
+            return false;
+        }
+        let Some((q, k, v)) = self.qkv_fp8_block_scaled() else {
+            return false;
+        };
+        // The kernel indexes block_scale[(n/128) * ceil(K/128) + k/128]; the
+        // o_proj FP8 tier carries the same `% 128` guards for the same reason.
+        let kv_dim = c.nkv * c.hd;
+        let dims_ok = c.h.is_multiple_of(128)
+            && c.q_proj_dim.is_multiple_of(128)
+            && kv_dim.is_multiple_of(128);
+        // Row pitches must be whole BF16 elements and 16B-aligned on the A side
+        // (uint4 activation loads); `normed` rows are `h` elements apart.
+        let strides_ok = c.per_seq_qkv.is_multiple_of(c.bf16) && c.h.is_multiple_of(8);
+        let shapes_ok = q.n == c.q_proj_dim && k.n == kv_dim && v.n == kv_dim;
+        dims_ok && strides_ok && shapes_ok
+    }
+
+    /// q/k/v all present as native FP8 with 2D block scales (the only format
+    /// `w8a16_gemv` and its batched siblings can read; `Fp8PerRow` weights are
+    /// dequantized/requantized at load and never reach here).
+    fn qkv_fp8_block_scaled(&self) -> Option<(&Fp8Weight, &Fp8Weight, &Fp8Weight)> {
+        // A free fn, not a closure: closure lifetime inference cannot tie the
+        // borrow of `w` to the returned reference here.
+        fn block_scaled(w: &Option<crate::weight_map::QuantWeight>) -> Option<&Fp8Weight> {
+            w.as_ref()
+                .and_then(|w| w.as_fp8())
+                .filter(|w| w.scale_format == WeightQuantFormat::Fp8BlockScaled)
+        }
+        Some((
+            block_scaled(&self.q_weight)?,
+            block_scaled(&self.k_weight)?,
+            block_scaled(&self.v_weight)?,
+        ))
+    }
+
+    /// ONE strided launch per projection for all `n` rows, writing straight
+    /// into `qkv_buf` at the SAME per-seq offsets the scalar loop uses
+    /// (Q at 0, K at `q_proj_bytes`, V after K), then the same post-GEMV step
+    /// the per-sequence FP8 branch applies.
+    ///
+    /// Post-GEMV parity with `ms_qkv_seq_q`/`ms_qkv_seq_kv`:
+    /// - gated Q gets the inline `deinterleave_qg` unless a q adapter is
+    ///   resident, in which case it is deferred to `ms_qkv_deinterleave_q` past
+    ///   the LoRA fold — identical condition, and the strided deinterleave does
+    ///   all `n` tokens in one launch (a pure permutation, so bit-identical to
+    ///   `n` single-token launches at the same addresses);
+    /// - LoRA and the q/k RMS norms are NOT done here: `ms_phase_qkv` runs
+    ///   `ms_qkv_apply_lora` / `ms_qkv_norms` for every branch.
+    pub(super) fn ms_qkv_batchm_fp8(&self, c: &MultiSeqCtx<'_>) -> Result<()> {
+        let MultiSeqCtx {
+            fwd,
+            n,
+            stream,
+            h,
+            nq,
+            nkv,
+            hd,
+            bf16,
+            q_proj_dim,
+            q_proj_bytes,
+            per_seq_qkv,
+            normed,
+            qkv_buf,
+            ..
+        } = *c;
+        let (q, k, v) = self
+            .qkv_fp8_block_scaled()
+            .expect("ms_qkv_batchm_fp8 entered without block-scaled FP8 q/k/v");
+
+        // Input rows: `normed` is contiguous [n, h]. Output rows: qkv_buf is
+        // strided by per_seq_qkv BYTES; the kernel wants BF16 ELEMENTS.
+        debug_assert_eq!(per_seq_qkv % bf16, 0);
+        let a_stride = h as u32;
+        let c_stride = (per_seq_qkv / bf16) as u32;
+        let kv_dim = nkv * hd;
+        let kv_bytes = kv_dim as usize * bf16;
+
+        // batch4 for n<=4, batch16 for 5..=8 — one launch either way; the only
+        // difference is the kernel's compile-time register-array bound (and so
+        // the MAX_M the wrapper enforces).
+        let (launch, kernel): (StridedBatchGemv, KernelHandle) = if n <= 4 {
+            (
+                ops::w8a16_gemv_batch4_strided,
+                self.w8a16_gemv_batch4_strided_k,
+            )
+        } else {
+            (
+                ops::w8a16_gemv_batch16_strided,
+                self.w8a16_gemv_batch16_strided_k,
+            )
+        };
+        let gemv = |w: &Fp8Weight, out: DevicePtr, n_out: u32| {
+            launch(
+                fwd.gpu,
+                kernel,
+                normed,
+                w.weight,
+                w.row_scale,
+                out,
+                n as u32,
+                n_out,
+                h as u32,
+                a_stride,
+                c_stride,
+                stream,
+            )
+        };
+
+        // `q_proj_dim == q_dim` when ungated, so this one width covers both the
+        // gated ([Q|gate], width 2*q_dim) and ungated arms of `ms_qkv_seq_q`.
+        gemv(q, qkv_buf, q_proj_dim)?;
+        gemv(k, qkv_buf.offset(q_proj_bytes), kv_dim)?;
+        gemv(v, qkv_buf.offset(q_proj_bytes + kv_bytes), kv_dim)?;
+
+        if self.gated && !self.q_lora_active() {
+            ops::deinterleave_qg(
+                fwd.gpu,
+                self.deinterleave_qg_k,
+                qkv_buf,
+                n as u32,
+                nq,
+                hd,
+                c_stride,
+                stream,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "qkv_fp8_batch_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv_fp8_batch_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/multi_seq/qkv_fp8_batch_tests.rs
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Dispatch-selection tests for the batched native-FP8 Q/K/V tier (O13).
+//!
+//! These assert LAUNCH COUNTS and argument layout on the mock backend — the
+//! whole point of the tier is that it is a pure launch-count change. Numeric
+//! parity against the scalar `w8a16_gemv` path is the GPU oracle
+//! (`examples/native_fp8_qkv_batch_microtest`), not this file.
+
+use super::super::ctx::MultiSeqCtx;
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::layers::{FfnComponent, qwen3_attention::Qwen3AttentionLayer};
+use crate::weight_map::{
+    AttentionWeights, DenseWeight, Fp8Weight, QuantWeight, QuantizedWeight, WeightQuantFormat,
+};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::{MockArg, MockGpuBackend};
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use spark_runtime::kv_cache::KvCacheDtype;
+
+const SCALAR_K: u64 = 0xF081;
+const BATCH4_K: u64 = 0xF084;
+const BATCH16_K: u64 = 0xF08C;
+const WIDTH: usize = 128;
+
+/// What the tier under test is expected to emit for one projection.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Expect {
+    /// One strided launch for all rows, on the given kernel.
+    Batched(u64),
+    /// The per-sequence scalar `w8a16_gemv` loop (one launch per row).
+    Scalar,
+}
+
+struct Case {
+    rows: usize,
+    width: usize,
+    handles: bool,
+    format: WeightQuantFormat,
+    enabled: bool,
+}
+
+impl Case {
+    fn new(rows: usize) -> Self {
+        Self {
+            rows,
+            width: WIDTH,
+            handles: true,
+            format: WeightQuantFormat::Fp8BlockScaled,
+            enabled: true,
+        }
+    }
+}
+
+#[test]
+fn native_fp8_qkv_batches_two_to_four_rows_on_batch4() {
+    for rows in [2, 3, 4] {
+        check_dispatch(&Case::new(rows), Expect::Batched(BATCH4_K));
+    }
+}
+
+#[test]
+fn native_fp8_qkv_batches_five_to_eight_rows_on_batch16() {
+    for rows in [5, 6, 8] {
+        check_dispatch(&Case::new(rows), Expect::Batched(BATCH16_K));
+    }
+}
+
+#[test]
+fn native_fp8_qkv_retains_scalar_for_single_row() {
+    check_dispatch(&Case::new(1), Expect::Scalar);
+}
+
+#[test]
+fn native_fp8_qkv_retains_scalar_without_strided_kernels() {
+    let mut case = Case::new(4);
+    case.handles = false;
+    check_dispatch(&case, Expect::Scalar);
+}
+
+#[test]
+fn native_fp8_qkv_retains_scalar_for_per_row_scales() {
+    let mut case = Case::new(4);
+    case.format = WeightQuantFormat::Fp8PerRow;
+    check_dispatch(&case, Expect::Scalar);
+}
+
+#[test]
+fn native_fp8_qkv_retains_scalar_for_unaligned_dims() {
+    let mut case = Case::new(4);
+    case.width = 64; // hidden/kv dims not a multiple of the 128 block-scale grid
+    check_dispatch(&case, Expect::Scalar);
+}
+
+/// Kill switch: `ATLAS_NO_FP8_QKV_BATCH` present ⇒ tier off. Driven through the
+/// injected flag rather than the env var so the test does not race the
+/// process-global `OnceLock` that caches it in production.
+#[test]
+fn native_fp8_qkv_kill_switch_deselects_the_tier() {
+    let mut case = Case::new(4);
+    case.enabled = false;
+    check_dispatch(&case, Expect::Scalar);
+}
+
+fn check_dispatch(case: &Case, expect: Expect) {
+    let gpu = MockGpuBackend::new();
+    let width = case.width;
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = width;
+    config.intermediate_size = 128;
+    config.num_attention_heads = 1;
+    config.num_key_value_heads = 1;
+    config.head_dim = width;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    let buffers = BufferArena::new(&config, 8, 16, 16, 8, &gpu).unwrap();
+    let dense = DenseWeight {
+        weight: gpu.alloc(256 * 256 * 2).unwrap(),
+    };
+    let fallback = QuantizedWeight::null();
+    let attn = AttentionWeights {
+        q_proj: dense,
+        k_proj: dense,
+        v_proj: dense,
+        o_proj: fallback,
+        q_norm: dense,
+        k_norm: dense,
+        q_norm_full: None,
+        k_norm_full: None,
+        k_scale: 1.0,
+        v_scale: 1.0,
+    };
+    let mut layer = Qwen3AttentionLayer::new(
+        dense,
+        attn,
+        dense,
+        FfnComponent::None,
+        0,
+        None,
+        None,
+        None,
+        &gpu,
+        KvCacheDtype::Bf16,
+        0,
+        &config,
+    )
+    .unwrap();
+    layer.w8a16_gemv_k = KernelHandle(SCALAR_K);
+    layer.w8a16_gemv_batch4_strided_k = KernelHandle(if case.handles { BATCH4_K } else { 0 });
+    layer.w8a16_gemv_batch16_strided_k = KernelHandle(if case.handles { BATCH16_K } else { 0 });
+    layer.deinterleave_qg_k = KernelHandle(0xF0D1);
+
+    let q_dim = (config.num_attention_heads * config.head_dim) as u32;
+    let q_proj_dim = if layer.gated { q_dim * 2 } else { q_dim };
+    let kv_dim = (config.num_key_value_heads * config.head_dim) as u32;
+    let fp8 = |n: u32| Fp8Weight {
+        weight: gpu.alloc(n as usize * width).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n,
+        k: width as u32,
+        scale_format: case.format,
+    };
+    let (q_w, k_w, v_w) = (fp8(q_proj_dim), fp8(kv_dim), fp8(kv_dim));
+    layer.q_weight = Some(QuantWeight::Fp8(q_w));
+    layer.k_weight = Some(QuantWeight::Fp8(k_w));
+    layer.v_weight = Some(QuantWeight::Fp8(v_w));
+
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let fwd = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu: &gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        // The QKV projections under test never read the decode scalars this guards.
+        decode_step: false,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    let c = MultiSeqCtx::new(
+        &layer,
+        &fwd,
+        buffers.hidden_states(),
+        buffers.residual(),
+        case.rows,
+        16,
+        0,
+    );
+
+    assert_eq!(
+        layer.ms_qkv_batchm_fp8_selected(&c, case.enabled),
+        expect != Expect::Scalar,
+        "tier selection for rows={} width={} handles={} enabled={}",
+        case.rows,
+        case.width,
+        case.handles,
+        case.enabled
+    );
+
+    if !case.enabled {
+        // The kill switch is checked above, on the selection predicate. The
+        // production call below reads the process-global `OnceLock` that caches
+        // the env var, which a single test in a shared process cannot flip
+        // without racing every other test — so stop here rather than assert a
+        // launch pattern this process cannot produce.
+        return;
+    }
+
+    let first = gpu.launch_count();
+    let allocations = gpu.alloc_count();
+    layer.ms_phase_qkv(&c).unwrap();
+    let all = gpu.launches_snapshot();
+    assert_eq!(
+        gpu.alloc_count(),
+        allocations,
+        "projection must reuse existing buffers"
+    );
+
+    let bf16 = 2usize;
+    let q_proj_bytes = q_proj_dim as usize * bf16;
+    let kv_bytes = kv_dim as usize * bf16;
+    let c_stride = (c.per_seq_qkv / bf16) as u32;
+    let projections = [
+        (layer.q_weight.as_ref().unwrap(), 0usize, q_proj_dim),
+        (layer.k_weight.as_ref().unwrap(), q_proj_bytes, kv_dim),
+        (
+            layer.v_weight.as_ref().unwrap(),
+            q_proj_bytes + kv_bytes,
+            kv_dim,
+        ),
+    ];
+    for (weight, out_off, n_out) in projections {
+        let w = weight.as_fp8().unwrap();
+        let launches: Vec<_> = all[first..]
+            .iter()
+            .filter(|l| l.args.contains(&MockArg::Buffer(w.weight)))
+            .collect();
+        match expect {
+            Expect::Batched(kernel) => {
+                assert_eq!(launches.len(), 1, "one strided launch per projection");
+                let l = launches[0];
+                assert_eq!(l.func, kernel);
+                assert_eq!(l.args[0], MockArg::Buffer(c.normed));
+                assert_eq!(l.args[1], MockArg::Buffer(w.weight));
+                assert_eq!(l.args[2], MockArg::Buffer(w.row_scale));
+                assert_eq!(l.args[3], MockArg::Buffer(c.qkv_buf.offset(out_off)));
+                assert_eq!(l.args[4], u32_arg(case.rows as u32));
+                assert_eq!(l.args[5], u32_arg(n_out));
+                assert_eq!(l.args[6], u32_arg(width as u32));
+                assert_eq!(l.args[7], u32_arg(width as u32), "A row stride = hidden");
+                assert_eq!(l.args[8], u32_arg(c_stride), "C row stride = per_seq_qkv");
+            }
+            Expect::Scalar => {
+                assert_eq!(launches.len(), case.rows, "one scalar GEMV per row");
+                for (row, l) in launches.iter().enumerate() {
+                    assert_eq!(l.func, SCALAR_K);
+                    assert_eq!(
+                        l.args[0],
+                        MockArg::Buffer(c.normed.offset(row * width * bf16))
+                    );
+                    assert_eq!(
+                        l.args[3],
+                        MockArg::Buffer(c.qkv_buf.offset(row * c.per_seq_qkv + out_off))
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn u32_arg(v: u32) -> MockArg {
+    MockArg::Bytes(v.to_ne_bytes().to_vec())
+}

--- a/crates/spark-model/src/layers/qwen3_attention/types.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types.rs
@@ -190,6 +190,12 @@ pub struct Qwen3AttentionLayer {
     pub(super) w8a16_gemv_k: KernelHandle,
     /// Optional four-row block-scaled FP8 GEMV; zero retains scalar dispatch.
     pub(super) w8a16_gemv_batch4_k: KernelHandle,
+    /// Strided siblings of the above (caller-supplied A/C row pitches) — the
+    /// multi-seq decode Q/K/V tier writes into the `per_seq_qkv`-strided QKV
+    /// buffer, which the contiguous `[M, N]` writers cannot address. Zero on
+    /// either handle retains the per-sequence scalar `w8a16_gemv` loop.
+    pub(super) w8a16_gemv_batch4_strided_k: KernelHandle,
+    pub(super) w8a16_gemv_batch16_strided_k: KernelHandle,
     pub(super) w8a16_gemm_k: KernelHandle,
     pub(super) w8a16_gemm_pipelined_k: KernelHandle,
     pub(super) w4a16_gemv_dual_k: KernelHandle,

--- a/kernels/gb10/common/w8a16_gemv_batch4.cu
+++ b/kernels/gb10/common/w8a16_gemv_batch4.cu
@@ -17,6 +17,10 @@
 // bit-identical to running `w8a16_gemv` M times (verified with exact BF16
 // output comparison). A:[M,K] BF16, B:[N,K] FP8 E4M3, block_scale:[N/128,K/128] FP32,
 // C:[M,N] BF16. Grid: (ceil(N/4), 1, 1)  Block: (256, 1, 1).
+//
+// Entry points: `w8a16_gemv_batch4` / `w8a16_gemv_batch16` (contiguous A and C)
+// and their `_strided` siblings at the bottom of this file, which take the A
+// and C row pitches in elements instead of assuming K and N.
 
 #include <cuda_bf16.h>
 
@@ -98,15 +102,27 @@ __device__ __constant__ float E4M3_LUT_B4[256] = {
 // instantiation serves all n in [1, MAX_M]. MAX_M=4 is the optimal common path
 // (n<=4); MAX_M=16 covers high-concurrency decode (n=5..16) without falling
 // back to the M-padded MMA.
+//
+// `a_row_stride` / `c_row_stride` are the row pitches of A and C in ELEMENTS.
+// The contiguous entry points pass K and N, which is what the body did
+// literally before the strides existed, so their PTX is unchanged. The strided
+// entry points let a caller read rows out of, and write rows into, a larger
+// interleaved buffer without staging a contiguous copy — the multi-seq decode
+// QKV buffer is [n, per_seq_qkv] with Q/K/V at fixed offsets inside each row,
+// so `c_row_stride = per_seq_qkv` targets one projection in place.
+// A must stay 16B-aligned per row (a_row_stride % 8 == 0 for BF16): the
+// activation loads below are uint4.
 template <int MAX_M>
 __device__ __forceinline__ void w8a16_gemv_batchm_impl(
-    const __nv_bfloat16* __restrict__ A,    // [M, K] BF16
+    const __nv_bfloat16* __restrict__ A,    // [M, a_row_stride] BF16, K used
     const unsigned char* __restrict__ B,     // [N, K] FP8 E4M3
     const float* __restrict__ block_scale,   // [N/128, K/128] FP32
-    __nv_bfloat16* __restrict__ C,           // [M, N] BF16
+    __nv_bfloat16* __restrict__ C,           // [M, c_row_stride] BF16, N used
     unsigned int M,
     unsigned int N,
-    unsigned int K
+    unsigned int K,
+    unsigned int a_row_stride,
+    unsigned int c_row_stride
 ) {
     const unsigned int threads_per_out = BLOCK_SIZE / N_PER_BLOCK;  // 64
     const unsigned int local_out = threadIdx.x / threads_per_out;
@@ -151,7 +167,7 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
         #pragma unroll
         for (int t = 0; t < MAX_M; t++) {
             if ((unsigned int)t >= M) continue;
-            const __nv_bfloat16* At = A + (unsigned long long)t * K;
+            const __nv_bfloat16* At = A + (unsigned long long)t * a_row_stride;
             uint4 a_lo = ((const uint4*)At)[k16 * 2];
             uint4 a_hi = ((const uint4*)At)[k16 * 2 + 1];
             const unsigned int ar[8] = {a_lo.x, a_lo.y, a_lo.z, a_lo.w,
@@ -188,7 +204,7 @@ __device__ __forceinline__ void w8a16_gemv_batchm_impl(
         for (int t = 0; t < MAX_M; t++) {
             if ((unsigned int)t >= M) continue;
             float r = smem[t][local_out * 2] + smem[t][local_out * 2 + 1];
-            C[(unsigned long long)t * N + n] = __float2bfloat16(r);
+            C[(unsigned long long)t * c_row_stride + n] = __float2bfloat16(r);
         }
     }
 }
@@ -203,7 +219,7 @@ extern "C" __global__ void w8a16_gemv_batch4(
     unsigned int N,
     unsigned int K
 ) {
-    w8a16_gemv_batchm_impl<4>(A, B, block_scale, C, M, N, K);
+    w8a16_gemv_batchm_impl<4>(A, B, block_scale, C, M, N, K, K, N);
 }
 
 // M<=16 (high-concurrency decode, n=5..16). Same weight-streaming pass; one
@@ -218,5 +234,49 @@ extern "C" __global__ void w8a16_gemv_batch16(
     unsigned int N,
     unsigned int K
 ) {
-    w8a16_gemv_batchm_impl<16>(A, B, block_scale, C, M, N, K);
+    w8a16_gemv_batchm_impl<16>(A, B, block_scale, C, M, N, K, K, N);
+}
+
+// ── Strided siblings ───────────────────────────────────────────────────────
+// Identical math and identical accumulation order to the two entry points
+// above; only the row pitches of A and C are caller-supplied. Added for the
+// multi-seq decode Q/K/V projections (O13): the concurrent-decode QKV buffer
+// is strided by `per_seq_qkv` (14336 BF16 elements on Qwen3.8-27B) with Q at
+// offset 0, K after Q and V after K, so the contiguous `[M, N]` writer above
+// could not serve it and the FP8 attention projections fell back to three
+// scalar `w8a16_gemv` launches PER ROW. These write each projection straight
+// into its slot for all M rows in ONE launch.
+//
+// Separate symbols on purpose: the contiguous entry points are load-bearing
+// for the SSM QKVZ / out_proj and o_proj callers and stay byte-for-byte as
+// they were.
+
+// M<=4 strided (2..=4 concurrent decode rows).
+extern "C" __global__ void w8a16_gemv_batch4_strided(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B,
+    const float* __restrict__ block_scale,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K,
+    unsigned int a_row_stride,
+    unsigned int c_row_stride
+) {
+    w8a16_gemv_batchm_impl<4>(A, B, block_scale, C, M, N, K, a_row_stride, c_row_stride);
+}
+
+// M<=16 strided (5..=16 concurrent decode rows).
+extern "C" __global__ void w8a16_gemv_batch16_strided(
+    const __nv_bfloat16* __restrict__ A,
+    const unsigned char* __restrict__ B,
+    const float* __restrict__ block_scale,
+    __nv_bfloat16* __restrict__ C,
+    unsigned int M,
+    unsigned int N,
+    unsigned int K,
+    unsigned int a_row_stride,
+    unsigned int c_row_stride
+) {
+    w8a16_gemv_batchm_impl<16>(A, B, block_scale, C, M, N, K, a_row_stride, c_row_stride);
 }


### PR DESCRIPTION
> **Stacked on #984.** Its four commits are the first four here; this PR's own content is the single commit `spark-model: batch native FP8 Q/K/V projections across decode rows (O13)`. Review that one — or `git diff pr/fp8-batch-parity-oproj..` — and merge #984 first. Base is `main` rather than #984's branch so the PR does not become unreviewable if #984 is rebased.

## Summary

Multi-row decode dispatched the native-FP8 (W8A16 block-scaled) Q/K/V projections as **three scalar `w8a16_gemv` launches per row**. The batched FP8 GEMV kernels write a contiguous `[M, N]` output, while the multi-seq QKV buffer is strided by `per_seq_qkv` — 14,336 BF16 elements on Qwen3.8-27B, with Q at offset 0, K after Q and V after K inside every row. The batched kernel could not address that layout, so every concurrent sequence re-read the whole q/k/v weight. In the C=4 decode profile that bucket (qkvz / out_proj) is ~6.3 ms of a 44.7 ms step, the third largest.

Refs #927.

## What was wrong

Not a missing kernel — a missing stride. `w8a16_gemv_batchm_impl` assumed A and C were packed `[M, K]` and `[M, N]`. The decode QKV buffer is neither: it is one row per sequence, `per_seq_qkv` elements apart, with the three projections living at fixed offsets *inside* each row. Batching across rows therefore had nowhere to write, and the dispatch fell back to `n x 3` scalar launches over weights that all `n` rows share.

## What the fix does

**Kernel** (`kernels/gb10/common/w8a16_gemv_batch4.cu`). `w8a16_gemv_batchm_impl` gains `a_row_stride` and `c_row_stride`, in elements, and two new entry points expose them: `w8a16_gemv_batch4_strided` and `w8a16_gemv_batch16_strided`. The existing contiguous entry points pass K and N for those arguments, which is literally what the body computed before — so they are unchanged by construction, and that is verified against PTX rather than asserted (below).

**Dispatch.** A new `ms_qkv_batchm_fp8` tier in its own module (`multi_seq/qkv_fp8_batch.rs`, kept out of the already-oversized `qkv.rs`) takes `n` in 2..=8 when all of q/k/v are block-scaled FP8, the dims are multiples of 128, both strided handles resolved, and `ATLAS_NO_FP8_QKV_BATCH` is unset. One launch per projection, straight into the per-seq offsets the scalar loop already used, then the same gated-Q deinterleave the per-sequence FP8 branch applies. LoRA and the q/k norms stay where `ms_phase_qkv` runs them for every branch — this tier does not move them.

The tier sits after the NVFP4 tiers and before the dense-BF16 one; they are mutually exclusive by weight type, so that ordering is readability, not precedence. It branches on the **padded** ctx `n` — the value the CUDA-graph cache is keyed by — never on the unpadded sequence count, so a captured graph cannot be replayed under a different dispatch than it was captured with.

## Oracle and evidence

**The entry points that already existed are byte-for-byte unaffected.** `w8a16_gemv_batch4` and `w8a16_gemv_batch16` were compiled from #984's tree and from this one, at `sm_90a` and `sm_121a`, and their entry bodies compared:

```
sm_90a   w8a16_gemv_batch4 : instruction-identical after symbol-name normalisation (606 lines)
sm_90a   w8a16_gemv_batch16: instruction-identical after symbol-name normalisation (1906 lines)
sm_121a  w8a16_gemv_batch4 : instruction-identical after symbol-name normalisation (509 lines)
sm_121a  w8a16_gemv_batch16: instruction-identical after symbol-name normalisation (1535 lines)
```

The only raw difference is the template's mangled shared-symbol name (`...PS0_jjjE` -> `...PS0_jjjjjE`, the two new parameters) and the `// demoted variable` shared declarations moving to module scope now that four entries instantiate the template instead of two. Not one instruction moves. Resource usage is identical across all four entry points on both targets, with no spills:

| target | batch4 / batch4_strided | batch16 / batch16_strided |
|---|---|---|
| sm_90a | 48 regs, 1152 B smem | 64 regs, 1536 B smem |
| sm_121a | 46 regs, 1152 B smem | 71 regs, 1536 B smem |

**Bit-exactness against the scalar path, H100, 2026-09-11 05:19 UTC.** `native_fp8_qkv_batch_microtest` at the real Qwen3.8-27B shapes (N=12288 / K=5120 / stride=14336 and the k/v shapes), each row compared against production scalar `w8a16_gemv`:

```
KNOWN_BAD output-bit: refused: batch output differs from production scalar BF16 bits
KNOWN_BAD gap:        refused: batched projection wrote outside its extent at byte 24642
KNOWN_BAD guard:      refused: batched projection wrote outside its extent at byte 0
KNOWN_BAD nonfinite:  refused: nonfinite projection output

q_proj   M=8 N=12288 K=5120 stride=14336 kernel=batch16 unequal_bf16=0 max_abs=0.000000000
full-qkv M=8 row_elems=14336 K=5120                     unequal_bf16=0 max_abs=0.000000000
ALL PASS: Qwen3.8-27B q/k/v shapes, strided batch4 M2/M3/M4 and batch16 M5/M8,
          exact scalar equivalence, gaps and guards intact
O13_EXIT=0
```

That is **20/20 positive cases** — M in {2,3,4} on `batch4`, M in {5,8} on `batch16`, each crossed with {q_proj, k_proj, v_proj, full-qkv} — every one `unequal_bf16=0`, with four negative controls refused first, so the harness demonstrably can fail. Each single-projection case leaves the other two slots as gaps and requires them, the rows past M, and the guard bands to stay sentinel: the whole risk of a strided write is writing outside the extent, so that is what is asserted.

The serving-level counterpart from the same session: a 16-way concurrent arithmetic probe, all 16 sharing one decode step, **16/16 correct** in 4.05 s wall with exact string matching.

Note the microtest only means anything with `ATLAS_TARGET_HW=hopper ATLAS_TARGET_MODEL=qwen3.8-27b ATLAS_TARGET_QUANT=nvfp4` exported, and nothing in `env.sh` supplies them. Worth fixing separately.

**Host dispatch** tests (`qkv_fp8_batch_tests.rs`) cover n=1, n in 2..=8, missing handles, per-row scales, unaligned dims and the `ATLAS_NO_FP8_QKV_BATCH` kill switch.

**No throughput number is claimed here.** The ~6.3 ms of 44.7 ms figure is the *pre-change* profile that motivated the work; the A/B that would say what this bought is owed on GB10 and is not something this PR asserts.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda --lib qkv` — **18 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda --lib o_proj` — **7 passed, 0 failed** (#984's tests, unmoved)
- [x] `cargo test -p spark-model --features cuda --lib` — **898 passed, 0 failed, 11 ignored** (891 on #984, +7 new dispatch tests)
- [x] `cargo clippy -p spark-model -p spark-server --tests --features cuda,nccl` — clean, no warnings emitted
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] PTX, strict, both targets — `nvcc --ptx -arch=sm_121a` and `-arch=sm_90a` with `-DATLAS_NO_WARP_BLOCKSCALE_MMA --Werror all-warnings`; all four entry points emit, plus the entry-body identity comparison and `--cubin -Xptxas -v` resource numbers above
- [x] Tested against real hardware — H100 microtest receipt above (2026-09-11)
- [ ] `scripts/hopper_ptx_gate.sh --hw gb10 --model qwen3.8-27b --jobs 8 --strict` — **the script does not exist on `main`**; it lives on the #895 campaign branch. The direct `nvcc` work above is the substitute and is reported as such, not claimed as that gate.

## GB10 perf-gate records

This diff touches `crates/` and `kernels/`, both PERF_PATHs, so `record_covers` invalidates every committed `.benchmarks/` record on landing. A GB10 re-measure is owed before merge — and it is also where the decode A/B this PR declines to claim would come from.

## Notes for reviewers

The reason the pre-existing entry points get a PTX identity check rather than a "it is obviously the same" argument: the refactor threads two new parameters through a template that four entry points now instantiate, and the compiler is free to re-register-allocate the lot. "Obviously the same" is exactly the claim that is cheap to make and cheap to check, so it is checked.

`n` in 2..=8 rather than 2..=16 is the conservative bound: `batch16_strided` is wired and covered by the oracle at M=5 and M=8, but no decode profile on the target hardware reaches the padded ctx above 8, so widening it would ship an untested band. Raising the ceiling is a one-line change once a profile needs it.

The kernel's accumulation order is the one #932 fixed and is not touched here — which is why this PR is stacked on #984 rather than racing it: both edit `w8a16_gemv_batch4.cu`, and landing them in the other order would put the strided template on top of the pair-summing accumulator.

Cherry-picked from `fix/o13-fp8-qkv-batch` on the fork with an `-x` provenance line. Applied to #984's branch with **no conflicts**; nothing was adapted.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
