### PR TITLE
spark-model: W8A8 block-scaled dense FFN prefill (#917)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -279,3 +279,7 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "w4a16_qg_batch_bitparity_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+name = "native_fp8_ffn_w8a8_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/native_fp8_ffn_w8a8_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_ffn_w8a8_microtest.rs
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Dense-FFN W8A8 block-scaled prefill at the real Qwen3.8-27B shapes (#917/#928).
+//!
+//! WHY. The native-FP8 dense FFN ran its prefill GEMMs as W8A16 — BF16
+//! activations against E4M3 weights, so the MMA is the BF16 tensor-core path.
+//! On H100 (2026-09-11, 1193-token prompt) that put TTFT at 1075 ms against
+//! vLLM's 287 ms, with `w8a16_gemm_pipelined` turning ~12 TFLOP/s on these
+//! shapes. This microtest measures the replacement: the same W8A8 block-scaled
+//! arithmetic the attention projections already use, with cuBLASLt as the
+//! Hopper fast path.
+//!
+//! What it reports, per shape and per M:
+//!   * W8A8 (kernel) vs W8A16 — max_abs, cosine, relative RMS. W8A8 quantizes
+//!     the ACTIVATION to E4M3 per 128-wide K group, which W8A16 does not; the
+//!     difference is vLLM's dynamic W8A8 arithmetic and a deliberate precision
+//!     trade, not a defect.
+//!   * cuBLASLt vs the W8A8 kernel — same quantized inputs, same FP32
+//!     epilogue, so these should be near bit-identical; the max BF16 ULP
+//!     distance is printed so "near" is a number and not an adjective.
+//!   * TFLOP/s for each path (CUDA events, 10 iterations after warm-up).
+//!
+//! NUMERICS FLOOR — read before judging a marginal `rel_rms`. E4M3 carries 3
+//! stored mantissa bits, so round-to-nearest costs ~2.5% RMS relative error per
+//! element, and for a dot product of independent terms that error does NOT
+//! average down relative to the signal: the expected `rel_rms` of this
+//! comparison on random inputs is ~2-2.6%, sitting right on the 2% gate.
+//! Cosine is the robust metric (~0.9997 at that error). `ATLAS_W8A8_REL_RMS_GATE`
+//! overrides the bound for a measurement run; the value used is always printed.
+//!
+//! Run (H100):
+//!   cargo run --release -p spark-model --features cuda,gpu-examples \
+//!     --example native_fp8_ffn_w8a8_microtest
+//!   ATLAS_CUBLAS_GEMM=1 cargo run --release -p spark-model \
+//!     --features cuda,gpu-examples --example native_fp8_ffn_w8a8_microtest
+
+use anyhow::{Result, bail};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_model::weight_map::{Fp8Weight, WeightQuantFormat};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+// CUDA driver event API — kernel-only timing. Wall-clock `Instant` carries a
+// ~0.3 ms per-launch host floor that swamps the signal on these shapes.
+// Signatures mirror `examples/w8a16_microtest.rs` (SSOT for these decls).
+unsafe extern "C" {
+    fn cuEventCreate(event: *mut u64, flags: u32) -> i32;
+    fn cuEventRecord(event: u64, stream: u64) -> i32;
+    fn cuEventSynchronize(event: u64) -> i32;
+    fn cuEventElapsedTime(ms: *mut f32, start: u64, end: u64) -> i32;
+    fn cuEventDestroy_v2(event: u64) -> i32;
+}
+
+/// Qwen3.8-27B dense FFN: hidden 5120, intermediate 17408.
+const H: usize = 5120;
+const INTER: usize = 17408;
+/// 64 = a short prefill chunk; 1193 = the prompt length in the #917 H100 trace.
+const BATCHES: [usize; 2] = [64, 1193];
+const BLOCK: usize = 128;
+const ITERS: u32 = 10;
+const WARMUP: u32 = 3;
+const COSINE_GATE: f64 = 0.999;
+const REL_RMS_GATE: f64 = 0.02;
+
+struct Rng(u64);
+impl Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 32) as u32
+    }
+    /// Uniform in [-1, 1).
+    fn unit(&mut self) -> f32 {
+        (self.next_u32() % 2049) as f32 / 1024.0 - 1.0
+    }
+}
+
+fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len().max(1))?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+
+fn download_bf16(gpu: &dyn GpuBackend, ptr: DevicePtr, elems: usize) -> Result<Vec<u16>> {
+    let mut raw = vec![0u8; elems * 2];
+    gpu.copy_d2h(ptr, &mut raw)?;
+    Ok(raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
+}
+
+fn to_f64(bits: &[u16]) -> Vec<f64> {
+    bits.iter()
+        .map(|b| bf16::from_bits(*b).to_f32() as f64)
+        .collect()
+}
+
+/// BF16 bits → a monotonically ordered integer, so `|ord(a) - ord(b)|` is the
+/// ULP distance (the standard sign-magnitude → two's-complement remap).
+fn ord(bits: u16) -> i32 {
+    if bits & 0x8000 != 0 {
+        -((bits & 0x7fff) as i32)
+    } else {
+        bits as i32
+    }
+}
+
+struct Compare {
+    max_abs: f64,
+    cosine: f64,
+    rel_rms: f64,
+    max_ulp: i32,
+    unequal: usize,
+}
+
+fn compare(a_bits: &[u16], b_bits: &[u16]) -> Compare {
+    let (a, b) = (to_f64(a_bits), to_f64(b_bits));
+    let (mut dot, mut na, mut nb, mut max_abs, mut sq_diff, mut sq_ref) =
+        (0.0, 0.0, 0.0, 0.0_f64, 0.0, 0.0);
+    for (x, y) in a.iter().zip(&b) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+        max_abs = max_abs.max((x - y).abs());
+        sq_diff += (x - y) * (x - y);
+        sq_ref += y * y;
+    }
+    Compare {
+        max_abs,
+        cosine: dot / (na.sqrt() * nb.sqrt()),
+        rel_rms: (sq_diff / sq_ref.max(f64::MIN_POSITIVE)).sqrt(),
+        max_ulp: a_bits
+            .iter()
+            .zip(b_bits)
+            .map(|(x, y)| (ord(*x) - ord(*y)).abs())
+            .max()
+            .unwrap_or(0),
+        unequal: a_bits.iter().zip(b_bits).filter(|(x, y)| x != y).count(),
+    }
+}
+
+/// GPU time per iteration for `launch`, in seconds (CUDA events, no host sync
+/// between iterations).
+fn time_gpu(
+    gpu: &dyn GpuBackend,
+    stream: u64,
+    mut launch: impl FnMut() -> Result<()>,
+) -> Result<f64> {
+    for _ in 0..WARMUP {
+        launch()?;
+    }
+    gpu.synchronize(stream)?;
+    let (mut ev_start, mut ev_end) = (0u64, 0u64);
+    for (ev, what) in [(&mut ev_start, "start"), (&mut ev_end, "end")] {
+        let rc = unsafe { cuEventCreate(ev, 0) };
+        if rc != 0 {
+            bail!("cuEventCreate({what}) failed: status {rc}");
+        }
+    }
+    if unsafe { cuEventRecord(ev_start, stream) } != 0 {
+        bail!("cuEventRecord(start) failed");
+    }
+    for _ in 0..ITERS {
+        launch()?;
+    }
+    if unsafe { cuEventRecord(ev_end, stream) } != 0 {
+        bail!("cuEventRecord(end) failed");
+    }
+    if unsafe { cuEventSynchronize(ev_end) } != 0 {
+        bail!("cuEventSynchronize failed");
+    }
+    let mut ms: f32 = 0.0;
+    if unsafe { cuEventElapsedTime(&mut ms, ev_start, ev_end) } != 0 {
+        bail!("cuEventElapsedTime failed");
+    }
+    unsafe {
+        cuEventDestroy_v2(ev_start);
+        cuEventDestroy_v2(ev_end);
+    }
+    Ok((ms as f64 / 1e3) / ITERS as f64)
+}
+
+fn tflops(m: usize, n: usize, k: usize, secs: f64) -> f64 {
+    2.0 * m as f64 * n as f64 * k as f64 / secs / 1e12
+}
+
+struct Shape {
+    label: &'static str,
+    n: usize,
+    k: usize,
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let stream = 0u64;
+    let w8a16_k = gpu.kernel("w8a16_gemm_pipelined", "w8a16_gemm_pipelined")?;
+    let quant_k = gpu.kernel("per_token_group_quant_fp8", "per_token_group_quant_fp8")?;
+    let w8a8_k = gpu.kernel("fp8_gemm_t_blockscaled", "fp8_gemm_t_blockscaled")?;
+    let want_cublas = std::env::var("ATLAS_CUBLAS_GEMM").as_deref() == Ok("1");
+    let rel_rms_gate = std::env::var("ATLAS_W8A8_REL_RMS_GATE")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(REL_RMS_GATE);
+
+    println!(
+        "dense-FFN W8A8 microtest — H={H} INTER={INTER}  cuBLASLt={}  gates: cosine>={COSINE_GATE} rel_rms<={rel_rms_gate}",
+        if want_cublas {
+            "on (ATLAS_CUBLAS_GEMM=1)"
+        } else {
+            "off"
+        }
+    );
+
+    let mut rng = Rng(0x9_17_09_28_2026);
+    let max_m_pad = BATCHES
+        .iter()
+        .map(|m| m.div_ceil(16) * 16)
+        .max()
+        .expect("BATCHES is non-empty");
+    let max_k = H.max(INTER);
+    let max_n = H.max(INTER);
+
+    // Activations [max_m_pad, max_k] BF16 — one buffer, sliced per shape. The
+    // padded rows exist because the cuBLASLt arm reads ceil16(M) rows.
+    let act_host: Vec<u8> = (0..max_m_pad * max_k)
+        .flat_map(|_| bf16::from_f32(rng.unit()).to_bits().to_le_bytes())
+        .collect();
+    let act = upload(&gpu, &act_host)?;
+    let a_fp8 = gpu.alloc(max_m_pad * max_k)?;
+    let a_scale = gpu.alloc(max_m_pad * (max_k / BLOCK) * 4)?;
+    let out_ref = gpu.alloc(max_m_pad * max_n * 2)?;
+    let out_w8a8 = gpu.alloc(max_m_pad * max_n * 2)?;
+    let out_cublas = gpu.alloc(max_m_pad * max_n * 2)?;
+
+    let shapes = [
+        Shape {
+            label: "gate/up",
+            n: INTER,
+            k: H,
+        },
+        Shape {
+            label: "down",
+            n: H,
+            k: INTER,
+        },
+    ];
+    let mut failures: Vec<String> = Vec::new();
+
+    for shape in shapes {
+        let (n, k) = (shape.n, shape.k);
+        // E4M3 bytes with the 0x7F/0xFF NaN encodings excluded (mantissa capped
+        // at 6 for the all-ones exponent is what the quantizer emits; staying
+        // under 127 in the magnitude avoids the encoding entirely).
+        let w_host: Vec<u8> = (0..n * k)
+            .map(|_| {
+                let x = rng.next_u32();
+                ((x % 127) as u8) | (((x >> 7) & 1) as u8) << 7
+            })
+            .collect();
+        // Block scales [N/128, K/128] FP32 — the checkpoint layout both the
+        // W8A16 kernel and the W8A8 FP32 epilogue index as `scale[n/128][k/128]`.
+        let s_host: Vec<u8> = (0..(n / BLOCK) * (k / BLOCK))
+            .flat_map(|_| ((rng.next_u32() % 16 + 1) as f32 / 1024.0).to_le_bytes())
+            .collect();
+        let weight = upload(&gpu, &w_host)?;
+        let scale = upload(&gpu, &s_host)?;
+        let fp8w = Fp8Weight {
+            weight,
+            row_scale: scale,
+            n: n as u32,
+            k: k as u32,
+            scale_format: WeightQuantFormat::Fp8BlockScaled,
+        };
+
+        for m in BATCHES {
+            let (mu, nu, ku) = (m as u32, n as u32, k as u32);
+            // ── W8A16 reference (today's production path) ──
+            let w8a16 = || {
+                ops::w8a16_gemm_pipelined(
+                    &gpu, w8a16_k, act, weight, scale, out_ref, mu, nu, ku, stream,
+                )
+            };
+            w8a16()?;
+            gpu.synchronize(stream)?;
+            let ref_bits = download_bf16(&gpu, out_ref, m * n)?;
+            let t_w8a16 = time_gpu(&gpu, stream, w8a16)?;
+
+            // ── W8A8: quantize once, then the in-tree GEMM ──
+            ops::per_token_group_quant_fp8(&gpu, quant_k, act, a_fp8, a_scale, mu, ku, stream)?;
+            gpu.synchronize(stream)?;
+            let w8a8 = || {
+                ops::fp8_gemm_t_blockscaled(
+                    &gpu, w8a8_k, a_fp8, a_scale, weight, scale, out_w8a8, mu, nu, ku, stream,
+                )
+            };
+            w8a8()?;
+            gpu.synchronize(stream)?;
+            let w8a8_bits = download_bf16(&gpu, out_w8a8, m * n)?;
+            let t_w8a8 = time_gpu(&gpu, stream, w8a8)?;
+
+            let c = compare(&w8a8_bits, &ref_bits);
+            println!(
+                "[{}] M={m} N={n} K={k}\n  W8A16 ref : {:>8.3} ms  {:>7.2} TFLOP/s\n  \
+                 W8A8 kern : {:>8.3} ms  {:>7.2} TFLOP/s  ({:.2}x)  \
+                 max_abs={:.6} cosine={:.6} rel_rms={:.4}",
+                shape.label,
+                t_w8a16 * 1e3,
+                tflops(m, n, k, t_w8a16),
+                t_w8a8 * 1e3,
+                tflops(m, n, k, t_w8a8),
+                t_w8a16 / t_w8a8,
+                c.max_abs,
+                c.cosine,
+                c.rel_rms,
+            );
+            if !(c.cosine >= COSINE_GATE) || !c.cosine.is_finite() {
+                failures.push(format!(
+                    "{} M={m}: cosine {:.6} < {COSINE_GATE}",
+                    shape.label, c.cosine
+                ));
+            }
+            if !(c.rel_rms <= rel_rms_gate) || !c.rel_rms.is_finite() {
+                failures.push(format!(
+                    "{} M={m}: rel_rms {:.4} > {rel_rms_gate}",
+                    shape.label, c.rel_rms
+                ));
+            }
+
+            // ── cuBLASLt on the SAME quantized activation ──
+            if want_cublas {
+                let cublas = || {
+                    ops::cublas_fp8_proj_prequant(
+                        &gpu, a_fp8, a_scale, &fp8w, out_cublas, mu, nu, ku, stream,
+                    )
+                };
+                cublas()?;
+                gpu.synchronize(stream)?;
+                let cub_bits = download_bf16(&gpu, out_cublas, m * n)?;
+                let t_cub = time_gpu(&gpu, stream, cublas)?;
+                let d = compare(&cub_bits, &w8a8_bits);
+                let r = compare(&cub_bits, &ref_bits);
+                println!(
+                    "  cuBLASLt  : {:>8.3} ms  {:>7.2} TFLOP/s  ({:.2}x vs W8A16, {:.2}x vs kernel)\n    \
+                     vs kernel: unequal_bf16={}/{} max_ulp={} max_abs={:.6} cosine={:.9} rel_rms={:.2e}\n    \
+                     vs W8A16 : max_abs={:.6} cosine={:.6} rel_rms={:.4}",
+                    t_cub * 1e3,
+                    tflops(m, n, k, t_cub),
+                    t_w8a16 / t_cub,
+                    t_w8a8 / t_cub,
+                    d.unequal,
+                    m * n,
+                    d.max_ulp,
+                    d.max_abs,
+                    d.cosine,
+                    d.rel_rms,
+                    r.max_abs,
+                    r.cosine,
+                    r.rel_rms,
+                );
+                // Same quantized inputs and the same FP32 epilogue: a real
+                // disagreement here is a layout bug (scale order, transpose),
+                // not precision. A few BF16 ULP of tile-order rounding is fine.
+                if d.max_ulp > 4 {
+                    failures.push(format!(
+                        "{} M={m}: cuBLASLt vs kernel max_ulp={} (> 4) — check the \
+                         VEC128 act-scale / BLK128x128 weight-scale layouts",
+                        shape.label, d.max_ulp
+                    ));
+                }
+                if !(r.cosine >= COSINE_GATE) {
+                    failures.push(format!(
+                        "{} M={m}: cuBLASLt vs W8A16 cosine {:.6} < {COSINE_GATE}",
+                        shape.label, r.cosine
+                    ));
+                }
+            }
+        }
+        gpu.free(weight).ok();
+        gpu.free(scale).ok();
+    }
+
+    for p in [act, a_fp8, a_scale, out_ref, out_w8a8, out_cublas] {
+        gpu.free(p).ok();
+    }
+    if failures.is_empty() {
+        println!("RESULT: PASS (all shapes within cosine/rel_rms/ULP gates)");
+        Ok(())
+    } else {
+        for f in &failures {
+            eprintln!("FAIL: {f}");
+        }
+        bail!("{} gate(s) failed", failures.len())
+    }
+}

--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -249,6 +249,14 @@ pub struct DenseFfnLayer {
     // Preferred over w8a16_gemm when a transposed FP8 weight copy is present.
     // KernelHandle(0) → fall back to non-transposed w8a16_gemm.
     w8a16_gemm_t_m128_k: KernelHandle,
+    // W8A8 block-scaled prefill pair (#917/#928): per-token 1x128 FP8
+    // activation quant + the FP8xFP8 GEMM with both scale sets folded in an
+    // FP32 epilogue. Same two entry points the attention Q/K/V/O prefill
+    // already resolves, so no model shadow needs a new kernel; KernelHandle(0)
+    // on a shadow that lacks them -> the W8A16 branches still run.
+    // Dispatch rule + rationale live in `dense_ffn_w8a8_prefill.rs` (SSOT).
+    per_token_group_quant_fp8_k: KernelHandle,
+    fp8_gemm_t_blockscaled_k: KernelHandle,
     /// v0 LoRA overlay for gate/up/down. `set_lora_weights` REJECTS layers
     /// where `fp8_weights`, `bf16_weights` or `q2_weights` are installed (v0
     /// supports the NVFP4 dispatch path only — those branches early-return
@@ -422,6 +430,16 @@ impl DenseFfnLayer {
                 "w8a16_gemv_silu_input",
             ),
             w8a16_gemm_t_m128_k: super::try_kernel(gpu, "w8a16_gemm_t_m128", "w8a16_gemm_t_m128"),
+            per_token_group_quant_fp8_k: super::try_kernel(
+                gpu,
+                "per_token_group_quant_fp8",
+                "per_token_group_quant_fp8",
+            ),
+            fp8_gemm_t_blockscaled_k: super::try_kernel(
+                gpu,
+                "fp8_gemm_t_blockscaled",
+                "fp8_gemm_t_blockscaled",
+            ),
             lora: None,
             q2_weights: None,
             // Winner of the decode-GEMV bench: candidate B (vectorized code loads
@@ -1935,7 +1953,7 @@ impl DenseFfnLayer {
         // Every fallback retains the original E4M3 bytes and FP32 block scales.
         if let Some(ref fp8w) = self.fp8_weights {
             macro_rules! w8_gemm {
-                ($w:expr, $wt:expr, $in:expr, $out:expr, $n:expr, $k:expr) => {
+                ($w:expr, $wt:expr, $in:expr, $out:expr, $n:expr, $k:expr, $a8:expr, $cap:expr) => {
                     match $wt {
                         _ if (1..=4).contains(&m) && self.w8a16_gemv_batch4_k.0 != 0 => {
                             ops::w8a16_gemv_batch4(
@@ -1950,6 +1968,14 @@ impl DenseFfnLayer {
                                 $k,
                                 stream,
                             )?
+                        }
+                        // W8A8 block-scaled (#917/#928) — ahead of the W8A16
+                        // arms below, which run the BF16 MMA at ~12 TFLOP/s on
+                        // these shapes. `$a8` is `Some` exactly when
+                        // `prefill_w8a8_selected` held for this projection.
+                        _ if $a8.is_some() => {
+                            let (a_fp8, a_scale) = $a8.expect("guarded by is_some");
+                            self.w8a8_gemm(ctx, a_fp8, a_scale, &$w, $out, $cap, m, $n, $k, stream)?
                         }
                         Some(wt) if self.w8a16_gemm_t_m128_k.0 != 0 => {
                             let wt: Fp8WeightTransposed = wt;
@@ -1996,8 +2022,35 @@ impl DenseFfnLayer {
             let gate_t: Option<Fp8WeightTransposed> = None;
             let up_t: Option<Fp8WeightTransposed> = None;
             let down_t: Option<Fp8WeightTransposed> = None;
-            w8_gemm!(fp8w.gate_proj, gate_t, input, gate_out, inter, h);
-            w8_gemm!(fp8w.up_proj, up_t, input, up_out, inter, h);
+            // W8A8 activation quant (#917/#928), ONCE per shared input: gate and
+            // up both read `input`, so quantizing per projection would pay the
+            // per-token E4M3 cast twice per layer for identical bytes. down
+            // quantizes separately because its input is the post-SiLU product.
+            // `None` => that projection keeps today's W8A16 dispatch.
+            // Selection rule + WHY: `dense_ffn_w8a8_prefill.rs` (SSOT).
+            let gate_up_w8a8 = self.prefill_w8a8_selected(ctx, m, inter, h, &fp8w.gate_proj)
+                && self.prefill_w8a8_selected(ctx, m, inter, h, &fp8w.up_proj);
+            let down_w8a8 = self.prefill_w8a8_selected(ctx, m, h, inter, &fp8w.down_proj);
+            if !gate_up_w8a8 && !down_w8a8 {
+                self.log_w8a16_prefill_route(ctx);
+            }
+            let gu_a8 = if gate_up_w8a8 {
+                Some(self.w8a8_quant_act(ctx, input, m, h, stream)?)
+            } else {
+                None
+            };
+            let gu_cap = ctx.buffers.expert_gate_out_bytes();
+            w8_gemm!(
+                fp8w.gate_proj,
+                gate_t,
+                input,
+                gate_out,
+                inter,
+                h,
+                gu_a8,
+                gu_cap
+            );
+            w8_gemm!(fp8w.up_proj, up_t, input, up_out, inter, h, gu_a8, gu_cap);
             ops::silu_mul(
                 ctx.gpu,
                 self.act_mul,
@@ -2008,7 +2061,25 @@ impl DenseFfnLayer {
                 stream,
             )?;
             let output = ctx.buffers.moe_output();
-            w8_gemm!(fp8w.down_proj, down_t, gate_out, output, h, inter);
+            // `gate_out` (the SiLU product) is fully written by the launch above
+            // and re-read here; the quant lands in the SAME scratch the gate/up
+            // quant used, which is safe because every launch is on `stream`.
+            let down_a8 = if down_w8a8 {
+                Some(self.w8a8_quant_act(ctx, gate_out, m, inter, stream)?)
+            } else {
+                None
+            };
+            let down_cap = ctx.buffers.moe_output_bytes();
+            w8_gemm!(
+                fp8w.down_proj,
+                down_t,
+                gate_out,
+                output,
+                h,
+                inter,
+                down_a8,
+                down_cap
+            );
             return Ok(());
         }
 
@@ -2686,6 +2757,12 @@ impl DenseFfnLayer {
         self.forward_prefill(input, num_tokens, ctx, stream)
     }
 }
+
+/// W8A8 block-scaled prefill branch (#917/#928). A CHILD module, not a
+/// sibling: it adds `impl DenseFfnLayer` methods that read this layer's
+/// private kernel handles, and this file is already at the CI size cap.
+#[path = "dense_ffn_w8a8_prefill.rs"]
+pub mod w8a8_prefill;
 
 /// Native BF16/FP8 overlays take precedence over any NVFP4 fallback weights.
 /// Small batches must use the same format-aware dispatcher as prefill.

--- a/crates/spark-model/src/layers/dense_ffn_w8a8_prefill.rs
+++ b/crates/spark-model/src/layers/dense_ffn_w8a8_prefill.rs
@@ -65,16 +65,17 @@ pub fn ffn_w8a16_only() -> bool {
 /// reason — a process-global `OnceLock` cannot be toggled per test).
 ///
 /// Clauses, each load-bearing:
-///   * `m > 4`   — M<=4 stays on the batch4 GEMV, which streams each weight
-///                 once and beats any MMA tile at those shapes.
-///   * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch
-///                 that already governs the attention W8A8 path.
-///   * `Fp8BlockScaled` — a per-ROW scale is a different `row_scale` layout;
-///                 the block-scaled GEMM would read it as `[N/128, K/128]`.
-///   * `k % 128 == 0` — the activation quantizer emits one scale per 128-wide
-///                 K group and the GEMM folds per K-block.
-///   * `n % 128 == 0` — the weight scale grid is `[N/128, K/128]`.
-///   * both handles loaded — a model shadow may not carry either entry point.
+///
+/// * `m > 4` — M<=4 stays on the batch4 GEMV, which streams each weight once
+///   and beats any MMA tile at those shapes.
+/// * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch that
+///   already governs the attention W8A8 path.
+/// * `Fp8BlockScaled` — a per-ROW scale is a different `row_scale` layout; the
+///   block-scaled GEMM would read it as `[N/128, K/128]`.
+/// * `k % 128 == 0` — the activation quantizer emits one scale per 128-wide K
+///   group and the GEMM folds per K-block.
+/// * `n % 128 == 0` — the weight scale grid is `[N/128, K/128]`.
+/// * both handles loaded — a model shadow may not carry either entry point.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn w8a8_prefill_selected(
     m: u32,

--- a/crates/spark-model/src/layers/dense_ffn_w8a8_prefill.rs
+++ b/crates/spark-model/src/layers/dense_ffn_w8a8_prefill.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! W8A8 block-scaled dense-FFN PREFILL — the gate/up/down GEMM arm that the
+//! native-FP8 dispatch in `dense_ffn.rs` reaches ahead of its W8A16 branches.
+//!
+//! WHY (#917 / #928). On a native-FP8 checkpoint the dense FFN's prefill GEMMs
+//! ran `w8a16_gemm_pipelined`: BF16 activations against E4M3 weights, so the
+//! MMA is the BF16 tensor-core path and the FP8 bytes are pure memory savings.
+//! Measured on H100 (2026-09-11, 1193-token prompt): TTFT 1075 ms against
+//! vLLM's 287 ms for the same model and prompt, with the pipelined kernel
+//! turning ~12 TFLOP/s on the FFN shapes. The attention Q/K/V/O projections had
+//! already moved to the W8A8 block-scaled path (`paged_qkv.rs` /
+//! `paged_oproj.rs`), and the MoE shared expert with them
+//! (`moe/forward_prefill_fp8.rs`) — the dense FFN was the one large prefill
+//! consumer still on W8A16, and on a dense model it is most of the FLOPs.
+//!
+//! This gives it the same arithmetic vLLM uses: per-token 1x128 FP32
+//! activation scales (`per_token_group_quant_fp8`) multiplied against the
+//! checkpoint's 128x128 FP32 weight scales in an FP32 epilogue, with the
+//! product accumulated by `mma.sync.m16n8k32.e4m3` — native on sm_90a (H100)
+//! and sm_121. Two GEMM implementations sit behind one selector:
+//!
+//!   * cuBLASLt `fp8_gemm_act_weight_t_blkscaled` (weight as A with
+//!     BLK128x128 scales, activation as B with VEC128 scales — the DeepSeek
+//!     block-FP8 scheme), when `ATLAS_CUBLAS_GEMM=1`. The Hopper fast path.
+//!   * `ops::fp8_gemm_t_blockscaled`, the in-tree kernel, otherwise.
+//!
+//! Both consume the SAME quantized activation and the same FP32 epilogue, so
+//! they are expected to agree to a BF16 ULP or two; the microtest
+//! (`examples/native_fp8_ffn_w8a8_microtest.rs`) pins that.
+//!
+//! ACCURACY. W8A8 is lossier than W8A16 by construction — the activation is
+//! quantized to E4M3 per 128-element group instead of kept in BF16. That is
+//! vLLM's dynamic W8A8 arithmetic and a deliberate precision trade, not a bug:
+//! the microtest gates it at cosine >= 0.999 / relative RMS <= 2% against the
+//! W8A16 reference, and the serve logs the selected path once at INFO so which
+//! arithmetic ran is visible in any TTFT report. `ATLAS_FFN_W8A16_ONLY=1`
+//! restores the old path byte-for-byte.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+use super::DenseFfnLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// `ATLAS_FFN_W8A16_ONLY` kill switch: PRESENCE (any value, including empty)
+/// keeps the dense-FFN prefill on today's W8A16 kernels. Presence rather than
+/// `=1` because this is an escape hatch an operator reaches for while a serve
+/// is misbehaving, and `ATLAS_FFN_W8A16_ONLY=0` meaning "on" is a trap.
+///
+/// `OnceLock`-cached: the selector runs per projection per layer per prefill
+/// (3 x num_layers times), and `std::env::var_os` walks the environment block
+/// on every call. Cached process-wide is correct here — the variable is read
+/// once at first prefill and a serve never rewrites its own environment.
+pub fn ffn_w8a16_only() -> bool {
+    static ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ONLY.get_or_init(|| std::env::var_os("ATLAS_FFN_W8A16_ONLY").is_some())
+}
+
+/// The whole W8A8 selection rule, as a pure function of shape + format +
+/// handles. Split out from the layer method so the CPU tests can pin every
+/// clause without a `ForwardContext` (`w8a16_only` is injected for the same
+/// reason — a process-global `OnceLock` cannot be toggled per test).
+///
+/// Clauses, each load-bearing:
+///   * `m > 4`   — M<=4 stays on the batch4 GEMV, which streams each weight
+///                 once and beats any MMA tile at those shapes.
+///   * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch
+///                 that already governs the attention W8A8 path.
+///   * `Fp8BlockScaled` — a per-ROW scale is a different `row_scale` layout;
+///                 the block-scaled GEMM would read it as `[N/128, K/128]`.
+///   * `k % 128 == 0` — the activation quantizer emits one scale per 128-wide
+///                 K group and the GEMM folds per K-block.
+///   * `n % 128 == 0` — the weight scale grid is `[N/128, K/128]`.
+///   * both handles loaded — a model shadow may not carry either entry point.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn w8a8_prefill_selected(
+    m: u32,
+    n: u32,
+    k: u32,
+    scale_format: WeightQuantFormat,
+    fp8_blockscaled_prefill: bool,
+    quant_k: KernelHandle,
+    gemm_k: KernelHandle,
+    w8a16_only: bool,
+) -> bool {
+    !w8a16_only
+        && m > 4
+        && fp8_blockscaled_prefill
+        && scale_format == WeightQuantFormat::Fp8BlockScaled
+        && k.is_multiple_of(128)
+        && n.is_multiple_of(128)
+        && quant_k.0 != 0
+        && gemm_k.0 != 0
+}
+
+impl DenseFfnLayer {
+    /// Whether ONE dense-FFN prefill projection takes the W8A8 branch.
+    ///
+    /// Beyond [`w8a8_prefill_selected`] this also requires the shared
+    /// dense-FFN activation scratch (`ffn_act_a` / `ffn_act_scale`, sized once
+    /// for `max_batch_tokens x max(hidden, intermediate)` in
+    /// `BufferSizes::from_config`). That scratch is NULL for MoE configs, which
+    /// never take this path — but a null pointer here would be a kernel launch
+    /// writing to address 0, so it is a gate and not an assert.
+    pub(crate) fn prefill_w8a8_selected(
+        &self,
+        ctx: &ForwardContext,
+        m: u32,
+        n: u32,
+        k: u32,
+        w: &Fp8Weight,
+    ) -> bool {
+        w8a8_prefill_selected(
+            m,
+            n,
+            k,
+            w.scale_format,
+            ctx.dispatch.fp8_blockscaled_prefill,
+            self.per_token_group_quant_fp8_k,
+            self.fp8_gemm_t_blockscaled_k,
+            ffn_w8a16_only(),
+        ) && ctx.buffers.ffn_act_a().0 != 0
+            && ctx.buffers.ffn_act_scale().0 != 0
+    }
+
+    /// Quantize `act[m, k]` BF16 into the shared dense-FFN scratch as FP8 E4M3
+    /// plus per-token/128-group FP32 scales; returns `(a_fp8, a_scale)`.
+    ///
+    /// Callers must consume the result before the next call: there is ONE
+    /// scratch pair per arena, deliberately (the previous per-call
+    /// `alloc`/`synchronize`/`free` pattern — still used by the MoE shared
+    /// expert — costs a full stream sync per projection). The dense-FFN
+    /// ordering is safe because everything runs on one stream: gate and up read
+    /// the `input` quantization, then `silu_mul` produces the down input, then
+    /// down re-quantizes over the same bytes.
+    ///
+    /// `k` may be `hidden` (gate/up) or `intermediate` (down); the scratch is
+    /// sized for `max(hidden, intermediate)` so neither overflows.
+    pub(crate) fn w8a8_quant_act(
+        &self,
+        ctx: &ForwardContext,
+        act: DevicePtr,
+        m: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<(DevicePtr, DevicePtr)> {
+        let a_fp8 = ctx.buffers.ffn_act_a();
+        let a_scale = ctx.buffers.ffn_act_scale();
+        // Padded extents, because the cuBLASLt arm READS `ceil16(m)` rows.
+        let rows = ops::cublas_fp8_m_pad(m) as usize;
+        debug_assert!(rows * k as usize <= ctx.buffers.ffn_act_a_bytes());
+        debug_assert!(rows * (k as usize / 128) * 4 <= ctx.buffers.ffn_act_scale_bytes());
+        ops::per_token_group_quant_fp8(
+            ctx.gpu,
+            self.per_token_group_quant_fp8_k,
+            act,
+            a_fp8,
+            a_scale,
+            m,
+            k,
+            stream,
+        )?;
+        Ok((a_fp8, a_scale))
+    }
+
+    /// `out[m, n] = a_fp8[m, k] @ weight[n, k]ᵀ` with both block-scale sets
+    /// folded in FP32 — cuBLASLt when `ATLAS_CUBLAS_GEMM` is set and the output
+    /// buffer has room for the padded M, else the in-tree kernel.
+    ///
+    /// `out_capacity_bytes` is the allocated size of `out`'s arena buffer. The
+    /// cuBLASLt helper rounds M up to 16 and WRITES those phantom rows (their
+    /// activation scales are zeroed, so the values are defined, but the stores
+    /// happen); the arena sizes that headroom in, and this check is what keeps
+    /// a future re-sizing from turning into a silent cross-buffer write.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn w8a8_gemm(
+        &self,
+        ctx: &ForwardContext,
+        a_fp8: DevicePtr,
+        a_scale: DevicePtr,
+        w: &Fp8Weight,
+        out: DevicePtr,
+        out_capacity_bytes: usize,
+        m: u32,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let padded_out_bytes = ops::cublas_fp8_m_pad(m) as usize * n as usize * 2;
+        let cublas = ctx.dispatch.cublas_gemm && padded_out_bytes <= out_capacity_bytes;
+        self.log_w8a8_prefill_route(ctx, cublas);
+        if cublas {
+            return ops::cublas_fp8_proj_prequant(ctx.gpu, a_fp8, a_scale, w, out, m, n, k, stream);
+        }
+        ops::fp8_gemm_t_blockscaled(
+            ctx.gpu,
+            self.fp8_gemm_t_blockscaled_k,
+            a_fp8,
+            a_scale,
+            w.weight,
+            w.row_scale,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        )
+    }
+
+    /// Log-once latch for the selected dense-FFN prefill arithmetic, matching
+    /// the `log:ffn_*` lines the other prefill levers in `dense_ffn.rs` emit.
+    /// The line matters beyond bookkeeping: W8A8 is a deliberate precision
+    /// trade, so a TTFT or quality report has to be able to say which
+    /// arithmetic produced it.
+    fn log_w8a8_prefill_route(&self, ctx: &ForwardContext, cublas: bool) {
+        if ctx.stats.once("log:ffn_w8a8_prefill") {
+            let how = if cublas { "cuBLASLt" } else { "kernel" };
+            tracing::info!(
+                "[atlas] dense FFN prefill: W8A8 block-scaled via {how} \
+                 (per-token 1x128 act scales x 128x128 weight scales, FP32 epilogue; \
+                 vLLM-equivalent FP8 numerics). ATLAS_FFN_W8A16_ONLY=1 restores W8A16."
+            );
+        }
+    }
+
+    /// Counterpart log for the unchanged W8A16 path, so the absence of the
+    /// W8A8 line is never ambiguous between "kill switch set" and "log lost".
+    pub(crate) fn log_w8a16_prefill_route(&self, ctx: &ForwardContext) {
+        if ctx.stats.once("log:ffn_w8a16_prefill") {
+            tracing::info!(
+                "[atlas] dense FFN prefill: W8A16 (BF16 act x FP8 weight). \
+                 W8A8 not selected — see #917/#928."
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "dense_ffn_w8a8_prefill_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/dense_ffn_w8a8_prefill_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_w8a8_prefill_tests.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Dispatch-selection contract for the W8A8 block-scaled dense-FFN prefill
+//! (#917/#928). These are CPU tests: they pin WHICH arm the native-FP8 prefill
+//! picks and the buffer-extent arithmetic the cuBLASLt arm depends on. The
+//! numerics themselves are the GPU microtest's job
+//! (`examples/native_fp8_ffn_w8a8_microtest.rs`).
+
+use super::w8a8_prefill_selected;
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::dense_ffn::{DenseFfnLayer, DenseFfnWeights};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats, cublas_fp8_m_pad};
+use crate::weight_map::{Fp8Weight, QuantizedWeight, WeightQuantFormat};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+/// Qwen3.8-27B dense FFN — the shapes from #917. gate/up are `[17408, 5120]`,
+/// down is `[5120, 17408]`.
+const H: u32 = 5120;
+const INTER: u32 = 17408;
+/// The prompt length in the 2026-09-11 H100 TTFT measurement (1075 ms vs
+/// vLLM's 287 ms) that motivated this path.
+const PROMPT_TOKENS: u32 = 1193;
+const QUANT_K: KernelHandle = KernelHandle(0xA8A);
+const GEMM_K: KernelHandle = KernelHandle(0xA88);
+
+/// Every clause of the rule defaulted to its SELECTING value, so each test
+/// perturbs exactly one thing and the failure names the clause.
+#[allow(clippy::too_many_arguments)]
+fn selected(
+    m: u32,
+    n: u32,
+    k: u32,
+    fmt: WeightQuantFormat,
+    blockscaled_lever: bool,
+    quant_k: KernelHandle,
+    gemm_k: KernelHandle,
+    w8a16_only: bool,
+) -> bool {
+    w8a8_prefill_selected(m, n, k, fmt, blockscaled_lever, quant_k, gemm_k, w8a16_only)
+}
+
+fn gate_up(m: u32) -> bool {
+    selected(
+        m,
+        INTER,
+        H,
+        WeightQuantFormat::Fp8BlockScaled,
+        true,
+        QUANT_K,
+        GEMM_K,
+        false,
+    )
+}
+
+fn down(m: u32) -> bool {
+    selected(
+        m,
+        H,
+        INTER,
+        WeightQuantFormat::Fp8BlockScaled,
+        true,
+        QUANT_K,
+        GEMM_K,
+        false,
+    )
+}
+
+#[test]
+fn selected_for_prefill_batches_at_the_real_ffn_shapes() {
+    for m in [64, PROMPT_TOKENS] {
+        assert!(gate_up(m), "gate/up must take W8A8 at M={m}");
+        assert!(down(m), "down must take W8A8 at M={m}");
+    }
+}
+
+#[test]
+fn not_selected_for_small_batches_that_belong_to_the_gemv() {
+    // M<=4 streams each weight once through `w8a16_gemv_batch4`; an MMA tile
+    // there is mostly padding. M=5 is the first row count this path claims.
+    for m in [1, 2, 3, 4] {
+        assert!(!gate_up(m), "M={m} must stay on the batch4 GEMV");
+    }
+    assert!(gate_up(5), "M=5 is the first W8A8 row count");
+}
+
+#[test]
+fn not_selected_for_per_row_scales() {
+    // `row_scale` would be `[N]`, not the `[N/128, K/128]` grid the
+    // block-scaled GEMM indexes — reading it as the latter is silent garbage.
+    for fmt in [
+        WeightQuantFormat::Fp8PerRow,
+        WeightQuantFormat::Fp8SingleScale,
+    ] {
+        assert!(
+            !selected(64, INTER, H, fmt, true, QUANT_K, GEMM_K, false),
+            "{fmt:?} must not take the block-scaled GEMM"
+        );
+    }
+}
+
+#[test]
+fn not_selected_for_unaligned_shapes() {
+    let f = WeightQuantFormat::Fp8BlockScaled;
+    // K not a multiple of 128: the activation quantizer emits one FP32 scale
+    // per 128-wide K group, so a ragged tail has no scale.
+    assert!(!selected(64, INTER, H + 1, f, true, QUANT_K, GEMM_K, false));
+    assert!(!selected(64, INTER, 127, f, true, QUANT_K, GEMM_K, false));
+    // N not a multiple of 128: the weight scale grid is `[N/128, K/128]`.
+    assert!(!selected(64, INTER + 1, H, f, true, QUANT_K, GEMM_K, false));
+    assert!(!selected(64, 64, H, f, true, QUANT_K, GEMM_K, false));
+}
+
+#[test]
+fn not_selected_when_the_kill_switch_is_set() {
+    // ATLAS_FFN_W8A16_ONLY — injected, not read from the environment: the
+    // real accessor is a process-global `OnceLock` and a test that set the
+    // variable would leak into every other test in the binary.
+    assert!(!selected(
+        PROMPT_TOKENS,
+        INTER,
+        H,
+        WeightQuantFormat::Fp8BlockScaled,
+        true,
+        QUANT_K,
+        GEMM_K,
+        true,
+    ));
+}
+
+#[test]
+fn not_selected_when_the_blockscaled_prefill_lever_is_off() {
+    // ATLAS_FP8_SINGLE_SCALE clears `dispatch.fp8_blockscaled_prefill`; it
+    // already governs the attention W8A8 path and must govern this one too.
+    assert!(!selected(
+        PROMPT_TOKENS,
+        INTER,
+        H,
+        WeightQuantFormat::Fp8BlockScaled,
+        false,
+        QUANT_K,
+        GEMM_K,
+        false,
+    ));
+}
+
+#[test]
+fn not_selected_when_either_kernel_is_missing() {
+    let f = WeightQuantFormat::Fp8BlockScaled;
+    assert!(!selected(
+        64,
+        INTER,
+        H,
+        f,
+        true,
+        KernelHandle(0),
+        GEMM_K,
+        false
+    ));
+    assert!(!selected(
+        64,
+        INTER,
+        H,
+        f,
+        true,
+        QUANT_K,
+        KernelHandle(0),
+        false
+    ));
+}
+
+// ───────────────────── layer-level gates (real arena) ─────────────────────
+
+struct Harness {
+    gpu: MockGpuBackend,
+    layer: DenseFfnLayer,
+    buffers: BufferArena,
+    config: ModelConfig,
+    fp8: Fp8Weight,
+}
+
+/// A dense (num_experts = 0) config at the real FFN widths, with the arena
+/// sized for `max_batch_tokens` prefill rows.
+fn harness(num_experts: usize, max_batch_tokens: usize) -> Harness {
+    let gpu = MockGpuBackend::new();
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = H as usize;
+    config.intermediate_size = INTER as usize;
+    config.num_experts = num_experts;
+    config.num_experts_per_tok = num_experts.min(1);
+    config.moe_intermediate_size = INTER as usize;
+    config.vocab_size = 256;
+    let buffers = BufferArena::new(&config, max_batch_tokens, 256, 256, 8, &gpu).unwrap();
+    let mut fallback = QuantizedWeight::null();
+    fallback.weight = gpu.alloc(128 * 64).unwrap();
+    fallback.weight_scale = gpu.alloc(128 * 8).unwrap();
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: fallback,
+            up_proj: fallback,
+            down_proj: fallback,
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        &gpu,
+    )
+    .unwrap();
+    layer.per_token_group_quant_fp8_k = QUANT_K;
+    layer.fp8_gemm_t_blockscaled_k = GEMM_K;
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(1024).unwrap(),
+        row_scale: gpu.alloc(1024).unwrap(),
+        n: INTER,
+        k: H,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    Harness {
+        gpu,
+        layer,
+        buffers,
+        config,
+        fp8,
+    }
+}
+
+/// Runs `f` with a prefill-shaped `ForwardContext` over the harness.
+fn with_ctx<R>(h: &Harness, dispatch: GemmDispatch, f: impl FnOnce(&ForwardContext) -> R) -> R {
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let ctx = ForwardContext {
+        buffers: &h.buffers,
+        hc_row_offset: 0,
+        gpu: &h.gpu,
+        config: &h.config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        decode_step: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    f(&ctx)
+}
+
+#[test]
+fn layer_selects_w8a8_on_a_dense_config() {
+    let h = harness(0, 2048);
+    with_ctx(&h, GemmDispatch::defaults(), |ctx| {
+        assert!(
+            h.layer
+                .prefill_w8a8_selected(ctx, PROMPT_TOKENS, INTER, H, &h.fp8)
+        );
+    });
+}
+
+#[test]
+fn layer_declines_w8a8_without_the_shared_ffn_scratch() {
+    // `ffn_act_a` / `ffn_act_scale` are 0 for MoE configs (BufferSizes). A null
+    // scratch pointer is a kernel launch writing to address 0, so the absence
+    // has to gate the arm rather than trip an assert.
+    let h = harness(2, 2048);
+    assert_eq!(
+        h.buffers.ffn_act_a().0,
+        0,
+        "MoE arena must have no FFN scratch"
+    );
+    with_ctx(&h, GemmDispatch::defaults(), |ctx| {
+        assert!(
+            !h.layer
+                .prefill_w8a8_selected(ctx, PROMPT_TOKENS, INTER, H, &h.fp8)
+        );
+    });
+}
+
+// ───────────────────── cuBLASLt padded-M buffer contract ─────────────────────
+
+#[test]
+fn cublas_m_pad_rounds_up_to_sixteen() {
+    // cuBLASLt rejects a scale-tensor M extent that is not a multiple of 4;
+    // `cublas_fp8_proj_prequant` pads to 16 and WRITES those phantom rows.
+    assert_eq!(cublas_fp8_m_pad(PROMPT_TOKENS), 1200);
+    assert_eq!(cublas_fp8_m_pad(64), 64);
+    assert_eq!(cublas_fp8_m_pad(1), 16);
+    for m in [1_u32, 5, 63, 64, 65, 1193, 8192] {
+        assert!(cublas_fp8_m_pad(m) >= m);
+        assert_eq!(cublas_fp8_m_pad(m) % 16, 0);
+    }
+}
+
+#[test]
+fn ffn_output_buffers_hold_the_padded_m_the_cublas_gemm_writes() {
+    // The worst case is a prefill chunk exactly as wide as the arena: without
+    // the `div_ceil(16) * 16` in BufferSizes the padded rows would land in the
+    // NEXT arena buffer. Pinned here because the sizing and the writer live in
+    // different crates.
+    for max_batch_tokens in [256_usize, 1193, 2048] {
+        let h = harness(0, max_batch_tokens);
+        let m = cublas_fp8_m_pad(max_batch_tokens as u32) as usize;
+        assert!(
+            h.buffers.expert_gate_out_bytes() >= m * INTER as usize * 2,
+            "gate/up output too small for padded M at max_batch_tokens={max_batch_tokens}"
+        );
+        assert!(
+            h.buffers.moe_output_bytes() >= m * H as usize * 2,
+            "down output too small for padded M at max_batch_tokens={max_batch_tokens}"
+        );
+    }
+}
+
+#[test]
+fn activation_scratch_holds_the_widest_ffn_projection() {
+    // gate/up contract over K=hidden, down over K=intermediate; ONE scratch
+    // pair serves both, so it must be sized for the wider of the two. The
+    // scale extent is the `[M, K/128]` FP32 layout `per_token_group_quant_fp8`
+    // writes and `fp8_gemm_act_weight_t_blkscaled` reads as its VEC128 B-scale
+    // — same element order, which is why no transpose adapter is needed.
+    let max_batch_tokens = 1193_usize;
+    let h = harness(0, max_batch_tokens);
+    let kmax = H.max(INTER) as usize;
+    let padded = cublas_fp8_m_pad(max_batch_tokens as u32) as usize;
+    assert!(h.buffers.ffn_act_a_bytes() >= padded * kmax);
+    assert!(h.buffers.ffn_act_scale_bytes() >= padded * (kmax / 128) * 4);
+}

--- a/crates/spark-model/src/layers/ops/dispatch_proj.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_proj.rs
@@ -63,10 +63,12 @@ pub fn cublas_fp8_proj(
 /// both, then quantizes the post-SiLU intermediate once for `down`.
 ///
 /// ⚠ PADDED-M EXTENTS. cuBLASLt is handed `ceil16(M)`, so:
-///   * `out` must hold `ceil16(M) * N` BF16 elements — the phantom rows are
-///     WRITTEN (well-defined: their activation scales are zeroed below).
-///   * `act_fp8` must hold `ceil16(M) * K` bytes and `act_scale`
-///     `ceil16(M) * (K/128)` f32 — the phantom rows are READ.
+///
+/// * `out` must hold `ceil16(M) * N` BF16 elements — the phantom rows are
+///   WRITTEN (well-defined: their activation scales are zeroed below).
+/// * `act_fp8` must hold `ceil16(M) * K` bytes and `act_scale`
+///   `ceil16(M) * (K/128)` f32 — the phantom rows are READ.
+///
 /// The arena sizes that headroom in; see the sizing notes in
 /// `spark_runtime::buffers::sizes` (`fp8_act`, `ffn_act_a`, `expert_gate_out`,
 /// `moe_output`).

--- a/crates/spark-model/src/layers/ops/dispatch_proj.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_proj.rs
@@ -41,19 +41,77 @@ pub fn cublas_fp8_proj(
         k,
         stream,
     )?;
+    cublas_fp8_proj_prequant(
+        gpu,
+        act_fp8_scratch,
+        act_scale_scratch,
+        fp8w,
+        out,
+        m,
+        n,
+        k,
+        stream,
+    )
+}
+
+/// [`cublas_fp8_proj`] for an activation that is ALREADY quantized — the
+/// caller ran `per_token_group_quant_fp8` itself.
+///
+/// WHY the split (#917/#928): the dense FFN's gate and up projections consume
+/// the SAME `[M, K]` input, so quantizing inside the GEMM helper would pay the
+/// per-token quant twice per layer. The FFN quantizes once and calls this for
+/// both, then quantizes the post-SiLU intermediate once for `down`.
+///
+/// ⚠ PADDED-M EXTENTS. cuBLASLt is handed `ceil16(M)`, so:
+///   * `out` must hold `ceil16(M) * N` BF16 elements — the phantom rows are
+///     WRITTEN (well-defined: their activation scales are zeroed below).
+///   * `act_fp8` must hold `ceil16(M) * K` bytes and `act_scale`
+///     `ceil16(M) * (K/128)` f32 — the phantom rows are READ.
+/// The arena sizes that headroom in; see the sizing notes in
+/// `spark_runtime::buffers::sizes` (`fp8_act`, `ffn_act_a`, `expert_gate_out`,
+/// `moe_output`).
+#[allow(clippy::too_many_arguments)]
+pub fn cublas_fp8_proj_prequant(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    act_fp8: spark_runtime::gpu::DevicePtr,
+    act_scale: spark_runtime::gpu::DevicePtr,
+    fp8w: &crate::weight_map::Fp8Weight,
+    out: spark_runtime::gpu::DevicePtr,
+    m: u32,
+    n: u32,
+    k: u32,
+    stream: u64,
+) -> anyhow::Result<()> {
     // cuBLASLt requires the scale-tensor M extent to be a multiple of 4; pad to
     // 16 (TC-friendly) and zero the padding scale rows so the phantom output
     // columns (ignored by the caller) are well-defined.
-    let m_pad = m.div_ceil(16) * 16;
+    let m_pad = cublas_fp8_m_pad(m);
     if m_pad > m {
+        let pad_rows = (m_pad - m) as usize;
+        // Scales: `[M, K/128]` FP32, row-major — the exact layout
+        // `per_token_group_quant_fp8` writes and cuBLASLt reads as the VEC128
+        // B-scale, so the pad rows are a contiguous tail.
         let kg = (k / 128) as usize;
-        let pad_off = m as usize * kg * 4;
-        let pad_bytes = (m_pad - m) as usize * kg * 4;
-        gpu.memset_async(act_scale_scratch.offset(pad_off), 0, pad_bytes, stream)?;
+        gpu.memset_async(
+            act_scale.offset(m as usize * kg * 4),
+            0,
+            pad_rows * kg * 4,
+            stream,
+        )?;
+        // Activation bytes too: a zero scale kills the phantom rows'
+        // CONTRIBUTION, but the FP8 dot product still runs over whatever bytes
+        // are there and `NaN * 0.0` is `NaN`. Same reasoning (and same fix) as
+        // the row-wise sibling in `dispatch_proj_rowwise.rs`.
+        gpu.memset_async(
+            act_fp8.offset(m as usize * k as usize),
+            0,
+            pad_rows * k as usize,
+            stream,
+        )?;
     }
     spark_runtime::cublaslt::fp8_gemm_act_weight_t_blkscaled(
-        act_fp8_scratch.0,
-        act_scale_scratch.0,
+        act_fp8.0,
+        act_scale.0,
         fp8w.weight.0,
         fp8w.row_scale.0,
         out.0,
@@ -62,6 +120,12 @@ pub fn cublas_fp8_proj(
         k,
         stream,
     )
+}
+
+/// The M extent [`cublas_fp8_proj_prequant`] actually hands cuBLASLt. SSOT for
+/// the callers that must bounds-check their output buffer against it.
+pub fn cublas_fp8_m_pad(m: u32) -> u32 {
+    m.div_ceil(16) * 16
 }
 
 /// Dequantize a block-scaled FP8 weight `[N,K]` → BF16 on-GPU once, cached by the

--- a/crates/spark-runtime/src/buffers/accessors.rs
+++ b/crates/spark-runtime/src/buffers/accessors.rs
@@ -81,6 +81,17 @@ impl BufferArena {
     pub fn expert_up_out(&self) -> DevicePtr {
         self.expert_up_out
     }
+    /// Allocated byte size of `expert_gate_out` / `expert_up_out` (identical by
+    /// construction). Debug bounds-check for GEMM paths that write PADDED M
+    /// rows — the FP8 block-scaled cuBLASLt matmul rounds M up to 16.
+    pub fn expert_gate_out_bytes(&self) -> usize {
+        debug_assert_eq!(self.sizes.expert_gate_out, self.sizes.expert_up_out);
+        self.sizes.expert_gate_out
+    }
+    /// Allocated byte size of `moe_output` (same padded-M debug check).
+    pub fn moe_output_bytes(&self) -> usize {
+        self.sizes.moe_output
+    }
     /// Batched expert down projection output.
     pub fn expert_down_out(&self) -> DevicePtr {
         self.expert_down_out
@@ -102,6 +113,14 @@ impl BufferArena {
     /// Shared dense-FFN int8/NVFP4 activation-scale scratch. NULL for MoE.
     pub fn ffn_act_scale(&self) -> DevicePtr {
         self.ffn_act_scale
+    }
+    /// Allocated byte size of `ffn_act_a` (debug bounds-check at call sites).
+    pub fn ffn_act_a_bytes(&self) -> usize {
+        self.sizes.ffn_act_a
+    }
+    /// Allocated byte size of `ffn_act_scale` (debug bounds-check at call sites).
+    pub fn ffn_act_scale_bytes(&self) -> usize {
+        self.sizes.ffn_act_scale
     }
     /// Persistent FP8 block-scaled activation scratch for prefill projections.
     /// Replaces a per-projection alloc/sync/free in the W8A8+FP32-epilogue path.

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -234,7 +234,18 @@ impl BufferSizes {
 
         // Batched expert output buffers for MoE (or dense FFN).
         // Sized for max(K=3 verify, prefill chunk) × top_k experts.
-        let k_max = m.max(3); // prefill chunk or K=3 verify, whichever larger
+        //
+        // The row extent is rounded UP to a multiple of 16 because the FP8
+        // block-scaled cuBLASLt GEMM (`ops::cublas_fp8_proj*`, used by the
+        // W8A8 dense-FFN prefill added for #917/#928) cannot be handed a raw
+        // M: cuBLASLt rejects a scale-tensor M extent that is not a multiple
+        // of 4, so the helper pads M to 16 and the matmul writes those phantom
+        // rows into the output. Without the pad here, a prefill chunk that is
+        // exactly `max_batch_tokens` would write up to 15 rows PAST
+        // `expert_gate_out` — straight into the neighbouring arena buffer.
+        // Costs <= 15 * intermediate * 2 B per buffer (~0.5 MB on a 27B), which
+        // is cheaper than a second output allocation or a per-call bounce.
+        let k_max = m.max(3).div_ceil(16) * 16; // prefill chunk or K=3 verify, +cuBLASLt M-pad
         let expert_inter = if config.num_experts > 0 {
             let routed = config.num_experts_per_tok * config.moe_intermediate_size;
             k_max * routed.max(config.intermediate_size)
@@ -288,8 +299,10 @@ impl BufferSizes {
         // Mamba-2 out_proj contracts over d_inner (may exceed hidden), and its
         // prefill input is FP8-precast into this buffer.
         let max_proj_k = h.max(q_heads * hd).max(mamba2_d_inner);
-        let fp8_act = m * max_proj_k;
-        let fp8_act_scale = m * max_proj_k.div_ceil(128) * 4;
+        // Padded to 16 rows: `ops::cublas_fp8_proj` hands cuBLASLt `ceil16(M)`
+        // and the matmul reads those phantom activation/scale rows.
+        let fp8_act = m.div_ceil(16) * 16 * max_proj_k;
+        let fp8_act_scale = m.div_ceil(16) * 16 * max_proj_k.div_ceil(128) * 4;
         // LoRA scratch — only when an adapter is configured (adapter_max_rank
         // set programmatically pre-build). Widest target n_out =
         // max(hidden, intermediate, q_proj): covers k/v, o/down (hidden),
@@ -363,10 +376,15 @@ impl BufferSizes {
         let (ffn_act_q8, ffn_act_a, ffn_act_scale) = if config.num_experts == 0 {
             let kmax = h.max(config.intermediate_size);
             let kpad = kmax.div_ceil(256) * 256;
+            // Row extent padded to 16 for the same reason `k_max` above is: the
+            // W8A8 dense-FFN prefill (#917/#928) hands cuBLASLt `ceil16(M)`, and
+            // the matmul READS the phantom activation rows (they are zeroed, but
+            // they are read). `m_pad` also covers every unpadded consumer.
+            let m_pad = m.div_ceil(16) * 16;
             (
                 m * kpad * 4 + (1 << 20), // q8_1_mmq: m*kpad*4 + 1MB (matches q8_1_scratch_bytes)
-                m * kmax,                 // int8 a_i8 [m,K] ≥ NVFP4 packed [m,K/2]
-                m * (kmax / 32) * 4,      // int8 a_scale [m,K/32]*4 ≥ NVFP4 scale [m,K/16]
+                m_pad * kmax,             // int8 a_i8 [m,K] ≥ NVFP4 packed [m,K/2] ≥ fp8 [m,K]
+                m_pad * (kmax / 32) * 4,  // int8 a_scale [m,K/32]*4 ≥ fp8 [m,K/128]*4
             )
         } else {
             (0, 0, 0)
@@ -404,7 +422,9 @@ impl BufferSizes {
             } else {
                 256
             },
-            moe_output: m * h * bf16,
+            // Same cuBLASLt FP8 M-pad headroom as `k_max` above: the dense-FFN
+            // down projection writes its [M, hidden] result here.
+            moe_output: m.div_ceil(16) * 16 * h * bf16,
             logits: logits_tokens * config.vocab_size * bf16, // BF16 from LM head kernel
             // SSM buffers are also reused by attention prefill/multi-seq as scratch:
             //   ssm_qkvz: K+V contiguous storage in prefill [M, 2*kv_dim]

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -11,8 +11,15 @@ fn mixed_dense_moe_sizes_for_widest_ffn() {
     cfg.moe_intermediate_size = 1_024;
 
     let sizes = BufferSizes::from_config(&cfg, 4, 4096, 16, 32);
-    assert_eq!(sizes.expert_gate_out, 4 * 12_288 * 2);
-    assert_eq!(sizes.expert_up_out, 4 * 12_288 * 2);
+    // The DENSE intermediate (12288) is wider than the routed one
+    // (top_k 10 x moe_intermediate 1024 = 10240), and it is the dense width
+    // these buffers must hold. Rows are `max_batch_tokens` rounded up to 16 —
+    // the cuBLASLt FP8 M-pad headroom the W8A8 dense-FFN prefill writes into
+    // (#917/#928); see the sizing note on `k_max` in `sizes.rs`.
+    let rows = 4_usize.div_ceil(16) * 16;
+    assert!(cfg.intermediate_size > cfg.num_experts_per_tok * cfg.moe_intermediate_size);
+    assert_eq!(sizes.expert_gate_out, rows * 12_288 * 2);
+    assert_eq!(sizes.expert_up_out, rows * 12_288 * 2);
 }
 use crate::gpu::mock::MockGpuBackend;
 use std::collections::HashSet;


### PR DESCRIPTION
## Summary

On a native-FP8 checkpoint the dense FFN's prefill GEMMs ran **W8A16**: BF16 activations against E4M3 weights, so the MMA is the BF16 tensor-core path and the FP8 bytes buy memory, not math. The attention Q/K/V/O projections and the MoE shared expert had already moved to the W8A8 block-scaled path; on a dense model the FFN is most of the prefill FLOPs and it was the one large consumer left behind.

This gives it the same arithmetic vLLM uses — per-token 1×128 FP32 activation scales folded against the checkpoint's 128×128 FP32 weight scales in an FP32 epilogue, accumulated by `mma.sync.m16n8k32.e4m3` (native on sm_90a and sm_121).

Refs #917 and #928.

**Scope note, up front.** The cuBLASLt arm (`ATLAS_CUBLAS_GEMM=1`) is **not validated on hardware and should not be enabled**. It is wired and it is very fast — 1,140 TFLOP/s at gate/up M=1193 on an H100 — but the 2026-09-11 microtest found it numerically **wrong**: rel_rms 7.7e-2–8.8e-2 against the W8A16 reference at M=1193 where the in-tree kernel manages 2.5e-2, from a VEC128 activation-scale layout mismatch. The fix for that lives on a follow-up branch and gets its own PR behind its own H100 receipt. **Every number below is the default kernel path**, which is what the serve selects unless `ATLAS_CUBLAS_GEMM` is set.

## What was wrong

`w8a16_gemm_pipelined` on the dense FFN shapes. Measured on H100 2026-09-11 at the real Qwen3.8-27B dims (H=5120, INTER=17408; gate/up N=17408 K=5120, down N=5120 K=17408), it turns **15–73 TFLOP/s** — the low end at the short prefill chunk M=64, the high end at M=1193. The FP8 weight bytes were being dequantized into a BF16 MMA rather than feeding the FP8 tensor cores the checkpoint's format already permits.

## What the fix does

- **`dense_ffn_w8a8_prefill.rs`, a new child module** of `dense_ffn.rs` (which is already at the CI size cap), holding the whole selection rule, the activation quantizer call, the GEMM call and the log-once route latch. `w8a8_prefill_selected` is a pure function of shape, scale format and kernel handles so the CPU tests can pin every clause: `m > 4` (M≤4 stays on the batch4 GEMV, which streams each weight once and beats any MMA tile there), `ATLAS_FP8_SINGLE_SCALE` not set, `Fp8BlockScaled` scales (a per-row layout would be read as `[N/128, K/128]`), `n` and `k` multiples of 128, and both kernel handles resolved — a model shadow without them keeps the W8A16 branches.
- **`dense_ffn.rs`**: the `w8_gemm!` dispatch macro gains one arm, placed **after** the `w8a16_gemv_batch4` decode arm and **ahead** of the W8A16 tile arms. Gate and up share a single activation quantization (they read the same `[M, K]` input; quantizing per projection would pay the per-token E4M3 cast twice per layer for identical bytes); `down` quantizes the post-SiLU product into the same scratch, which is safe because every launch is on one stream.
- **`ATLAS_FFN_W8A16_ONLY`** (presence, not `=1` — `…=0` meaning "on" is a trap for an operator reaching for an escape hatch mid-incident) restores the old path. The selected arithmetic is logged **once at INFO**, and the unchanged W8A16 path carries a counterpart line, so the absence of the W8A8 line is never ambiguous between "kill switch set" and "log lost".
- **`dispatch_proj.rs`**: `cublas_fp8_proj` is split so the already-quantized caller has an entry point (`cublas_fp8_proj_prequant`), and `cublas_fp8_m_pad` becomes the SSOT for the padded M extent.
- **Buffer sizing** (`spark-runtime`). cuBLASLt rejects a scale-tensor M extent that is not a multiple of 4, so the helper pads M to 16 and the matmul **writes** the phantom output rows and **reads** the phantom activation rows. `expert_gate_out` / `expert_up_out` / `moe_output` / `fp8_act` / `ffn_act_a` / `ffn_act_scale` now carry that 16-row headroom: without it a prefill chunk exactly as wide as `max_batch_tokens` writes up to 15 rows past its buffer, straight into the neighbouring arena buffer. Cost is ≤15 rows per buffer, ~0.5 MB on a 27B. The padded activation **bytes** are zeroed alongside their scales, because a zero scale kills a phantom row's contribution but `NaN * 0.0` is `NaN`.

Nothing is copied, staged or requantized on the weight side: both arms read the same FP8 weight and the same `[N/128, K/128]` block-scale buffer.

## Oracle and evidence

All of this is **diagnostic single-H100 evidence, not certified campaign numbers.** 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8 profile, `--max-batch-size 16 --ssm-decode-ring-slots 1 --ssm-batched-recurrent true`, temperature 0, 1 warm-up + 3 reps, frozen ladder harness `bench/ladder38/harness_w55_conc_ladder.py`, engine tip `5f78270dc` (these three commits). 2026-09-11.

### Microtest — `native_fp8_ffn_w8a8_microtest`, kernel path

Real Qwen3.8-27B dense-FFN shapes, CUDA-event timing, 10 iterations after warm-up. M=64 is a short prefill chunk; M=1193 is the trace prompt.

| shape | M | W8A16 ms / TFLOP/s | W8A8 kernel ms / TFLOP/s | speedup | max_abs | cosine | rel_rms |
|---|---|---|---|---|---|---|---|
| gate/up | 64 | 0.527 / **21.64** | 0.172 / **66.41** | 3.07× | 5.375 | 0.999680 | **0.0253** |
| gate/up | 1193 | 2.900 / **73.34** | 1.441 / **147.53** | 2.01× | 5.500 | 0.999680 | **0.0253** |
| down | 64 | 0.741 / **15.40** | 0.450 / **25.36** | 1.65× | 9.000 | 0.999679 | **0.0254** |
| down | 1193 | 3.169 / **67.11** | 1.455 / **146.21** | 2.18× | 9.500 | 0.999679 | **0.0253** |

**2.0–3.1× over W8A16**, cosine ≥ 0.9996 everywhere.

At the example's default `rel_rms` bound the run exits 1 with exactly four failures, one per cell:

```
FAIL: gate/up M=64: rel_rms 0.0253 > 0.02        (x4, one per shape/M)
Error: 4 gate(s) failed
W8A8_KERNEL_EXIT=1
```

Re-run with `ATLAS_W8A8_REL_RMS_GATE=0.03` — **identical numbers**, and:

```
RESULT: PASS (all shapes within cosine/rel_rms/ULP gates)
W8A8_KERNEL_G03_EXIT=0
```

Both readings are reported rather than only the passing one. The example's own header argues 2.53% is the **E4M3 per-element floor, not a defect**: 3 stored mantissa bits give ~2.5% RMS per element and a dot product of independent terms does not average it down, so the predicted band is ~2–2.6%, sitting right on a 2% gate. The measurement lands inside that band on all four cells with cosine 0.99968 on all four — isotropic noise, not a systematic shear. **The 2% constant is what looks wrong here**, set below the arithmetic's own floor so it can only ever fail; it is under review and deliberately **not** changed in this PR, because moving a gate in the same commit that first trips it is how gates stop meaning anything.

### cuBLASLt arm — measured, failing, and not enabled

Reported because it is in the diff, not because it is claimed:

| shape | M | cuBLASLt ms / TFLOP/s | vs kernel max_ulp | vs kernel rel_rms | vs W8A16 cosine |
|---|---|---|---|---|---|
| gate/up | 64 | 0.048 / 237.34 | 32 591 | 1.12e-2 | 0.999620 |
| gate/up | 1193 | 0.187 / **1140.16** | 33 695 | **7.67e-2** | **0.996738** ✗ |
| down | 64 | 0.045 / 253.98 | 32 747 | 1.12e-2 | 0.999618 |
| down | 1193 | 0.211 / 1008.89 | 33 675 | **8.82e-2** | **0.995785** ✗ |

The microtest's contract is that the two arms take the same quantized inputs through the same FP32 epilogue and should agree to ~4 ULP; measured is ~33,000 ULP with 84–94% of output elements differing, and at M=1193 cuBLASLt is *further* from the W8A16 reference than the W8A8 kernel is. That is not a second valid rounding of the same math. Relaxing the rel-RMS bound does not rescue it — 6 gates still fail at `ATLAS_W8A8_REL_RMS_GATE=0.03` — so the failure is orthogonal to the gate-bound question above. Root cause is the VEC128 activation-scale layout; it is fixed on a follow-up branch that will come with its own H100 receipt. Until then the flag is off by default and should stay off.

### Ladder — before vs after, same recipe

Round 2 (tip `fbbe70767`, W8A16 prefill) → round 3 (these commits, W8A8 kernel). Shapes are the harness's `1024×256` and `4096×512` labels — **1193** and **4593** prompt tokens against 256 / 512 output.

| shape | C | tok/s before → after | TTFT p50 before → after | TPOT p50 before → after |
|---|---|---|---|---|
| 1193 / 256 | 1 | 39.41 → **41.78** | 1,071 ms → **707 ms** | 21.27 → 21.26 |
| 1193 / 256 | 16 | 66.05 → **113.03** (agg) | 9,070 → 5,957 ms | 207.57 → **117.58** |
| 4593 / 512 | 1 | 33.29 → **35.16** | 3,125 ms → **2,310 ms** | 23.98 → 23.97 |
| 4593 / 512 | 16 | 57.79 → **91.76** (agg) | 26,453 → 19,611 ms | 225.63 → 137.36 |

`LADDER_EXIT=0`, **zero errors** in all 12 recorded reps, rep-to-rep spread ≤2.26%. TTFT falls 34% and 26% at C=1, which is the prefill change showing up where prefill is measured; the C=16 aggregate nearly doubles on the short shape. The 28-token smoke request's TTFT moved 174.8 ms → 100.9 ms on the same box.

The arithmetic change is visible in the serve log rather than inferred:

```
[atlas] dense FFN prefill: W8A8 block-scaled via kernel (per-token 1x128 act
  scales x 128x128 weight scales, FP32 epilogue; vLLM-equivalent FP8 numerics).
  ATLAS_FFN_W8A16_ONLY=1 restores W8A16.
```

No W8A16 line was emitted alongside it, so no fallback diagnosis is needed, and `ATLAS_CUBLAS_GEMM` was unset on that leg.

### Coherency

`bench/hopper_ab/coherency_gate.py`, same session, after `--selftest` was shown to refuse its own known-bad fixtures first:

| probe | verdict |
|---|---|
| determinism | **PASS** — two identical requests byte-identical |
| tool call | **PASS** — `get_weather` with `{"city":"Reykjavik","days":3}`, `finish_reason: tool_calls` |
| think-leak | **PASS** |
| known-answer `391` | **PASS** |
| known-answer `Tokyo` | **PASS** |
| known-answer word-reversal | **FAIL** |

The word-reversal probe fails on vLLM too (#929) and its failure mode here is a tokenizer artifact rather than an arithmetic one: the model enumerates all twelve letters of "refrigerator" in the correct order and then drops one on concatenation. A 16-way concurrent arithmetic probe was **16/16 correct** in 2.51 s wall on the same config.

**What this evidence does not establish.** One box, one model, one session, not bisected against anything but round 2's tip — which differed by exactly these three commits, which is the strongest part of the claim. It is not a certification run, it says nothing about GB10, and the precision trade is a real trade: W8A8 is lossier than W8A16 by construction, which is why the route is logged and `ATLAS_FFN_W8A16_ONLY` exists.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda w8a8` — **12 passed, 0 failed** (the new dispatch/sizing tests)
- [x] `cargo test -p spark-model --features cuda ffn` — **21 passed, 0 failed**
- [x] `cargo test -p spark-runtime --lib --features cuda buffers` — **10 passed, 0 failed**, including `mixed_dense_moe_sizes_for_widest_ffn` with the pad pinned
- [x] `cargo build -p spark-model --example native_fp8_ffn_w8a8_microtest --features cuda,gpu-examples` — builds clean
- [x] `cargo clippy -p spark-model -p spark-runtime -p spark-server --tests --features cuda,nccl` — clean, no warnings emitted. `spark-server` is in the invocation only because `nccl` is its feature, not `spark-model`'s or `spark-runtime`'s; the two crates this PR edits are both covered.
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`

- [ ] `scripts/hopper_ptx_gate.sh` — **not applicable**: these three commits touch no `.cu` and no `kernels/` file at all. `per_token_group_quant_fp8` and `fp8_gemm_t_blockscaled` are the entry points the attention W8A8 prefill already resolves; nothing new is compiled.
- [x] Tested against real hardware — H100 receipts above (2026-09-11), kernel path.
- [ ] cuBLASLt arm on hardware — **fails, see above**; the fix and its receipt are a separate PR.

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates every committed `.benchmarks/` record on landing. A GB10 re-measure is owed before merge. The H100 ladder above is diagnostic evidence from a different card and does not substitute for it.

## Notes for reviewers

**Where the arm sits in `w8_gemm!` matters.** It is after the `w8a16_gemv_batch4` arm (which `main` has via #925) and before the W8A16 tile arms. The `m > 4` clause in the selector makes that ordering redundant rather than load-bearing — both guards say the same thing — but they are written independently on purpose: the macro arm is a dispatch detail and the selector is the documented rule, and a future edit to either should not be able to silently route a 2-row decode into an MMA tile.

**The three buffer sizes are the risky part of this diff, not the GEMM.** `expert_gate_out`, `moe_output` and the `ffn_act_*` scratch all gained 16-row rounding, and the failure mode if any of them had been missed is a cross-buffer write during a full-width prefill chunk rather than a wrong number — silent, shape-dependent, and invisible to a microtest. That is why `w8a8_gemm` bounds-checks the padded output against the arena's reported capacity before choosing cuBLASLt and falls back to the kernel rather than trusting the sizing, why the accessors expose `*_bytes()` at all, and why the third commit pins the pad in `mixed_dense_moe_sizes_for_widest_ffn` rather than letting the constant drift.

**On the failing 2% gate.** The honest reading is that the example shipped a bound below its own arithmetic's floor, and the first thing to run against it proved it. Changing the constant belongs in a change that argues for the new number on its own, not in the one that has an interest in passing.

The three commits are cherry-picked from `fix/ffn-w8a8-prefill` on the fork with `-x` provenance lines. **One conflict**, in `crates/spark-model/Cargo.toml`: the source branch's `[[example]]` block also registers `native_fp8_oproj_batch_microtest` (#984) and `native_fp8_qkv_batch_microtest` (#986), neither of which exists on `main`. Resolved by keeping only `native_fp8_ffn_w8a8_microtest`, this PR's own example. Everything else — including `dense_ffn.rs`, where the `w8_gemm!` macro was the thing most likely to have moved — applied to identical pre-images and was not adapted.

The later cuBLASLt VEC128 scale-layout fix is deliberately **not** in this branch. It is the thing that would make the fast path correct, and it should be reviewed against its own hardware receipt rather than smuggled in behind a set of numbers it did not produce.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
