### PR TITLE
spark-model: stop building the unreachable NVFP4 sidecars and W8A16 twins on the native-FP8 dense route (#915)

### DIFF
--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -467,6 +467,14 @@ impl DenseFfnLayer {
         if self.q2_weights.is_some() {
             return Ok(());
         }
+        // Native FP8 (#915): `forward_prefill_inner` returns from inside its
+        // `self.fp8_weights` arm long before the Q4_K/MMQ arm, so this repack
+        // is dead work — and since #915 the loader installs NULL NVFP4 source
+        // weights on that route, over which `ensure_q4k_weight`'s dequant is a
+        // CUDA-700 illegal access. Same reason as the packed-Q2 guard above.
+        if self.fp8_weights.is_some() {
+            return Ok(());
+        }
         let q4k_active = self.q4k_mmq_nc_k.0 != 0
             && self.q4k_quant_act_k.0 != 0
             && self.q4k_quant_w_k.0 != 0
@@ -563,6 +571,13 @@ impl DenseFfnLayer {
         // present) and repacks the NVFP4 gate/up — over NULL pointers that's a
         // CUDA-700 illegal access. Packed-Q2 uses its own decode/prefill path.
         if self.q2_weights.is_some() {
+            return Ok(());
+        }
+        // Native FP8 (#915): same reasoning as `finalize_q4k_load`, and this
+        // one is active by DEFAULT wherever the W4A4-MMQ kernels exist — so on
+        // a target that ships them it would repack NULL NVFP4 gate/up AND free
+        // `_t` copies for a prefill arm the FP8 early-return never reaches.
+        if self.fp8_weights.is_some() {
             return Ok(());
         }
         let active = self.nvfp4_mmq_nc_k.0 != 0
@@ -1552,7 +1567,15 @@ impl DenseFfnLayer {
     /// (batchm kernel present AND NVFP4 weights loaded — the batchm GEMV
     /// reads the non-transposed NVFP4 layout).
     pub fn can_forward_km(&self, m: u32) -> bool {
-        self.batchm_kernel(m).0 != 0 && !self.weights.gate_proj.weight.is_null()
+        self.batchm_kernel(m).0 != 0
+            && (!self.weights.gate_proj.weight.is_null()
+                // Native FP8 (#915): the loader no longer builds the NVFP4
+                // fallback, but `forward_km` redirects to `forward_prefill` for
+                // an FP8 layer anyway (`native_small_batch_uses_prefill`), so
+                // the answer must stay `true` or the n=4..8 verify arm in
+                // `multi_seq/ffn.rs:145` would fall through to a DIFFERENT
+                // branch and quietly change the routing this fix must not touch.
+                || self.fp8_weights.is_some())
     }
 
     /// K=m (m<=8) speculative verify: batched GEMV for m tokens.
@@ -2704,6 +2727,12 @@ mod native_batch_tests;
 #[cfg(test)]
 #[path = "dense_ffn_kernel_tests.rs"]
 mod kernel_tests;
+
+/// #915: the native-FP8 route must work with NO NVFP4 fallback weights, so the
+/// loader can stop allocating 18.4 GiB of them.
+#[cfg(test)]
+#[path = "dense_ffn_fp8_residency_tests.rs"]
+mod fp8_residency_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/dense_ffn_fp8_residency_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_fp8_residency_tests.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The native-FP8 dense FFN must work with NO NVFP4 fallback weights (#915).
+//!
+//! WHY. On 1xH100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`, the loader built an
+//! NVFP4 gate/up/down plus a transposed twin for all 64 layers — 18.4 GiB — on
+//! the strength of a comment that said the batched spec-decode paths had no FP8
+//! branch. They do: `forward_k2`/`forward_k3`/`forward_km` all redirect through
+//! `native_small_batch_uses_prefill`, and `w8_gemm!` binds its transposed
+//! operand to a literal `None`. These tests pin that, so the loader can install
+//! `QuantizedWeight::null()` and the 18.4 GiB stays unallocated.
+//!
+//! Every case here is RED before #915: with a NULL `gate_proj`,
+//! `can_forward_km` returned false (silently rerouting the 4..8-row verify arm)
+//! and `finalize_nvfp4_mmq_load` — active by DEFAULT wherever its kernels
+//! exist — repacked over the null pointers.
+
+use super::{DenseFfnLayer, DenseFfnWeights};
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::weight_map::{Fp8Weight, QuantizedWeight, WeightQuantFormat};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+fn config() -> ModelConfig {
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = 128;
+    config.intermediate_size = 128;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    config
+}
+
+/// Exactly what `qwen35_dense.rs` now builds on the native-FP8 route: NULL
+/// NVFP4 fallbacks, no transposed twins, an FP8 overlay on top.
+fn native_fp8_layer(gpu: &MockGpuBackend) -> DenseFfnLayer {
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: QuantizedWeight::null(),
+            up_proj: QuantizedWeight::null(),
+            down_proj: QuantizedWeight::null(),
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        gpu,
+    )
+    .unwrap();
+    layer.w8a16_gemm_k = KernelHandle(0xF08);
+    layer.act_mul = KernelHandle(0xAC7);
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(128 * 128).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n: 128,
+        k: 128,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    layer.set_fp8_weights(fp8, fp8, fp8);
+    layer
+}
+
+/// Turn on every handle the two load-time MMQ finalizers check, so the test
+/// exercises the arm a real Blackwell/GB10 kernel set would enable rather than
+/// passing because the handles happen to be zero.
+fn arm_the_mmq_finalizers(layer: &mut DenseFfnLayer) {
+    for h in [
+        &mut layer.q4k_mmq_nc_k,
+        &mut layer.q4k_quant_act_k,
+        &mut layer.q4k_quant_w_k,
+        &mut layer.dequant_nvfp4_bf16_k,
+        &mut layer.nvfp4_mmq_nc_k,
+        &mut layer.nvfp4_quant_act_k,
+        &mut layer.nvfp4_repack_k,
+        &mut layer.nvfp4_silu_scaled_k,
+    ] {
+        *h = KernelHandle(0xBEEF);
+    }
+}
+
+fn with_ctx(gpu: &MockGpuBackend, f: impl FnOnce(&ForwardContext, &BufferArena)) {
+    let config = config();
+    let buffers = BufferArena::new(&config, 8, 256, 256, 8, gpu).unwrap();
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let ctx = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        decode_step: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    f(&ctx, &buffers);
+}
+
+#[test]
+fn the_verify_arm_still_selects_this_layer_without_nvfp4_weights() {
+    // `multi_seq/ffn.rs:145` gates the 4..=8-row verify branch on this. It must
+    // not change answer just because the NVFP4 fallback is gone, or the fix
+    // would silently reroute decode as well as shrink it.
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_layer(&gpu);
+    for rows in 1..=8 {
+        assert!(
+            layer.can_forward_km(rows),
+            "native FP8 layer must stay eligible at m={rows}"
+        );
+    }
+}
+
+#[test]
+fn a_layer_with_neither_nvfp4_nor_fp8_weights_is_not_eligible() {
+    // The guard `can_forward_km` actually exists for: packed-Q2 and any other
+    // route whose NVFP4 weights are NULL with nothing installed over them.
+    let gpu = MockGpuBackend::new();
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: QuantizedWeight::null(),
+            up_proj: QuantizedWeight::null(),
+            down_proj: QuantizedWeight::null(),
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        &gpu,
+    )
+    .unwrap();
+    layer.act_mul = KernelHandle(0xAC7);
+    assert!(!layer.can_forward_km(4));
+}
+
+#[test]
+fn the_mmq_finalizers_are_no_ops_under_a_native_fp8_overlay() {
+    // `finalize_nvfp4_mmq_load` is active by DEFAULT (no opt-in env) wherever
+    // its four kernels exist. Over NULL NVFP4 sources that is a CUDA-700; and
+    // even over real ones it is dead work, because `forward_prefill_inner`
+    // returns from the FP8 arm long before the MMQ arm.
+    let gpu = MockGpuBackend::new();
+    let mut layer = native_fp8_layer(&gpu);
+    arm_the_mmq_finalizers(&mut layer);
+    let allocs = gpu.alloc_count();
+    let launches = gpu.launch_count();
+    layer.finalize_q4k_load(&gpu, 128, 128, 7).unwrap();
+    layer.finalize_nvfp4_mmq_load(&gpu, 128, 128, 7).unwrap();
+    assert_eq!(gpu.alloc_count(), allocs, "no MMQ repack may be allocated");
+    assert_eq!(gpu.launch_count(), launches, "no kernel may be launched");
+}
+
+#[test]
+fn every_small_batch_entry_point_runs_without_nvfp4_weights() {
+    // The claim the 18.4 GiB rested on: "the batched spec-decode forward_k2/k3
+    // paths have no FP8 branch". They redirect to `forward_prefill`; if any of
+    // these reached a w4a16 dispatch it would read a NULL pointer, which on the
+    // mock backend surfaces as a launch carrying the null buffer.
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_layer(&gpu);
+    with_ctx(&gpu, |ctx, buffers| {
+        let start = gpu.launch_count();
+        let allocs = gpu.alloc_count();
+        let input = buffers.norm_output();
+        layer.forward(input, ctx, 7).unwrap();
+        layer.forward_k2(input, ctx, 7).unwrap();
+        layer.forward_k3(input, ctx, 7).unwrap();
+        layer.forward_km(input, 4, ctx, 7).unwrap();
+        layer.forward_prefill(input, 64, ctx, 7).unwrap();
+        assert_eq!(
+            gpu.alloc_count(),
+            allocs,
+            "dispatch must not allocate weight copies"
+        );
+        let launches = gpu.launches_snapshot();
+        assert!(launches.len() > start, "the forwards must have dispatched");
+        for launch in &launches[start..] {
+            for arg in &launch.args {
+                if let spark_runtime::gpu::mock::MockArg::Buffer(p) = arg {
+                    assert!(
+                        !p.is_null(),
+                        "a NULL NVFP4 weight reached a kernel launch: {launch:?}"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/crates/spark-model/src/layers/qwen3_attention/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/mod.rs
@@ -43,7 +43,7 @@ pub use innerq_driver::InnerQDriver;
 pub(crate) use types::HeadGateActivation;
 pub use types::Qwen3AttentionLayer;
 pub use types_weights::{
-    CompressorWeights, HcHeadWeights, HcLowRank, HcSiteWeights, HcWeights, MlaWeights,
+    CompressorWeights, Fp8TwinSet, HcHeadWeights, HcLowRank, HcSiteWeights, HcWeights, MlaWeights,
 };
 
 /// Startup fail-fast for `--kv-cache-dtype`: resolve every kernel handle the

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -9,7 +9,8 @@ use anyhow::Result;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
 use super::types::Qwen3AttentionLayer;
-use crate::weight_map::{Fp8Weight, QuantWeight, QuantizedWeight};
+use super::types_weights::Fp8TwinSet;
+use crate::weight_map::{Fp8Weight, Fp8WeightTransposed, QuantWeight, QuantizedWeight};
 
 impl Qwen3AttentionLayer {
     /// Dispatch the M=128 W4A16 prefill GEMM. Routes to the v2 shadow
@@ -342,13 +343,40 @@ impl Qwen3AttentionLayer {
         anyhow::bail!("LoRA: router/expert deltas installed on a layer with no MoE FFN component")
     }
 
+    /// Whether BOTH kernels the W8A8 block-scaled prefill arm needs are
+    /// loaded for this target (`prefill/paged_qkv.rs:220`,
+    /// `prefill/paged_oproj.rs:94`). The loader asks this to decide whether the
+    /// Q and O FP8 prefill twins are reachable at all (#915).
+    pub fn has_w8a8_prefill_kernels(&self) -> bool {
+        self.per_token_group_quant_fp8_k.0 != 0 && self.fp8_gemm_t_blockscaled_k.0 != 0
+    }
+
     /// Transpose FP8 weights for fast prefill (`w8a16_gemm_t`: coalesced
     /// reads). Must be called after [`Self::set_fp8_weights`]. Allocates
     /// new GPU buffers.
+    ///
+    /// Builds all four twins and gives them no owner — the pre-#915 behaviour,
+    /// kept for the loaders that have not been given a residency plan.
     pub fn transpose_fp8_for_prefill(
         &mut self,
         gpu: &dyn GpuBackend,
         stream: u64,
+    ) -> anyhow::Result<()> {
+        self.transpose_fp8_for_prefill_selected(gpu, stream, Fp8TwinSet::ALL, None)
+    }
+
+    /// [`Self::transpose_fp8_for_prefill`], building only `want` and handing
+    /// each result to `derived` so teardown RELEASES it instead of the backend
+    /// sweep reclaiming it unowned (#736, #915).
+    ///
+    /// `want` comes from the loader's residency plan; which projection is
+    /// reachable on which prefill chain is documented on [`Fp8TwinSet`].
+    pub fn transpose_fp8_for_prefill_selected(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+        want: Fp8TwinSet,
+        derived: Option<&spark_runtime::weights::DerivedStore>,
     ) -> anyhow::Result<()> {
         // Load-time decision, taken in the weight loader before any
         // `TransformerModel` exists to carry the config. Resolved at the point
@@ -360,27 +388,43 @@ impl Qwen3AttentionLayer {
             );
             return Ok(());
         }
+        if !want.any() {
+            return Ok(());
+        }
         if self.w8a16_gemm_t_k.0 == 0 {
             return Ok(()); // kernel not available
         }
         let transpose_k = gpu.kernel("w8a16_gemm_t", "transpose_fp8")?;
         let transpose_scale_k = gpu.kernel("w8a16_gemm_t", "transpose_block_scale")?;
 
-        if let Some(w) = self.q_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.q_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        let build = |src: Option<&QuantWeight>| -> anyhow::Result<Option<Fp8WeightTransposed>> {
+            let Some(w) = src.and_then(|w| w.as_fp8()) else {
+                return Ok(None);
+            };
+            let t = w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?;
+            if let Some(d) = derived {
+                let (n, k) = (w.n as usize, w.k as usize);
+                d.adopt("attn fp8 prefill twin (weight_t)", t.weight_t, n * k);
+                d.adopt(
+                    "attn fp8 prefill twin (scale_t)",
+                    t.scale_t,
+                    n.div_ceil(128) * k.div_ceil(128) * 4,
+                );
+            }
+            Ok(Some(t))
+        };
+
+        if want.q {
+            self.q_fp8w_t = build(self.q_weight.as_ref())?;
         }
-        if let Some(w) = self.k_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.k_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.k {
+            self.k_fp8w_t = build(self.k_weight.as_ref())?;
         }
-        if let Some(w) = self.v_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.v_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.v {
+            self.v_fp8w_t = build(self.v_weight.as_ref())?;
         }
-        if let Some(w) = self.o_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.o_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.o {
+            self.o_fp8w_t = build(self.o_weight.as_ref())?;
         }
         Ok(())
     }

--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -226,3 +226,50 @@ pub struct HcWeights {
     /// final norm and the checkpoint ships no `model.norm.weight`.
     pub is_last_model_layer: bool,
 }
+
+/// Which of the four attention projections get an FP8 `[K, N]` transposed twin
+/// built by [`Qwen3AttentionLayer::transpose_fp8_for_prefill`].
+///
+/// WHY per projection and not one flag (#915): the four are reached by
+/// DIFFERENT prefill chains and only two of them are W8A8-gated.
+///
+/// * **K and V** are read by `prefill/cache_skip_qkv.rs:218` / `:235`, whose
+///   dispatch chain has **no W8A8 arm at all** — and `cache_skip` is the
+///   first-chunk path (`trait_impl/prefill_inner.rs:138`, `seq_len_start == 0`)
+///   taken by every request. Their twins are never dead.
+/// * **Q** on that chain is behind `ATLAS_ATTN_PREFILL_Q_T=1`
+///   (`cache_skip_qkv.rs:142`); otherwise it is reached only after the W8A8
+///   arm in `prefill/paged_qkv.rs:220` declines.
+/// * **O** is routed to `prefill/paged_oproj.rs` from both chains, so it is
+///   reached only after the W8A8 arm at `paged_oproj.rs:94` declines.
+///
+/// On 1xH100 (Qwen3.8-27B-FP8) the four cost 100 MiB/layer x 16 layers =
+/// 1,600 MB — the `weight_map/quantized.rs:643` ledger row.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Fp8TwinSet {
+    pub q: bool,
+    pub k: bool,
+    pub v: bool,
+    pub o: bool,
+}
+
+impl Fp8TwinSet {
+    pub const NONE: Self = Self {
+        q: false,
+        k: false,
+        v: false,
+        o: false,
+    };
+    /// Every twin — what a loader that has not opted into the #915 plan asks
+    /// for, i.e. the pre-#915 behaviour.
+    pub const ALL: Self = Self {
+        q: true,
+        k: true,
+        v: true,
+        o: true,
+    };
+
+    pub fn any(self) -> bool {
+        self.q || self.k || self.v || self.o
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -230,6 +230,9 @@ pub struct HcWeights {
 /// Which of the four attention projections get an FP8 `[K, N]` transposed twin
 /// built by [`Qwen3AttentionLayer::transpose_fp8_for_prefill`].
 ///
+/// [`Qwen3AttentionLayer::transpose_fp8_for_prefill`]:
+///     super::Qwen3AttentionLayer::transpose_fp8_for_prefill
+///
 /// WHY per projection and not one flag (#915): the four are reached by
 /// DIFFERENT prefill chains and only two of them are W8A8-gated.
 ///

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -275,8 +275,9 @@ impl TransformerModel {
         // therefore unreachable, and on this model it is NOT cheap: 8 slots x
         // max_batch x the full SSM blob (27B: 158.9 MB) = ~19.9 GB at batch 16,
         // allocated up front. Skip it when speculative decode is on.
-        // The ring-depth decision (env overrides + speculative/watchdog
-        // skip) is SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
+        // The ring-depth decision (the published `--ssm-decode-ring-slots` /
+        // #915 auto-fit depth, env overrides, speculative/watchdog skip) is
+        // SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
         // — spark-server's `preflight_reserve` calls the SAME helper, so the
         // GPU reservation and this allocation cannot drift. The scheduler
         // keys off `decode_rollback_ring_slots()`, so a 0 here disables save

--- a/crates/spark-model/src/ssm_reserve.rs
+++ b/crates/spark-model/src/ssm_reserve.rs
@@ -1,48 +1,32 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! SSOT for the Phase-C decode-rollback ring depth.
+//! SSOT for the SSM/linear-attention GPU reserve terms.
 //!
-//! Two call sites MUST agree on this number or a serve either
-//! under-reserves (runtime CUDA alloc failure after weights load) or
-//! over-reserves (preflight refuses batch sizes the runtime could fund):
+//! Every term here is computed TWICE — once by `spark-server`'s
+//! `preflight_reserve` before the weights load, once by the allocating call
+//! site (`SsmStatePool::new`, `TransformerModel::new`) after — and the two
+//! MUST agree or a serve either under-reserves (runtime CUDA alloc failure)
+//! or over-reserves (preflight refuses a configuration the runtime could
+//! fund). Each function below is the one place that decision is made.
 //!
-//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
-//!   reservation before weights load;
-//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
-//!
-//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
-//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
-//! speculative path does its rejection rollback through the verify snapshot,
-//! never this ring. Under `--speculative` the ring is unreachable, and it is
-//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
-//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
-//! while the runtime skipped it capped the native batch at ~20 on GB10
-//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
-//!
-//! Env contract (read HERE and nowhere else):
-//!
-//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
-//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
-//!   should keep loop re-steer); `=0` force-disables it even without spec.
-//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
-//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
-//!   never fire, so the ring is skipped.
+//! The Phase-C decode-rollback ring DEPTH — its publication cell, the
+//! `ATLAS_SSM_DECODE_RING` / `ATLAS_DISABLE_WATCHDOGS` contract and the #915
+//! auto-fit — lives in the `decode_ring` sibling module and is re-exported
+//! here, so every existing `ssm_reserve::decode_rollback_ring_slots` path is
+//! unchanged.
 
-/// Outcome of the ring-depth decision.
-///
-/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
-/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
-/// override — so the allocating call site can log the savings once.
-pub struct DecodeRingDecision {
-    pub slots: usize,
-    pub skip_reason: Option<&'static str>,
-}
+mod decode_ring;
+pub use decode_ring::{
+    DECODE_RING_FIT_LADDER, DecodeRingDecision, decode_rollback_ring_slots,
+    decode_rollback_ring_slots_with, fit_decode_ring_slots, parse_decode_ring_slots,
+    published_decode_ring_slots, set_decode_ring_slots, watchdogs_disabled_from_value,
+};
 
 /// Number of SSM-pool slots the MTP/DFlash VERIFY state pools (per-token
 /// intermediates + pre-verify checkpoints) must cover.
 ///
 /// Three call sites MUST agree on this number (same contract as the decode
-/// ring above):
+/// ring in `decode_ring`):
 ///
 /// * `spark-server` `preflight_reserve` — sizes the pre-load GPU reserve;
 /// * `SsmStatePool::new` — allocates the intermediate/checkpoint pools;
@@ -425,71 +409,6 @@ pub fn ssm_replay_ring_bytes(
     mtp_state_slots: usize,
 ) -> usize {
     mtp_state_slots * k_ceiling.saturating_sub(1) * num_ssm_layers * row_bytes
-}
-
-/// Decide the per-sequence decode-rollback ring depth.
-///
-/// `use_speculative` MUST be the same flag `factory::build_model` receives
-/// (`--speculative || --dflash` as plumbed by spark-server) at every call
-/// site, or preflight and allocation diverge.
-pub fn decode_rollback_ring_slots(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-) -> DecodeRingDecision {
-    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
-    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
-    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
-    decode_rollback_ring_slots_with(
-        num_ssm_layers,
-        use_speculative,
-        ring_override.as_deref(),
-        watchdogs_disabled,
-    )
-}
-
-fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
-    value
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v == "1" || v == "true"
-        })
-        .unwrap_or(false)
-}
-
-fn decode_rollback_ring_slots_with(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-    ring_override: Option<&str>,
-    watchdogs_disabled: bool,
-) -> DecodeRingDecision {
-    if num_ssm_layers == 0 {
-        return DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        };
-    }
-    match ring_override {
-        Some("1") => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-        Some("0") => DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        },
-        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
-            slots: 0,
-            skip_reason: Some(if use_speculative {
-                "speculative decode active"
-            } else {
-                "watchdogs disabled"
-            }),
-        },
-        _ => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-    }
 }
 
 /// Outcome of the Marconi snapshot-slot decision.

--- a/crates/spark-model/src/ssm_reserve/decode_ring.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT for the Phase-C decode-rollback ring DEPTH.
+//!
+//! A sibling of `ssm_reserve.rs` (which sits over the 500-line cap),
+//! following the `per_sequence_state.rs` precedent: the depth decision, its
+//! publication cell and the #915 auto-fit live here.
+//!
+//! Two call sites MUST agree on this number or a serve either under-reserves
+//! (runtime CUDA alloc failure after weights load) or over-reserves
+//! (preflight refuses batch sizes the runtime could fund):
+//!
+//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
+//!   reservation before weights load;
+//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
+//!
+//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
+//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
+//! speculative path does its rejection rollback through the verify snapshot,
+//! never this ring. Under `--speculative` the ring is unreachable, and it is
+//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
+//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
+//! while the runtime skipped it capped the native batch at ~20 on GB10
+//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
+//!
+//! ## Why the depth is now sized from free memory (#915)
+//!
+//! The depth was a CONSTANT (8) multiplied by `--max-batch-size`, so it grew
+//! with a flag that says nothing about what the card can hold. Serving
+//! Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) asked
+//! for 8 × 32 × 151.5 MiB = 37.88 GiB of ring alone — an inference reserve of
+//! 45,823 MiB against a 71.3 GiB budget with 57.2 GiB of weights — and the
+//! serve REFUSED to boot (rental H100, 2026-09-05). The recipe workaround was
+//! `--max-batch-size 4`, i.e. paying for rollback depth with four fifths of
+//! the serve's concurrency.
+//!
+//! The ring degrades gracefully with depth (fewer retained boundaries = fewer
+//! reachable re-steer anchors, never wrong output), so preflight now SHRINKS
+//! it down the [`DECODE_RING_FIT_LADDER`] until the reserve fits and publishes
+//! the chosen depth through [`set_decode_ring_slots`], instead of refusing.
+//! Refusal is kept only for the case where even depth 0 does not fit.
+//!
+//! Env contract (read HERE and nowhere else):
+//!
+//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
+//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
+//!   should keep loop re-steer); `=0` force-disables it even without spec.
+//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
+//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
+//!   never fire, so the ring is skipped.
+
+/// Outcome of the ring-depth decision.
+///
+/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
+/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
+/// override, a published `--ssm-decode-ring-slots N` or the #915 auto-fit —
+/// so the allocating call site can log the savings once.
+pub struct DecodeRingDecision {
+    pub slots: usize,
+    pub skip_reason: Option<&'static str>,
+}
+
+/// Depths preflight's #915 auto-fit may choose from, LARGEST FIRST.
+///
+/// Halving rather than decrementing: each rung halves the ring's share of
+/// the reserve, so at most four steps separate "the default" from "no ring",
+/// and every rung is a power of two — the ring's slot assignment is
+/// `(next_slot + 1) % capacity` (`SsmDecodeRing::record`), which is exact at
+/// any capacity but wraps most evenly at these.
+///
+/// 8 is [`atlas_kernels::DECODE_ROLLBACK_RING_SLOTS`] and covers the
+/// 3-repeat fuzzy loop detector with margin; 1 still anchors a single clean
+/// boundary; 0 means the sequence hard-stops instead of re-steering
+/// (`RollbackFallback::NoSsmSnapshot` — an honest decline, never a partial
+/// rewind).
+pub const DECODE_RING_FIT_LADDER: [usize; 5] = [8, 4, 2, 1, 0];
+
+/// The depth published by the serve command line (`--ssm-decode-ring-slots
+/// N`) or by preflight's auto-fit. Written once, read by BOTH sizing call
+/// sites — same first-write-wins cell pattern as
+/// [`super::set_ssm_rollback_mode`].
+///
+/// Absent is NOT a value: `--ssm-decode-ring-slots auto` publishes nothing,
+/// so the documented `ATLAS_SSM_DECODE_RING` fallback stays reachable and
+/// preflight can publish the auto-fit depth later in the same boot.
+static DECODE_RING_SLOTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Publish the decode-ring depth. Returns the value in force (first write
+/// wins, matching `gdn_flags::set_from_cli`): an explicit
+/// `--ssm-decode-ring-slots N` is published before preflight runs, so the
+/// auto-fit's later write is a no-op and an operator's explicit depth is
+/// never silently shrunk.
+pub fn set_decode_ring_slots(slots: usize) -> usize {
+    let _ = DECODE_RING_SLOTS.set(slots);
+    *DECODE_RING_SLOTS.get().expect("just set")
+}
+
+/// The published depth, or `None` when nothing has been published.
+///
+/// Does NOT initialize the cell — preflight asks this to tell an EXPLICIT
+/// depth (auto-fit disabled, refuse as before) from `auto` (auto-fit
+/// allowed), and asking must not itself seal the decision.
+pub fn published_decode_ring_slots() -> Option<usize> {
+    DECODE_RING_SLOTS.get().copied()
+}
+
+/// SSOT parse for the `--ssm-decode-ring-slots` value: `auto` (`None` — size
+/// it from free memory at preflight) or an explicit `0..=8`.
+///
+/// `validate_serve_args` and `publish_kernel_flags` both go through THIS, so
+/// what the CLI accepts and what it publishes cannot drift.
+pub fn parse_decode_ring_slots(s: &str) -> Result<Option<usize>, String> {
+    if s == "auto" {
+        return Ok(None);
+    }
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("unknown ssm-decode-ring-slots '{s}' (valid: auto, 0..=8)"))?;
+    if n > atlas_kernels::DECODE_ROLLBACK_RING_SLOTS {
+        return Err(format!(
+            "ssm-decode-ring-slots {n} exceeds the {} the ring is sized for",
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        ));
+    }
+    Ok(Some(n))
+}
+
+/// Decide the per-sequence decode-rollback ring depth.
+///
+/// `use_speculative` MUST be the same flag `factory::build_model` receives
+/// (`--speculative || --dflash` as plumbed by spark-server) at every call
+/// site, or preflight and allocation diverge.
+pub fn decode_rollback_ring_slots(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+) -> DecodeRingDecision {
+    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
+    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
+    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
+    decode_rollback_ring_slots_with(
+        num_ssm_layers,
+        use_speculative,
+        published_decode_ring_slots(),
+        ring_override.as_deref(),
+        watchdogs_disabled,
+    )
+}
+
+/// `ATLAS_DISABLE_WATCHDOGS` truthiness — trimmed, case-insensitive, `1` or
+/// `true` only (mirrors spark-server's `parse_disable_watchdogs`).
+pub fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
+    value
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        })
+        .unwrap_or(false)
+}
+
+/// Pure core of [`decode_rollback_ring_slots`] (env-free, unit-testable).
+///
+/// Precedence, highest first:
+///
+/// 1. no SSM layers — there is no recurrent state to snapshot;
+/// 2. `published` — `--ssm-decode-ring-slots N`, or the depth preflight's
+///    auto-fit chose. It outranks the env override AND the implicit skips for
+///    the same reason `ATLAS_SSM_DECODE_RING=1` always has: an operator (or a
+///    reserve that has already been sized against free memory) asking for a
+///    specific depth must get that depth on BOTH sides, or the two diverge;
+/// 3. `ATLAS_SSM_DECODE_RING=1|0` — the legacy spelling of "8" and "0";
+/// 4. the implicit skips (speculative decode, watchdogs off);
+/// 5. the default depth.
+pub fn decode_rollback_ring_slots_with(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+    published: Option<usize>,
+    ring_override: Option<&str>,
+    watchdogs_disabled: bool,
+) -> DecodeRingDecision {
+    if num_ssm_layers == 0 {
+        return DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        };
+    }
+    if let Some(slots) = published {
+        return DecodeRingDecision {
+            slots,
+            skip_reason: None,
+        };
+    }
+    match ring_override {
+        Some("1") => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+        Some("0") => DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        },
+        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
+            slots: 0,
+            skip_reason: Some(if use_speculative {
+                "speculative decode active"
+            } else {
+                "watchdogs disabled"
+            }),
+        },
+        _ => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+    }
+}
+
+/// Largest [`DECODE_RING_FIT_LADDER`] depth `<= start_slots` whose ring term
+/// still fits in `free_mem` alongside everything else the reserve needs
+/// (#915). Pure — preflight owns the bytes, this owns the ladder.
+///
+/// `bytes_per_ring_slot` is ONE depth unit: `max_batch_size × the per-seq SSM
+/// state blob`, the same product `ssm_snapshot_bytes` multiplies the depth by.
+///
+/// Returns 0 when nothing fits — including the case where the rest of the
+/// reserve ALONE exceeds `free_mem`, which is the caller's cue to refuse with
+/// the existing suggested-batch text rather than to boot a ringless serve.
+pub fn fit_decode_ring_slots(
+    start_slots: usize,
+    reserve_without_ring: usize,
+    bytes_per_ring_slot: usize,
+    free_mem: usize,
+) -> usize {
+    DECODE_RING_FIT_LADDER
+        .iter()
+        .copied()
+        .filter(|&slots| slots <= start_slots)
+        .find(|&slots| {
+            reserve_without_ring.saturating_add(slots.saturating_mul(bytes_per_ring_slot))
+                <= free_mem
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod decode_ring_tests;

--- a/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`ssm_reserve::decode_ring`). A sibling file via
+//! `#[path]` — the `ssm_reserve_tests.rs` idiom — so both stay under the
+//! 500-line cap.
+//!
+//! Every byte figure below is the 2026-09-05 rental-H100 configuration from
+//! issue #915 (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe): 48 GDN
+//! layers, 151.5 MiB of SSM state per sequence, `--max-batch-size 32`,
+//! inference reserve 45,823 MiB, 57.2 GiB of weights inside a 71.3 GiB
+//! budget. Pinning the arithmetic here is what stops the fit and the reserve
+//! from drifting apart.
+use super::*;
+
+/// Per-sequence SSM state blob: 48 GDN layers x (h + conv) = 158,859,264 B,
+/// the "151.5 MiB/seq" every #915 log line quotes. Same derivation as the
+/// `H_BLOB`/`CONV_BLOB` constants in `ssm_reserve_tests.rs`.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// One unit of ring depth at `--max-batch-size 32`.
+const SLOT_BYTES: usize = 32 * PER_SEQ_BLOB;
+/// The 45,823 MiB inference reserve MINUS its 8-slot ring (38,784 MiB): the
+/// part of the #915 reserve that does not scale with ring depth.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+#[test]
+fn decode_ring_decision_matrix() {
+    let decide = |layers, spec, override_value, watchdogs| {
+        let decision =
+            decode_rollback_ring_slots_with(layers, spec, None, override_value, watchdogs);
+        (decision.slots, decision.skip_reason)
+    };
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+
+    for value in ["1", "true", " TRUE "] {
+        assert!(
+            watchdogs_disabled_from_value(Some(value)),
+            "value={value:?}"
+        );
+    }
+    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
+        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
+    }
+
+    assert_eq!(decide(0, false, Some("1"), false), (0, None));
+    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
+    assert_eq!(decide(48, false, Some("0"), false), (0, None));
+    assert_eq!(
+        decide(48, true, None, false),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(
+        decide(48, false, None, true),
+        (0, Some("watchdogs disabled"))
+    );
+    assert_eq!(
+        decide(48, true, Some("invalid"), true),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(decide(48, false, None, false), (ring, None));
+}
+
+/// A published depth is what BOTH sizing call sites must see — preflight
+/// sized the reserve against it, so `TransformerModel::new` allocating
+/// anything else re-opens the divergence this module exists to close.
+#[test]
+fn a_published_depth_outranks_the_default_the_env_and_the_skips() {
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+    let d = decode_rollback_ring_slots_with(48, false, Some(2), None, false);
+    assert_eq!((d.slots, d.skip_reason), (2, None));
+    // Against the legacy env spelling of "8" ...
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, false, Some(2), Some("1"), false).slots,
+        2
+    );
+    // ... and against BOTH implicit skips, exactly as ATLAS_SSM_DECODE_RING=1
+    // already did: an explicit depth is an explicit depth.
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, true, Some(4), None, true).slots,
+        4
+    );
+    // A published 0 is an explicit off, not an implicit skip: no skip_reason,
+    // so the allocating call site does not log a saving nobody asked for.
+    let zero = decode_rollback_ring_slots_with(48, false, Some(0), None, false);
+    assert_eq!((zero.slots, zero.skip_reason), (0, None));
+    // No SSM layers still outranks everything — no recurrent state to snapshot.
+    assert_eq!(
+        decode_rollback_ring_slots_with(0, false, Some(ring), None, false).slots,
+        0
+    );
+}
+
+/// The value the CLI accepts and the value it publishes come from ONE parse.
+#[test]
+fn parse_accepts_auto_and_zero_through_eight() {
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("0"), Ok(Some(0)));
+    assert_eq!(
+        parse_decode_ring_slots("8"),
+        Ok(Some(atlas_kernels::DECODE_ROLLBACK_RING_SLOTS))
+    );
+    // Above the ceiling the ring is sized for, and anything non-numeric, is a
+    // startup refusal — never a silent clamp to 8.
+    assert!(parse_decode_ring_slots("9").is_err());
+    assert!(parse_decode_ring_slots("AUTO").is_err());
+    assert!(parse_decode_ring_slots("").is_err());
+    assert!(parse_decode_ring_slots("-1").is_err());
+}
+
+/// The #915 boot: 7,039 MiB of non-ring reserve, 14.1 GiB free after 57.2 GiB
+/// of weights inside a 71.3 GiB budget. Depth 8 asks 37.88 GiB and refuses;
+/// depth 1 fits and boots.
+#[test]
+fn autofit_picks_the_largest_fitting_depth() {
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+    let fitted = fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free);
+    assert_eq!(fitted, 1, "largest ladder depth that fits in 14.1 GiB");
+    assert!(RESERVE_WITHOUT_RING + fitted * SLOT_BYTES <= free);
+    assert!(
+        RESERVE_WITHOUT_RING + 2 * SLOT_BYTES > free,
+        "and 2 does not"
+    );
+
+    // With more room the ladder lands on 4 — it never picks 5, 6 or 7, so a
+    // fitted depth is always a rung the operator can recognise.
+    let roomier = 30 * 1024 * 1024 * 1024;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, roomier),
+        4
+    );
+    // Already fitting at the requested depth is left alone.
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        8
+    );
+    // The fit never RAISES a depth: a request below the ladder top is a
+    // ceiling, not a target.
+    assert_eq!(
+        fit_decode_ring_slots(2, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        2
+    );
+}
+
+/// When the rest of the reserve alone exceeds free memory the ring is not the
+/// problem: the fit bottoms out at 0 and the caller must still refuse.
+#[test]
+fn autofit_is_zero_when_even_a_ringless_reserve_does_not_fit() {
+    let free = RESERVE_WITHOUT_RING - 1;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free),
+        0
+    );
+    assert!(
+        RESERVE_WITHOUT_RING > free,
+        "0 slots is still over budget — the caller refuses rather than booting ringless"
+    );
+    // A zero-byte ring (pure-attention model) is a no-op, not a division trap.
+    assert_eq!(fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, 0, free), 0);
+}
+
+#[test]
+fn the_fit_ladder_is_descending_and_starts_at_the_wired_default() {
+    assert_eq!(
+        DECODE_RING_FIT_LADDER[0],
+        atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+    );
+    assert_eq!(*DECODE_RING_FIT_LADDER.last().unwrap(), 0);
+    assert!(
+        DECODE_RING_FIT_LADDER.windows(2).all(|w| w[0] > w[1]),
+        "`fit_decode_ring_slots` returns the FIRST fitting rung, so the ladder \
+         must be strictly descending or it would return a smaller depth than fits"
+    );
+}

--- a/crates/spark-model/src/ssm_reserve_tests.rs
+++ b/crates/spark-model/src/ssm_reserve_tests.rs
@@ -383,41 +383,9 @@ fn rollback_mode_parses_and_rejects() {
     assert!(SsmRollbackMode::from_str("").is_err());
 }
 
-#[test]
-fn decode_ring_decision_matrix() {
-    let decide = |layers, spec, override_value, watchdogs| {
-        let decision = decode_rollback_ring_slots_with(layers, spec, override_value, watchdogs);
-        (decision.slots, decision.skip_reason)
-    };
-    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
-
-    for value in ["1", "true", " TRUE "] {
-        assert!(
-            watchdogs_disabled_from_value(Some(value)),
-            "value={value:?}"
-        );
-    }
-    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
-        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
-    }
-
-    assert_eq!(decide(0, false, Some("1"), false), (0, None));
-    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
-    assert_eq!(decide(48, false, Some("0"), false), (0, None));
-    assert_eq!(
-        decide(48, true, None, false),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(
-        decide(48, false, None, true),
-        (0, Some("watchdogs disabled"))
-    );
-    assert_eq!(
-        decide(48, true, Some("invalid"), true),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(decide(48, false, None, false), (ring, None));
-}
+// The decode-rollback ring's depth decision, its publication cell and the
+// #915 auto-fit are tested in `ssm_reserve/decode_ring_tests.rs`, next to the
+// module that owns them.
 
 // ─────────────────── Marconi snapshot-slot gate (2026-08-31) ───────────────────
 //

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -514,7 +514,9 @@ pub trait Model: Send + Sync {
     /// model keeps no decode-rollback snapshots — appropriate for
     /// pure-attention models and for SSM models when the snapshot pool
     /// has no capacity reserved. SSM models with a populated pool
-    /// override to `ROLLBACK_RESTEER_CAP + 1`.
+    /// override to the depth `ssm_reserve::decode_rollback_ring_slots`
+    /// decided — 8 by default, or whatever `--ssm-decode-ring-slots` /
+    /// preflight's free-memory fit published (#915).
     fn decode_rollback_ring_slots(&self) -> usize {
         0
     }

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -1688,7 +1688,7 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
     /// `norm.weight` are aliased or conditionally aliased depending on their
     /// on-disk dtype, and every attention / FFN tensor is bound zero-copy.
     /// Only the four names below are freed, and only for layers where
-    /// [`gdn_fp8_arm_selected`] says that arm actually ran.
+    /// `gdn_fp8_arm_selected` (private to this module) says that arm actually ran.
     fn prune_after_load(
         &self,
         store: &mut WeightStore,

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -167,6 +167,24 @@ fn dense_fp8_enabled() -> bool {
     std::env::var("ATLAS_DENSE_FP8").as_deref() == Ok("1")
 }
 
+/// Whether the native block-scaled FP8 GDN arm runs for this SSM layer.
+///
+/// ONE predicate, called by `load_layers` and by `prune_after_load`: the
+/// second frees the store tensors the first copied into the fused `[QKV|Z]`
+/// weight, and a drift between the two is a use-after-free with no
+/// diagnostic. The keep-packed Q2 arm `continue`s ahead of this one, so it is
+/// part of the condition (#915).
+fn gdn_fp8_arm_selected(store: &WeightStore, la: &str, tp_size: usize) -> bool {
+    let q2 = tp_size.max(1) == 1
+        && std::env::var_os("ATLAS_NO_Q2_GDN").is_none()
+        && proj_q2_group(store, &format!("{la}.in_proj_qkv")).is_some()
+        && proj_q2_group(store, &format!("{la}.in_proj_z")).is_some();
+    !q2 && std::env::var_os("ATLAS_NO_GDN_FP8").is_none()
+        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_qkv"))
+        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_z"))
+        && proj_is_fp8_any_scale(store, &format!("{la}.out_proj"))
+}
+
 /// The dense-FFN width. `moe_intermediate_size` is the PER-EXPERT width and is
 /// unset (=0) on dense Qwen3.6/3.8-*-FP8, so reading it first would size a
 /// 0-byte allocation; `intermediate_size` is unset on the older MoE-style
@@ -1104,11 +1122,7 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     // Internal opt-out for the FP8-vs-NVFP4 GDN A/B + KL-drift
                     // gate (not a user choice; mirrors the `ATLAS_NO_*` debug
                     // levers). Default engages native FP8.
-                    if std::env::var_os("ATLAS_NO_GDN_FP8").is_none()
-                        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_qkv"))
-                        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_z"))
-                        && proj_is_fp8_any_scale(store, &format!("{la}.out_proj"))
-                    {
+                    if gdn_fp8_arm_selected(store, &la, config.tp_world_size) {
                         let in_proj_a = dense(store, &format!("{la}.in_proj_a.weight"))?;
                         let in_proj_b = dense(store, &format!("{la}.in_proj_b.weight"))?;
                         let conv1d = dense(store, &format!("{la}.conv1d.weight"))?;
@@ -1656,6 +1670,72 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         }
 
         Ok(layers)
+    }
+
+    /// Drop the SSM source tensors the native-FP8 GDN arm copied and no longer
+    /// reads (#915).
+    ///
+    /// That arm builds a fused `[QKV|Z]` FP8 weight by device-to-device
+    /// appending `in_proj_qkv` and `in_proj_z` (`concat_fp8_block_scaled`), and
+    /// builds `in_proj_ba` by a D2H -> host interleave -> H2D round trip
+    /// (`interleave_ba`). All four store originals are dead the moment
+    /// `load_layers` returns — 80 MiB + ~1 MB per SSM layer, ~3.9 GB across the
+    /// 48 GDN layers of Qwen3.8-27B-FP8, which is what the fused copy costs.
+    /// Keeping both is the duplicate that came straight out of the KV budget.
+    ///
+    /// 🪤 Narrow on purpose. `out_proj.weight` IS `out_proj_fp8w.weight`
+    /// (zero-copy from the store), `conv1d`, `A_log`, `dt_bias` and
+    /// `norm.weight` are aliased or conditionally aliased depending on their
+    /// on-disk dtype, and every attention / FFN tensor is bound zero-copy.
+    /// Only the four names below are freed, and only for layers where
+    /// [`gdn_fp8_arm_selected`] says that arm actually ran.
+    fn prune_after_load(
+        &self,
+        store: &mut WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
+    ) -> Result<()> {
+        // Same resolution `load_layers` uses: an explicit `layer_types` list
+        // wins over the computed pattern, and pruning must be decided from the
+        // list that actually selected the arms.
+        let layer_types = if config.layer_types.is_empty() {
+            (0..config.num_hidden_layers)
+                .map(|i| config.layer_type(i))
+                .collect::<Vec<_>>()
+        } else {
+            config.layer_types.clone()
+        };
+        let mut doomed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (i, lt) in layer_types.iter().enumerate() {
+            if *lt != LayerType::LinearAttention {
+                continue;
+            }
+            let la = format!("{}.linear_attn", config.layer_prefix(i));
+            if !gdn_fp8_arm_selected(store, &la, config.tp_world_size) {
+                continue;
+            }
+            for leaf in [
+                "in_proj_qkv.weight",
+                "in_proj_qkv.weight_scale_inv",
+                "in_proj_qkv.weight_scale",
+                "in_proj_z.weight",
+                "in_proj_z.weight_scale_inv",
+                "in_proj_z.weight_scale",
+                "in_proj_a.weight",
+                "in_proj_b.weight",
+            ] {
+                doomed.insert(format!("{la}.{leaf}"));
+            }
+        }
+        if doomed.is_empty() {
+            return Ok(());
+        }
+        let (count, bytes) = store.free_matching(gpu, |name| doomed.contains(name))?;
+        tracing::info!(
+            "native FP8 GDN: released {count} store tensors ({:.2} GB) consumed by the fused              [QKV|Z] concat and the BA interleave; out_proj/conv1d/A_log/dt_bias/norm kept              (still aliased)",
+            bytes as f64 / 1e9,
+        );
+        Ok(())
     }
 
     fn load_embedding(

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -167,8 +167,24 @@ fn dense_fp8_enabled() -> bool {
     std::env::var("ATLAS_DENSE_FP8").as_deref() == Ok("1")
 }
 
+/// The dense-FFN width. `moe_intermediate_size` is the PER-EXPERT width and is
+/// unset (=0) on dense Qwen3.6/3.8-*-FP8, so reading it first would size a
+/// 0-byte allocation; `intermediate_size` is unset on the older MoE-style
+/// configs. Same fallback order as `weight_map/fp8_lut.rs::load_dense_ffn`.
+fn ffn_inter(config: &ModelConfig) -> usize {
+    if config.intermediate_size > 0 {
+        config.intermediate_size
+    } else {
+        config.moe_intermediate_size
+    }
+}
+
+mod fp8_residency;
 mod loaders_b;
 mod rowwise_fp8;
+
+use crate::layers::qwen3_attention::Fp8TwinSet;
+use fp8_residency::{DerivedResidency, RouteEnv};
 
 pub struct Qwen35DenseWeightLoader;
 
@@ -264,6 +280,12 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         };
         log_free("dense-load-start");
 
+        // #915: resolved ONCE, from the same resolvers the forward pass uses —
+        // the loader runs before `ForwardContext` exists. Contract and WHY:
+        // `fp8_residency.rs`.
+        let route_env = RouteEnv::from_env();
+        let mut residency = DerivedResidency::default();
+
         for (i, lt) in layer_types.iter().enumerate() {
             if i % 8 == 0 {
                 log_free(&format!("layer-{i}"));
@@ -280,13 +302,17 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 && config.tp_world_size.max(1) == 1
                 && matches!(variant, Nvfp4Variant::Fp8Dequanted)
                 && proj_is_native_fp8(store, &format!("{lp}.mlp.gate_proj"));
-            // Always load the NVFP4 weights so every dispatch path (incl. the
-            // batched spec-decode forward_k2/k3 paths that have no FP8 branch)
-            // has a valid weight to fall back to — a null NVFP4 weight under a
-            // w4a16 dispatch is the CUDA-700-at-concurrency bug. When native
-            // FP8 is enabled we overlay the block-scaled FP8 weights on top;
-            // the hot forward / forward_prefill paths then use FP8, the rare
-            // batched paths fall back to real NVFP4.
+            // 2026-09-11 (#915), replacing "always load the NVFP4 weights so
+            // every dispatch path has a valid weight to fall back to": there is
+            // no such path any more. `forward_k2`/`k3`/`km` redirect to
+            // `forward_prefill` whenever an FP8 overlay is installed
+            // (`native_small_batch_uses_prefill`), and both `forward` and
+            // `forward_prefill_inner` return from inside their `fp8_weights`
+            // arm. Building the fallback cost 18.4 GiB on Qwen3.8-27B-FP8 that
+            // nothing could read. The CUDA-700-at-concurrency hazard the old
+            // rule guarded is real and is why this is decided by
+            // `fp8_residency.rs` rather than inline: a NULL NVFP4 weight is
+            // only sound when the plan proves no w4a16 dispatch is reachable.
             // Native-BF16 dense-FFN prefill (Holo/Ornith Bf16Raw): the fast
             // tensor-core `dense_gemm_tc` path (dense_ffn::forward_prefill) needs
             // LIVE BF16 gate/up/down. `load_dense_ffn`'s Bf16Raw arm runtime-
@@ -341,9 +367,30 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 None
             };
 
-            let ffn_weights = if ffn_q2 {
-                // NULL NVFP4 fallback: decode uses the packed weights; prefill /
-                // batched paths bail (Tier-2). No NVFP4 allocation → memory win.
+            // #915: the NVFP4 gate/up/down fallback and its transposed twins
+            // are 18.4 GiB on Qwen3.8-27B-FP8 that NO native-FP8 dispatch can
+            // reach — every `DenseFfnLayer` entry point returns from inside its
+            // `self.fp8_weights` arm and `w8_gemm!` binds the transposed
+            // operand to a literal `None`. The comment above ("always load the
+            // NVFP4 weights ... the rare batched paths fall back to real
+            // NVFP4") described the pre-#927 dispatch; `forward_k2`/`k3`/`km`
+            // have redirected to `forward_prefill` since
+            // `native_small_batch_uses_prefill` landed. Decision table and the
+            // loader-runs-before-dispatch contract: `fp8_residency.rs`.
+            let plan = route_env.plan(ffn_fp8, false, false);
+            let ffn_nvfp4 = !ffn_q2 && plan.ffn_nvfp4;
+            let ffn_weights = if ffn_nvfp4 {
+                load_dense_ffn(
+                    store, &lp, gpu, variant, absmax_k, quantize_k, stream, config,
+                )?
+            } else {
+                // NULL NVFP4 fallback. Packed-Q2 (Tier-1c): decode uses the
+                // packed weights; prefill / batched paths bail (Tier-2).
+                // Native FP8: every arm reads the E4M3 bytes installed by
+                // `set_fp8_weights` below. No NVFP4 allocation → memory win.
+                if ffn_fp8 {
+                    residency.skip(fp8_residency::dense_ffn_nvfp4_bytes(h, ffn_inter(config)));
+                }
                 use crate::weight_map::QuantizedWeight;
                 crate::layers::dense_ffn::DenseFfnWeights {
                     gate_proj: QuantizedWeight::null(),
@@ -353,11 +400,8 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     up_proj_t: None,
                     down_proj_t: None,
                 }
-            } else {
-                load_dense_ffn(
-                    store, &lp, gpu, variant, absmax_k, quantize_k, stream, config,
-                )?
             };
+            residency.twins.ffn_nvfp4 |= ffn_nvfp4;
             let mut dffn = DenseFfnLayer::new(ffn_weights, gpu)?;
             if ffn_q2 {
                 dffn.set_q2_weights(
@@ -368,8 +412,21 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 );
             }
             if ffn_fp8 {
-                let load_ffn_fp8 = |name: &str| {
-                    load_fp8_block_scaled_as_fp8weight(store, &format!("{lp}.mlp.{name}"), gpu)
+                // The FP8 `.weight` bytes are store-owned (zero-copy from the
+                // checkpoint); only the widened FP32 block-scale grid is a
+                // fresh allocation (`loaders_fp8.rs:109`). Adopt it — #736
+                // lists the loader sites that allocate without an owner.
+                let load_ffn_fp8 = |name: &str| -> Result<Fp8Weight> {
+                    let w = load_fp8_block_scaled_as_fp8weight(
+                        store,
+                        &format!("{lp}.mlp.{name}"),
+                        gpu,
+                    )?;
+                    let bytes = (w.n as usize).div_ceil(128) * (w.k as usize).div_ceil(128) * 4;
+                    store
+                        .derived()
+                        .adopt("ffn fp8 block scale (widened)", w.row_scale, bytes);
+                    Ok(w)
                 };
                 dffn.set_fp8_weights(
                     load_ffn_fp8("gate_proj")?,
@@ -494,6 +551,17 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                         }
                         continue;
                     }
+                    // #915: does the native FP8 attention overlay replace
+                    // these weights below? Hoisted out of the overlay block so
+                    // the NVFP4 build can be skipped rather than built and
+                    // immediately orphaned — `set_fp8_weights` OVERWRITES
+                    // `q/k/v/o_weight`, so on this route the NVFP4 q/k/v/o were
+                    // unreachable the moment they were installed.
+                    let attn_fp8 = dense_fp8_enabled()
+                        && config.tp_world_size.max(1) == 1
+                        && matches!(variant, Nvfp4Variant::Fp8Dequanted)
+                        && proj_is_native_fp8(store, &format!("{p}.q_proj"));
+                    let attn_nvfp4 = route_env.attn_nvfp4(attn_fp8);
                     let (attn, q_nvfp4, k_nvfp4, v_nvfp4) = match variant {
                         Nvfp4Variant::CompressedTensors => {
                             // NVFP4-from-disk path: column-parallel Q/K/V, row-parallel O.
@@ -557,6 +625,50 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                                 v_scale,
                             };
                             (attn, Some(q), Some(k), Some(v))
+                        }
+                        Nvfp4Variant::Standard | Nvfp4Variant::Fp8Dequanted if !attn_nvfp4 => {
+                            // #915: the FP8 overlay below replaces q/k/v/o, and
+                            // nothing reads the NVFP4 copies afterwards — the
+                            // transposed twins only under `ATLAS_CUTLASS_NVFP4_*`
+                            // and the base `o_proj` only under `ATLAS_ATTN_W4A4`,
+                            // both of which `RouteEnv::attn_nvfp4` accounts for.
+                            // Skipping the build also skips the BF16 dequant of
+                            // every FP8 projection that fed `quantize_to_nvfp4`.
+                            // Same NULL-o_proj shape the Bf16Raw arm below uses.
+                            let (k_scale, v_scale) = load_kv_scales(store, &p, gpu);
+                            let (nh, hd) = (config.num_attention_heads, config.head_dim);
+                            let (nkv, hh) = (config.num_key_value_heads, config.hidden_size);
+                            let q_n = nh * hd * if config.attn_gated { 2 } else { 1 };
+                            residency.skip(fp8_residency::attn_nvfp4_bytes(
+                                q_n,
+                                nkv * hd,
+                                nh * hd,
+                                hh,
+                            ));
+                            let null = || DenseWeight {
+                                weight: spark_runtime::gpu::DevicePtr::NULL,
+                            };
+                            let attn = AttentionWeights {
+                                q_proj: null(),
+                                k_proj: null(),
+                                v_proj: null(),
+                                o_proj: crate::weight_map::QuantizedWeight::null(),
+                                q_norm: dense(store, &format!("{p}.q_norm.weight"))?,
+                                k_norm: dense(store, &format!("{p}.k_norm.weight"))?,
+                                q_norm_full: None,
+                                k_norm_full: None,
+                                k_scale,
+                                v_scale,
+                            };
+                            // The NULL o_proj is only sound while the FP8
+                            // overlay is installed below — a null NVFP4 weight
+                            // reached by a w4a16 dispatch is the
+                            // CUDA-700-at-concurrency failure mode.
+                            debug_assert!(
+                                attn_fp8,
+                                "attn_nvfp4=false must imply a native FP8 overlay"
+                            );
+                            (attn, None, None, None)
                         }
                         Nvfp4Variant::Standard | Nvfp4Variant::Fp8Dequanted => {
                             // BF16 → NVFP4 path: shard BF16 then quantize per-rank.
@@ -778,21 +890,34 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     if let Some(o_dense) = o_dense_bf16 {
                         attn_layer.set_o_dense_bf16(o_dense);
                     }
-                    // Overlay native FP8 q/k/v/o on top of the NVFP4 weights when
-                    // enabled (single-GPU FP8 checkpoint). Hot decode/prefill paths
-                    // dispatch FP8 (w8a16); any path without an FP8 branch falls back
-                    // to the real NVFP4 weights above (never a null → no CUDA-700).
-                    if dense_fp8_enabled()
-                        && config.tp_world_size.max(1) == 1
-                        && matches!(variant, Nvfp4Variant::Fp8Dequanted)
-                        && proj_is_native_fp8(store, &format!("{p}.q_proj"))
-                    {
+                    // Install native FP8 q/k/v/o (single-GPU FP8 checkpoint).
+                    // `set_fp8_weights` REPLACES `q/k/v/o_weight`, so on this
+                    // route the NVFP4 weights above are not a fallback — they
+                    // are unreachable, which is why `attn_nvfp4` skipped
+                    // building them (#915). The paths that could still read
+                    // NVFP4 (`ATLAS_CUTLASS_NVFP4_*`, `ATLAS_ATTN_W4A4`) are
+                    // exactly what `RouteEnv::attn_nvfp4` checks.
+                    if attn_fp8 {
                         let load_fp8_proj = |name: &str,
                                              _n: usize,
                                              _k: usize,
                                              _kind: TpShardKind|
                          -> Result<Fp8Weight> {
-                            load_fp8_block_scaled_as_fp8weight(store, &format!("{p}.{name}"), gpu)
+                            // Only `row_scale` is allocated here; the E4M3
+                            // bytes are store-owned. Adopt it (#736).
+                            let w = load_fp8_block_scaled_as_fp8weight(
+                                store,
+                                &format!("{p}.{name}"),
+                                gpu,
+                            )?;
+                            let bytes =
+                                (w.n as usize).div_ceil(128) * (w.k as usize).div_ceil(128) * 4;
+                            store.derived().adopt(
+                                "attn fp8 block scale (widened)",
+                                w.row_scale,
+                                bytes,
+                            );
+                            Ok(w)
                         };
                         let [q_fp8, k_fp8, v_fp8, o_fp8] = load_qkvo_tp(config, load_fp8_proj)?;
                         attn_layer.set_fp8_weights(
@@ -801,7 +926,28 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                             Some(v_fp8),
                             Some(o_fp8),
                         );
-                        if let Err(e) = attn_layer.transpose_fp8_for_prefill(gpu, stream) {
+                        // #915: build only the twins a selected kernel reads,
+                        // and hand each to the store so teardown RELEASES it.
+                        // K/V are NOT optional — `prefill/cache_skip_qkv.rs` has
+                        // no W8A8 arm and is the first-chunk path of every
+                        // request. Table: `Fp8TwinSet` + `fp8_residency.rs`.
+                        let want =
+                            route_env.attn_fp8_twins(true, attn_layer.has_w8a8_prefill_kernels());
+                        let (nh, hd) = (config.num_attention_heads, config.head_dim);
+                        let (nkv, hh) = (config.num_key_value_heads, config.hidden_size);
+                        let q_n = nh * hd * if config.attn_gated { 2 } else { 1 };
+                        let twin_bytes = |set| {
+                            fp8_residency::attn_fp8_twin_bytes(set, q_n, nkv * hd, nh * hd, hh)
+                        };
+                        residency.twins.attn_fp8 |= want.any();
+                        residency.skip(twin_bytes(Fp8TwinSet::ALL) - twin_bytes(want));
+                        residency.keep(twin_bytes(want));
+                        if let Err(e) = attn_layer.transpose_fp8_for_prefill_selected(
+                            gpu,
+                            stream,
+                            want,
+                            Some(store.derived()),
+                        ) {
                             tracing::warn!("Layer {i}: dense FP8 transpose failed: {e}");
                         }
                     }
@@ -988,8 +1134,38 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                         let qkvz_f = concat_fp8_block_scaled(&qkv_f, &z_f, h, gpu)?;
                         // The concat copied both grids; free the per-projection
                         // scale allocs (weight bytes are store-owned, not freed).
+                        let scale_bytes =
+                            |n: usize, k: usize| n.div_ceil(128) * k.div_ceil(128) * 4;
                         gpu.free(qkv_f.row_scale)?;
                         gpu.free(z_f.row_scale)?;
+                        residency.free(
+                            scale_bytes(qkv_f.n as usize, h) + scale_bytes(z_f.n as usize, h),
+                        );
+                        // #736/#915: the fused `[QKV|Z]` weight is the SSM's
+                        // hottest tensor and there is no un-fused dispatch to
+                        // fall back to, so it STAYS — but it is a derived copy
+                        // that no `ModelResource` owned, which is the
+                        // 3,840 MB x48 row of the H100 teardown sweep. Adopt it.
+                        let qkvz_bytes = (qkvz_f.n as usize) * h;
+                        let qkvz_scale_bytes =
+                            scale_bytes(qkv_f.n as usize, h) + scale_bytes(z_f.n as usize, h);
+                        let ba_bytes = nv * 2 * h * 2; // [2*nv, h] BF16
+                        let out_scale_bytes = scale_bytes(out_f.n as usize, out_f.k as usize);
+                        let d = store.derived();
+                        d.adopt("ssm qkvz fp8 concat", qkvz_f.weight, qkvz_bytes);
+                        d.adopt(
+                            "ssm qkvz fp8 block scale",
+                            qkvz_f.row_scale,
+                            qkvz_scale_bytes,
+                        );
+                        d.adopt(
+                            "ssm out_proj fp8 block scale",
+                            out_f.row_scale,
+                            out_scale_bytes,
+                        );
+                        d.adopt("ssm in_proj_ba interleaved", ba_dense.weight, ba_bytes);
+                        residency.keep(qkvz_bytes + qkvz_scale_bytes + out_scale_bytes + ba_bytes);
+                        residency.twins.ssm_fp8_concat = true;
                         let ssm = SsmWeights {
                             in_proj_qkvz: DenseWeight {
                                 weight: spark_runtime::gpu::DevicePtr::NULL,
@@ -1464,6 +1640,20 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
             attn_idx,
             layers.len() - attn_idx,
         );
+        // #915: the line the next H100 serve is read against. `weights` is the
+        // checkpoint as the ledger sees it; `derived` is everything this loader
+        // built on top of it and now OWNS (released at teardown, not swept);
+        // `not built` is what the pre-#915 loader allocated here and this one
+        // proved unreachable. Emitted unconditionally — a residency regression
+        // that only shows under a debug flag is one nobody sees.
+        tracing::info!("{}", residency.summary(store.resident_bytes()));
+        for (label, bytes, count) in store.derived().by_label() {
+            tracing::debug!(
+                "  derived-weight owner: {:>9.1} MB x{:<5} {label}",
+                bytes as f64 / (1024.0 * 1024.0),
+                count,
+            );
+        }
 
         Ok(layers)
     }

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Which derived weight copies the native-FP8 dense route actually needs, and
+//! a tally of the ones it still builds.
+//!
+//! **WHY (#915 root cause; O9 of the 2026-09-05 rental; refs #916, #917, #736).**
+//! Measured on 1xH100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8` at `5f78270dc`,
+//! native-FP8 profile (`ATLAS_DENSE_FP8=1`, `--lm-head-dtype bf16`):
+//!
+//! * the checkpoint itself is **28.75 GB** — `WeightStore after prune: 1606
+//!   tensors, 28.747 GiB still resident`, one ledger site
+//!   (`fast_weights/mod.rs:434`, 29,436.7 MB x1606);
+//! * the ledger nevertheless reported **58.1 GB live before the KV cache was
+//!   sized**, and `ATLAS_MEM_PROFILE` recorded GPU-free falling **437 MB per
+//!   layer over all 64 layers (28.0 GB)** *after* the checkpoint was resident;
+//! * the teardown sweep reclaimed **28.01 GB across 1,980 allocations that no
+//!   `ModelResource` owned**.
+//!
+//! The six sites the ledger named, and what each holds per layer:
+//!
+//! | site | bytes x count | tensor |
+//! |---|---|---|
+//! | `weight_map/loaders_fp8.rs:229` | 8,960 MB x256 | `quantize_to_nvfp4` packed `[N,K/2]` |
+//! | `weight_map/quantized.rs:261` | 8,960 MB x256 | the transposed twin of the same |
+//! | `weight_loader/qwen35_dense.rs:135` | 3,840 MB x48 | SSM fused `[QKV\|Z]` FP8 concat |
+//! | `weight_map/quantized.rs:643` | 1,600 MB x64 | attention `Fp8WeightTransposed::weight_t` |
+//! | `weight_map/loaders_fp8.rs:230` | 1,120 MB x256 | the NVFP4 per-16 group scales |
+//! | `weight_map/quantized.rs:262` | 1,120 MB x256 | the transposed twin of those scales |
+//!
+//! The 256 counts are `64 layers x 3` dense-FFN projections (gate/up/down,
+//! 42.5 MiB packed each) plus `16 attention layers x 4` (q/k/v/o, 25/6.25/
+//! 6.25/12.5 MiB) — 8,160 + 800 MB, which is exactly the 8,960 reported.
+//!
+//! **None of the NVFP4 copies is reachable once the native FP8 overlay is
+//! installed.** `DenseFfnLayer::forward` (`dense_ffn.rs:1044`) and
+//! `forward_prefill_inner` (`dense_ffn.rs:1985`) both return from inside their
+//! `if let Some(ref fp8w) = self.fp8_weights` arm, `forward_k2`/`forward_k3`/
+//! `forward_km` redirect to `forward_prefill` via
+//! `native_small_batch_uses_prefill`, and the `w8_gemm!` macro binds
+//! `gate_t`/`up_t`/`down_t` to a literal `None`, so even the W8A16 fallback
+//! rungs read the original `[N,K]` E4M3 bytes. The NVFP4 gate/up/down and
+//! their transposed twins are pure load-time waste: 18.4 GiB of the 28.
+//!
+//! **The loader runs before dispatch exists**, so the route has to be derived
+//! from the same resolvers the forward pass uses rather than from a
+//! `ForwardContext`:
+//!
+//! * [`crate::layers::ops::GemmDispatch::from_env`] — the exact constructor
+//!   `model/impl_a1.rs:836` calls to build the context. It is a pure function
+//!   of the environment and a serve never rewrites its own environment, so the
+//!   loader's answer and the context's answer cannot disagree.
+//!
+//! `ATLAS_FFN_W8A16_ONLY` is deliberately NOT an input: it steers the dense FFN
+//! from the W8A8 arm onto rung 5 of the same `w8_gemm!` match, whose transposed
+//! operand is that literal `None` — so it selects between two kernels that both
+//! read the original FP8 bytes, and cannot resurrect an NVFP4 reader.
+//!
+//! That is the contract: **any new lever that can route a native-FP8 layer back
+//! onto an NVFP4 kernel must be added to [`DenseFp8Plan::resolve`] as well as
+//! to the dispatch site**, or the loader will have freed the weight that site
+//! wants. `ATLAS_DENSE_FP8_KEEP_NVFP4` is the escape hatch that restores the
+//! pre-#915 behaviour wholesale while such a gap is diagnosed.
+
+use crate::layers::ops::GemmDispatch;
+use crate::layers::qwen3_attention::Fp8TwinSet;
+
+/// The per-layer kill switch that restores the pre-#915 behaviour: build every
+/// NVFP4 fallback copy even where the dispatch cannot reach it.
+///
+/// PRESENCE (any value, including empty), matching `ATLAS_FFN_W8A16_ONLY` —
+/// this is an escape hatch an operator reaches for while a serve is
+/// misbehaving, and `ATLAS_DENSE_FP8_KEEP_NVFP4=0` meaning "on" is a trap.
+pub fn keep_nvfp4_fallback() -> bool {
+    static KEEP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *KEEP.get_or_init(|| std::env::var_os("ATLAS_DENSE_FP8_KEEP_NVFP4").is_some())
+}
+
+/// What a native-FP8 dense layer must materialise beyond the checkpoint bytes.
+///
+/// Every field is "build this derived copy": `false` means the selected
+/// kernels provably never read it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenseFp8Plan {
+    /// NVFP4 gate/up/down **and** their `w4a16_gemm_t_m128` transposed twins.
+    pub ffn_nvfp4: bool,
+    /// NVFP4 q/k/v/o, their transposed twins, and the fused `[q|k|v]` twin.
+    pub attn_nvfp4: bool,
+    /// Which `Fp8WeightTransposed` twins `transpose_fp8_for_prefill` builds.
+    pub attn_fp8_twins: Fp8TwinSet,
+}
+
+/// The inputs [`DenseFp8Plan::resolve`] decides from. Taken as a struct so the
+/// CPU decision-table test can pin every clause without touching the process
+/// environment (the `OnceLock` resolvers cannot be toggled per test).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenseFp8Inputs {
+    /// The native FP8 dense-FFN overlay will be installed on this layer
+    /// (`ATLAS_DENSE_FP8=1`, tp_size 1, `Fp8Dequanted`, gate_proj native FP8).
+    pub ffn_fp8: bool,
+    /// The native FP8 attention overlay will be installed on this layer.
+    pub attn_fp8: bool,
+    /// `ATLAS_DENSE_FP8_KEEP_NVFP4` — restore the pre-#915 behaviour.
+    pub keep_nvfp4: bool,
+    /// Resolved exactly as `model/impl_a1.rs:836` resolves it.
+    pub dispatch: GemmDispatch,
+    /// Whether the target's `per_token_group_quant_fp8` + `fp8_gemm_t_blockscaled`
+    /// kernels are both loaded. Both are required by the W8A8 prefill arm in
+    /// `qwen3_attention/prefill/paged_qkv.rs:220` and
+    /// `prefill/paged_oproj.rs:94`; without them those two chains fall through
+    /// to the transposed W8A16 kernels, which read the FP8 twins.
+    pub w8a8_kernels: bool,
+    /// `ATLAS_ATTN_W4A4` is set. `prefill/paged_oproj.rs:38-42` builds its W4A4
+    /// arm with NO weight-type predicate and then feeds it
+    /// `&self.attn.o_proj` — the NVFP4 o_proj — so this one lever keeps the
+    /// NVFP4 attention weights alive even under a full FP8 overlay. (The QKV
+    /// side at `paged_qkv.rs:51` does check `as_nvfp4()`, so it is already
+    /// closed; the o_proj asymmetry is not.)
+    pub attn_w4a4: bool,
+    /// `ATLAS_ATTN_PREFILL_Q_T=1`. `prefill/cache_skip_qkv.rs:142` reads it per
+    /// projection per prefill and, when set, dispatches Q through `q_fp8w_t`.
+    pub attn_prefill_q_t: bool,
+}
+
+impl DenseFp8Plan {
+    /// The decision table. Pure — no environment reads, no allocation.
+    ///
+    /// * **FFN NVFP4** — unreachable the moment `set_fp8_weights` runs (see the
+    ///   module docs: every entry point returns from inside the FP8 arm and the
+    ///   `w8_gemm!` transposed operands are a literal `None`). Built only under
+    ///   the escape hatch.
+    /// * **Attention NVFP4** — `set_fp8_weights` *overwrites*
+    ///   `q_weight`/`k_weight`/`v_weight`/`o_weight` with `QuantWeight::Fp8`,
+    ///   so the base NVFP4 weights are orphaned at load. The transposed and
+    ///   fused twins survive only behind the `ATLAS_CUTLASS_NVFP4_*` levers,
+    ///   which default off.
+    /// * **Attention FP8 twins, K and V** — KEPT UNCONDITIONALLY. The
+    ///   first prefill chunk (`seq_len_start == 0`, the default for every
+    ///   request) does not go through `paged_qkv.rs` at all: it goes through
+    ///   `prefill/cache_skip_qkv.rs`, whose dispatch chain has **no W8A8 arm**,
+    ///   so `k_fp8w_t`/`v_fp8w_t` are dereferenced at `cache_skip_qkv.rs:218`
+    ///   / `:235` on every request regardless of `fp8_blockscaled_prefill`.
+    ///   Freeing them is a NULL-pointer kernel launch on the first token.
+    /// * **Attention FP8 twins, Q and O** — Q on that same chain is behind
+    ///   `ATLAS_ATTN_PREFILL_Q_T=1` (`cache_skip_qkv.rs:142`) and O is routed
+    ///   to `paged_oproj.rs` from both chains, so both are reachable only after
+    ///   the W8A8 arm declines — block-scaled prefill off, or a target missing
+    ///   one of the two kernels.
+    pub fn resolve(i: DenseFp8Inputs) -> Self {
+        if i.keep_nvfp4 {
+            return Self {
+                ffn_nvfp4: true,
+                attn_nvfp4: true,
+                attn_fp8_twins: if i.attn_fp8 {
+                    Fp8TwinSet::ALL
+                } else {
+                    Fp8TwinSet::NONE
+                },
+            };
+        }
+        let cutlass_nvfp4_attn = i.dispatch.cutlass_nvfp4_gemm
+            || i.dispatch.cutlass_nvfp4_attn_q
+            || i.dispatch.cutlass_nvfp4_attn_kv
+            || i.dispatch.cutlass_nvfp4_attn_o;
+        // `transpose_fp8_for_prefill` already refuses to build anything under
+        // the umbrella NVFP4 flag (`prefill_weights.rs:357`); mirror that here
+        // so the plan and the builder cannot drift.
+        let w8a8_covers_prefill = i.dispatch.fp8_blockscaled_prefill && i.w8a8_kernels;
+        let fp8_twins = if !i.attn_fp8 || i.dispatch.cutlass_nvfp4_gemm {
+            Fp8TwinSet::NONE
+        } else {
+            Fp8TwinSet {
+                q: i.attn_prefill_q_t || !w8a8_covers_prefill,
+                k: true,
+                v: true,
+                o: !w8a8_covers_prefill,
+            }
+        };
+        Self {
+            ffn_nvfp4: !i.ffn_fp8,
+            attn_nvfp4: !i.attn_fp8 || cutlass_nvfp4_attn || i.attn_w4a4,
+            attn_fp8_twins: fp8_twins,
+        }
+    }
+}
+
+/// The environment-resolved half of [`DenseFp8Inputs`], read ONCE per load.
+///
+/// Hoisted out of the per-layer decision because `GemmDispatch::from_env`
+/// walks the environment block for a dozen variables and a 64-layer model
+/// would otherwise do it 64 times — and because resolving once is what makes
+/// "every layer of this model took the same route" a property of the type
+/// rather than of the environment holding still.
+#[derive(Clone, Copy, Debug)]
+pub struct RouteEnv {
+    pub keep_nvfp4: bool,
+    pub dispatch: GemmDispatch,
+    /// Mirrors `prefill/paged_oproj.rs:42` and `prefill/paged_qkv.rs:53`,
+    /// which read this per projection per prefill and are NOT memoised.
+    pub attn_w4a4: bool,
+    /// Mirrors `prefill/cache_skip_qkv.rs:142`, same caveat.
+    pub attn_prefill_q_t: bool,
+}
+
+impl RouteEnv {
+    pub fn from_env() -> Self {
+        Self {
+            keep_nvfp4: keep_nvfp4_fallback(),
+            dispatch: GemmDispatch::from_env(),
+            // Same predicates as the dispatch sites, character for character:
+            // `is_ok()` (presence) for W4A4, `== "1"` for the Q-transpose.
+            attn_w4a4: std::env::var("ATLAS_ATTN_W4A4").is_ok(),
+            attn_prefill_q_t: std::env::var("ATLAS_ATTN_PREFILL_Q_T").ok().as_deref() == Some("1"),
+        }
+    }
+
+    /// This layer's plan. `w8a8_kernels` is a property of the *layer* (its
+    /// resolved kernel handles), which is why it is not part of `RouteEnv`.
+    pub fn plan(&self, ffn_fp8: bool, attn_fp8: bool, w8a8_kernels: bool) -> DenseFp8Plan {
+        DenseFp8Plan::resolve(DenseFp8Inputs {
+            ffn_fp8,
+            attn_fp8,
+            keep_nvfp4: self.keep_nvfp4,
+            dispatch: self.dispatch,
+            w8a8_kernels,
+            attn_w4a4: self.attn_w4a4,
+            attn_prefill_q_t: self.attn_prefill_q_t,
+        })
+    }
+
+    /// The NVFP4 half of the plan. Asked BEFORE the layer exists, so it may
+    /// not depend on any layer-local kernel handle — pinned by
+    /// `attn_nvfp4_does_not_depend_on_the_w8a8_kernels`.
+    pub fn attn_nvfp4(&self, attn_fp8: bool) -> bool {
+        self.plan(false, attn_fp8, true).attn_nvfp4
+    }
+
+    /// Which FP8 prefill twins this layer needs. `w8a8_kernels` is read off
+    /// the constructed layer (`Qwen3AttentionLayer::has_w8a8_prefill_kernels`).
+    pub fn attn_fp8_twins(&self, attn_fp8: bool, w8a8_kernels: bool) -> Fp8TwinSet {
+        self.plan(false, attn_fp8, w8a8_kernels).attn_fp8_twins
+    }
+}
+
+/// Bytes one NVFP4 `QuantizedWeight` costs: packed `[N, K/2]` E2M1 nibbles
+/// plus the `[N, K/16]` per-group scale byte. Mirrors `quantize_to_nvfp4`
+/// (`weight_map/loaders_fp8.rs:229`-`230`) and `transpose_for_gemm_gs`
+/// (`weight_map/quantized.rs:261`-`262`), which allocate the same two sizes.
+pub fn nvfp4_bytes(n: usize, k: usize) -> usize {
+    n * k / 2 + n * k / 16
+}
+
+/// What the pre-#915 loader spent per dense-FFN layer on NVFP4: gate, up and
+/// down, each with a transposed twin of identical size.
+pub fn dense_ffn_nvfp4_bytes(hidden: usize, inter: usize) -> usize {
+    // gate/up are [inter, hidden] and down is [hidden, inter] — the same
+    // element count, so all three cost the same.
+    3 * 2 * nvfp4_bytes(inter, hidden)
+}
+
+/// What the pre-#915 loader spent per full-attention layer on NVFP4: q/k/v/o,
+/// each with a transposed twin, plus the fused `[q|k|v]` transposed twin
+/// (`transpose_concat_for_gemm`).
+///
+/// `q_n` is `num_attention_heads * head_dim`, doubled when `attn_gated`;
+/// `kv_n` is `num_key_value_heads * head_dim`; `o_k` is the o_proj contraction
+/// width `num_attention_heads * head_dim`.
+pub fn attn_nvfp4_bytes(q_n: usize, kv_n: usize, o_k: usize, hidden: usize) -> usize {
+    let qkv = nvfp4_bytes(q_n, hidden) + 2 * nvfp4_bytes(kv_n, hidden);
+    let o = nvfp4_bytes(hidden, o_k);
+    // base + per-projection twin + the fused q|k|v twin
+    2 * (qkv + o) + nvfp4_bytes(q_n + 2 * kv_n, hidden)
+}
+
+/// Bytes one FP8 `[K, N]` transposed twin costs: the E4M3 bytes plus the
+/// transposed `[K/128, N/128]` FP32 block-scale grid. Mirrors
+/// `Fp8Weight::transpose_for_gemm` (`weight_map/quantized.rs:643`/`:660`).
+pub fn fp8_twin_bytes(n: usize, k: usize) -> usize {
+    n * k + n.div_ceil(128) * k.div_ceil(128) * 4
+}
+
+/// The FP8 prefill twins `want` selects, for one full-attention layer.
+pub fn attn_fp8_twin_bytes(
+    want: Fp8TwinSet,
+    q_n: usize,
+    kv_n: usize,
+    o_k: usize,
+    hidden: usize,
+) -> usize {
+    let mut b = 0;
+    if want.q {
+        b += fp8_twin_bytes(q_n, hidden);
+    }
+    if want.k {
+        b += fp8_twin_bytes(kv_n, hidden);
+    }
+    if want.v {
+        b += fp8_twin_bytes(kv_n, hidden);
+    }
+    if want.o {
+        b += fp8_twin_bytes(hidden, o_k);
+    }
+    b
+}
+
+/// Running tally of the derived (non-checkpoint) device bytes this loader
+/// allocated, and of the ones it decided not to build.
+///
+/// Counted in the loader rather than read back from the ledger because the
+/// ledger cannot tell a derived copy from a checkpoint tensor — both are plain
+/// `gpu.alloc` — and because the "not built" number is the one the fix is
+/// judged on and has no allocation to read.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DerivedResidency {
+    /// Derived bytes still resident at the end of load.
+    pub kept: u64,
+    /// Derived bytes the plan declined to build, versus the pre-#915 loader.
+    pub skipped: u64,
+    /// Transient derived bytes allocated and freed during load.
+    pub freed: u64,
+    /// Which twin families were built, for the one-line summary.
+    pub twins: TwinsBuilt,
+}
+
+/// Which derived twin families the plan built. Reported by name so the serve
+/// log says *which* copies are resident rather than only how many bytes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TwinsBuilt {
+    pub ffn_nvfp4: bool,
+    pub attn_nvfp4: bool,
+    pub attn_fp8: bool,
+    pub ssm_fp8_concat: bool,
+}
+
+impl TwinsBuilt {
+    /// `none`, or a comma-separated list, for the summary line.
+    pub fn describe(self) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        if self.ffn_nvfp4 {
+            parts.push("ffn-nvfp4+t");
+        }
+        if self.attn_nvfp4 {
+            parts.push("attn-nvfp4+t");
+        }
+        if self.attn_fp8 {
+            parts.push("attn-fp8-t");
+        }
+        if self.ssm_fp8_concat {
+            parts.push("ssm-qkvz-fp8");
+        }
+        if parts.is_empty() {
+            "none".to_owned()
+        } else {
+            parts.join(", ")
+        }
+    }
+}
+
+impl DerivedResidency {
+    pub fn keep(&mut self, bytes: usize) {
+        self.kept += bytes as u64;
+    }
+
+    pub fn skip(&mut self, bytes: usize) {
+        self.skipped += bytes as u64;
+    }
+
+    pub fn free(&mut self, bytes: usize) {
+        self.freed += bytes as u64;
+    }
+
+    /// The line the next H100 run is read against.
+    ///
+    /// Emitted at the end of `load_layers` so a serve log proves the residency
+    /// without an `ATLAS_MEM_PROFILE` rerun: `weights` is the checkpoint,
+    /// `derived` is everything this loader built on top of it, and `skipped`
+    /// is what the pre-#915 loader would have built and this one did not.
+    pub fn summary(&self, weight_bytes: usize) -> String {
+        let gb = |b: u64| b as f64 / 1e9;
+        format!(
+            "native FP8 dense residency: weights {:.2} GB, derived {:.2} GB \
+             (twins: {}), freed {:.2} GB, not built {:.2} GB",
+            weight_bytes as f64 / 1e9,
+            gb(self.kept),
+            self.twins.describe(),
+            gb(self.freed),
+            gb(self.skipped),
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "fp8_residency_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The native-FP8 dense loader's decision table (#915).
+//!
+//! Every case is a route the H100 serve can actually be put into, expressed
+//! through the SAME `GemmDispatch` the forward pass carries — not through the
+//! process environment, which a `OnceLock` resolver would pin for the whole
+//! test binary.
+
+use super::*;
+use crate::layers::ops::GemmDispatch;
+
+/// The shape a native-FP8 dense serve boots in with no `ATLAS_*` set: FP8
+/// overlays on both the FFN and attention, block-scaled prefill on, the W8A8
+/// kernels present.
+fn h100_default() -> DenseFp8Inputs {
+    DenseFp8Inputs {
+        ffn_fp8: true,
+        attn_fp8: true,
+        keep_nvfp4: false,
+        dispatch: GemmDispatch::defaults(),
+        w8a8_kernels: true,
+        attn_w4a4: false,
+        attn_prefill_q_t: false,
+    }
+}
+
+/// K and V, and nothing else: the measured default route.
+const KV_ONLY: Fp8TwinSet = Fp8TwinSet {
+    q: false,
+    k: true,
+    v: true,
+    o: false,
+};
+
+#[test]
+fn default_native_fp8_route_builds_no_nvfp4_and_only_the_kv_fp8_twins() {
+    let p = DenseFp8Plan::resolve(h100_default());
+    assert_eq!(
+        p,
+        DenseFp8Plan {
+            ffn_nvfp4: false,
+            attn_nvfp4: false,
+            attn_fp8_twins: KV_ONLY,
+        },
+        "the dense FFN and the attention NVFP4 fallbacks are unreachable; K/V \
+         FP8 twins are NOT (cache_skip_qkv.rs has no W8A8 arm)"
+    );
+}
+
+#[test]
+fn the_kv_fp8_twins_survive_every_default_route_variation() {
+    // `cache_skip_qkv.rs:218`/`:235` dereference them on the FIRST prefill
+    // chunk of every request, with no W8A8 arm ahead of them. No lever below
+    // may take them away — this is the NULL-pointer-launch regression guard.
+    for dispatch in [
+        GemmDispatch::defaults(),
+        GemmDispatch {
+            fp8_blockscaled_prefill: false,
+            ..GemmDispatch::defaults()
+        },
+    ] {
+        for w8a8_kernels in [true, false] {
+            for attn_prefill_q_t in [true, false] {
+                let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+                    dispatch,
+                    w8a8_kernels,
+                    attn_prefill_q_t,
+                    ..h100_default()
+                });
+                assert!(p.attn_fp8_twins.k && p.attn_fp8_twins.v, "{p:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn a_non_fp8_layer_keeps_every_nvfp4_copy_and_gets_no_fp8_twins() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        ffn_fp8: false,
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert!(p.ffn_nvfp4, "no FP8 overlay -> NVFP4 is the only weight");
+    assert!(p.attn_nvfp4);
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet::NONE,
+        "there are no FP8 weights to transpose on a non-FP8 layer"
+    );
+}
+
+#[test]
+fn the_ffn_and_attention_overlays_are_decided_independently() {
+    // `proj_is_native_fp8` is checked per projection family, so a checkpoint
+    // can ship a native-FP8 FFN beside BF16-dequant attention.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert!(!p.ffn_nvfp4);
+    assert!(p.attn_nvfp4);
+
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        ffn_fp8: false,
+        ..h100_default()
+    });
+    assert!(p.ffn_nvfp4);
+    assert!(!p.attn_nvfp4);
+}
+
+#[test]
+fn single_scale_prefill_brings_the_q_and_o_fp8_twins_back() {
+    // ATLAS_FP8_SINGLE_SCALE clears `fp8_blockscaled_prefill`, which makes the
+    // W8A8 arms in `paged_qkv.rs:220` / `paged_oproj.rs:94` decline — prefill
+    // then lands on `w8a16_gemm_n128_m128`, which reads `weight_t`/`scale_t`.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            fp8_blockscaled_prefill: false,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::ALL);
+    assert!(
+        !p.ffn_nvfp4,
+        "the dense FFN still never reads NVFP4: `w8_gemm!` binds its \
+         transposed operand to a literal None on every rung"
+    );
+}
+
+#[test]
+fn a_target_without_the_w8a8_kernels_keeps_every_fp8_twin() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        w8a8_kernels: false,
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::ALL);
+}
+
+#[test]
+fn the_q_transpose_lever_keeps_only_the_q_twin() {
+    // `cache_skip_qkv.rs:142` reads ATLAS_ATTN_PREFILL_Q_T per prefill and is
+    // NOT memoised, so the loader has to mirror it or free a twin a later
+    // getenv re-enables.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_prefill_q_t: true,
+        ..h100_default()
+    });
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet {
+            q: true,
+            k: true,
+            v: true,
+            o: false,
+        }
+    );
+}
+
+#[test]
+fn every_cutlass_nvfp4_attention_lever_keeps_the_nvfp4_attention_copies() {
+    for set in [
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_gemm = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_q = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_kv = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_o = true,
+    ] {
+        let mut dispatch = GemmDispatch::defaults();
+        set(&mut dispatch);
+        let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+            dispatch,
+            ..h100_default()
+        });
+        assert!(
+            p.attn_nvfp4,
+            "a CUTLASS NVFP4 attention lever reads the transposed NVFP4 twin: {dispatch:?}"
+        );
+    }
+}
+
+#[test]
+fn the_umbrella_nvfp4_flag_builds_no_fp8_twins() {
+    // `transpose_fp8_for_prefill` itself early-returns under this flag
+    // (`prefill_weights.rs:357`); the plan must agree or the two drift.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            cutlass_nvfp4_gemm: true,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::NONE);
+    assert!(p.attn_nvfp4);
+}
+
+#[test]
+fn attn_w4a4_keeps_the_nvfp4_o_proj() {
+    // `prefill/paged_oproj.rs:38-42` builds its W4A4 arm with NO weight-type
+    // predicate and feeds it `&self.attn.o_proj`, so a NULL o_proj under this
+    // lever is a NULL-pointer kernel launch. (The QKV side at
+    // `paged_qkv.rs:51` does check `as_nvfp4()` and is already closed.)
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_w4a4: true,
+        ..h100_default()
+    });
+    assert!(p.attn_nvfp4);
+}
+
+#[test]
+fn an_ssm_only_lever_does_not_resurrect_the_attention_copies() {
+    // `cutlass_nvfp4_ssm_out` is deliberately not implied by the umbrella flag
+    // and does not touch attention — see `ops/dispatch_config.rs`.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            cutlass_nvfp4_ssm_out: true,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert!(!p.attn_nvfp4);
+}
+
+#[test]
+fn attn_nvfp4_does_not_depend_on_the_w8a8_kernels() {
+    // `RouteEnv::attn_nvfp4` is asked BEFORE the layer exists, so it passes a
+    // placeholder for the layer-local handle. That is only sound while this
+    // holds.
+    for w8a8_kernels in [true, false] {
+        for attn_fp8 in [true, false] {
+            let a = DenseFp8Plan::resolve(DenseFp8Inputs {
+                attn_fp8,
+                w8a8_kernels,
+                ..h100_default()
+            });
+            let b = DenseFp8Plan::resolve(DenseFp8Inputs {
+                attn_fp8,
+                w8a8_kernels: !w8a8_kernels,
+                ..h100_default()
+            });
+            assert_eq!(a.attn_nvfp4, b.attn_nvfp4);
+        }
+    }
+}
+
+#[test]
+fn the_escape_hatch_restores_the_pre_915_loader() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        keep_nvfp4: true,
+        ..h100_default()
+    });
+    assert_eq!(
+        p,
+        DenseFp8Plan {
+            ffn_nvfp4: true,
+            attn_nvfp4: true,
+            attn_fp8_twins: Fp8TwinSet::ALL,
+        },
+        "ATLAS_DENSE_FP8_KEEP_NVFP4 must reproduce the old footprint exactly, \
+         or it is useless for bisecting a suspected gap in this table"
+    );
+}
+
+#[test]
+fn the_escape_hatch_cannot_invent_fp8_twins_on_a_non_fp8_layer() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        keep_nvfp4: true,
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet::NONE,
+        "there is no FP8 weight to transpose"
+    );
+}
+
+/// The Qwen3.8-27B-FP8 numbers from the H100 ledger, reproduced from the
+/// shapes. If these drift, the attribution in the module docs is wrong.
+#[test]
+fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
+    const H: usize = 5120;
+    const INTER: usize = 17408;
+    const MIB: usize = 1024 * 1024;
+
+    // `loaders_fp8.rs:229` + `quantized.rs:261` (packed) and `:230` + `:262`
+    // (scales), 8,960 MB + 1,120 MB each across 256 allocations: 64 layers x 3
+    // FFN projections plus 16 attention layers x 4.
+    let ffn = dense_ffn_nvfp4_bytes(H, INTER);
+    assert_eq!(
+        ffn / MIB,
+        3 * 2 * (42 * 2 + 5) + 3,
+        "≈127.5 MiB x2 per layer"
+    );
+    assert_eq!(64 * ffn / MIB, 2 * (8160 + 1020));
+
+    // 16 attention layers: q_n = 10240 (gated), kv_n = 2560, o_k = 5120.
+    let attn = attn_nvfp4_bytes(10240, 2560, 5120, H);
+    // Base + twin for q/k/v/o is 800 MB + 100 MB over the 16 layers; the fused
+    // q|k|v twin is the remainder and is NOT part of the ledger's 8,960 row.
+    let paired = 2 * (nvfp4_bytes(10240, H) + 2 * nvfp4_bytes(2560, H) + nvfp4_bytes(H, 5120));
+    assert_eq!(16 * paired / MIB, 2 * (800 + 100));
+    assert!(attn > paired, "the fused twin is extra");
+
+    // `quantized.rs:643`, 1,600 MB x64 = the four FP8 prefill twins x16 layers.
+    let twins = attn_fp8_twin_bytes(Fp8TwinSet::ALL, 10240, 2560, 5120, H);
+    assert_eq!(16 * (twins / MIB), 1600, "100 MiB of FP8 twins per layer");
+
+    // What the default route now declines: the whole FFN NVFP4 family, the
+    // whole attention NVFP4 family, and the Q+O FP8 twins.
+    let declined =
+        64 * ffn + 16 * attn + 16 * (twins - attn_fp8_twin_bytes(KV_ONLY, 10240, 2560, 5120, H));
+    assert!(
+        (20.0..23.0).contains(&(declined as f64 / 1e9)),
+        "expected ~21 GB not built, got {} GB",
+        declined as f64 / 1e9
+    );
+}
+
+#[test]
+fn the_summary_line_names_the_twins_it_built() {
+    let mut r = DerivedResidency::default();
+    r.keep(3_840 * 1024 * 1024);
+    r.skip(20_000 * 1024 * 1024);
+    r.free(1_024 * 1024 * 1024);
+    r.twins.ssm_fp8_concat = true;
+    let line = r.summary(28_747 * 1024 * 1024);
+    assert!(
+        line.starts_with("native FP8 dense residency: weights "),
+        "{line}"
+    );
+    assert!(line.contains("(twins: ssm-qkvz-fp8)"), "{line}");
+    assert!(line.contains("not built "), "{line}");
+}
+
+#[test]
+fn no_twins_reads_as_none_not_as_an_empty_list() {
+    assert_eq!(TwinsBuilt::default().describe(), "none");
+    assert_eq!(
+        TwinsBuilt {
+            ffn_nvfp4: true,
+            attn_fp8: true,
+            ..TwinsBuilt::default()
+        }
+        .describe(),
+        "ffn-nvfp4+t, attn-fp8-t"
+    );
+}

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -287,12 +287,12 @@ fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
     // (scales), 8,960 MB + 1,120 MB each across 256 allocations: 64 layers x 3
     // FFN projections plus 16 attention layers x 4.
     let ffn = dense_ffn_nvfp4_bytes(H, INTER);
+    assert_eq!(ffn / MIB, 286, "127.5 MiB of NVFP4 per layer, twice over");
     assert_eq!(
-        ffn / MIB,
-        3 * 2 * (42 * 2 + 5) + 3,
-        "≈127.5 MiB x2 per layer"
+        64 * ffn / MIB,
+        2 * (8160 + 1020),
+        "8,160 MB of the 8,960 packed row and 1,020 of the 1,120 scale row"
     );
-    assert_eq!(64 * ffn / MIB, 2 * (8160 + 1020));
 
     // 16 attention layers: q_n = 10240 (gated), kv_n = 2560, o_k = 5120.
     let attn = attn_nvfp4_bytes(10240, 2560, 5120, H);

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -311,8 +311,8 @@ fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
     let declined =
         64 * ffn + 16 * attn + 16 * (twins - attn_fp8_twin_bytes(KV_ONLY, 10240, 2560, 5120, H));
     assert!(
-        (20.0..23.0).contains(&(declined as f64 / 1e9)),
-        "expected ~21 GB not built, got {} GB",
+        (22.5..23.5).contains(&(declined as f64 / 1e9)),
+        "expected ~23.1 GB of the sweep's 28.01 GB not to be built, got {} GB",
         declined as f64 / 1e9
     );
 }

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -165,6 +165,10 @@ impl WeightTensor {
 /// All model weights loaded onto the GPU, keyed by HuggingFace name.
 pub struct WeightStore {
     weights: HashMap<String, WeightTensor>,
+    /// Buffers a loader derived from these tensors — fused concats, transposed
+    /// twins, requants. Owned here so teardown RELEASES them instead of the
+    /// backend sweep reclaiming them unowned (#736, #915); see `derived.rs`.
+    derived: DerivedStore,
     /// Tensors deliberately NOT uploaded, with where they live on disk.
     ///
     /// The n-gram embedding tables of the LongCat / Qwen3.8-Flash-Next family
@@ -196,6 +200,7 @@ impl WeightStore {
         Self {
             weights: HashMap::new(),
             deferred: HashMap::new(),
+            derived: DerivedStore::default(),
         }
     }
 
@@ -226,6 +231,7 @@ impl WeightStore {
         Self {
             weights,
             deferred: HashMap::new(),
+            derived: DerivedStore::default(),
         }
     }
 
@@ -297,6 +303,15 @@ impl WeightStore {
             count += 1;
         }
         Ok((count, bytes))
+    }
+
+    /// The owner for buffers a loader derives from these tensors.
+    ///
+    /// `&self` because `ModelWeightLoader::load_layers` takes `&WeightStore`;
+    /// the interior `Mutex` is the whole reason `DerivedStore` exists as a
+    /// type rather than a `Vec` field. See `weights/derived.rs`.
+    pub fn derived(&self) -> &DerivedStore {
+        &self.derived
     }
 
     /// Total bytes across all weight tensors on the GPU.
@@ -447,6 +462,8 @@ impl SafetensorsLoader {
 /// `embedders.2` must precede `embedders.10`; a plain lexicographic sort puts
 /// `10` first and silently mis-maps every table after the ninth.
 pub mod adapter;
+mod derived;
+pub use derived::DerivedStore;
 mod gguf;
 mod loader;
 pub mod mlx_int8;
@@ -483,7 +500,11 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for WeightStore {
     }
 
     fn release(&mut self, gpu: &dyn GpuBackend) -> anyhow::Result<()> {
-        let mut first_error = None;
+        // Derived buffers FIRST: they are re-encodings of the tensors below and
+        // nothing reads one after the other is gone, but freeing the source a
+        // derivation was built from while the derivation is still listed would
+        // make a later failure here impossible to attribute.
+        let mut first_error = self.derived.release(gpu).err();
         // `drain` rather than iterate: the map must not be left holding
         // pointers to memory that is gone, and it makes this idempotent.
         for (name, tensor) in self.weights.drain() {

--- a/crates/spark-runtime/src/weights/derived.rs
+++ b/crates/spark-runtime/src/weights/derived.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Load-time derived weight buffers, and who frees them.
+//!
+//! **WHY (#736, #915).** A loader that re-encodes a checkpoint tensor — a
+//! transposed twin, a row-concatenation of two projections, an NVFP4 requant —
+//! allocates a buffer that lives in a *layer struct*. Layer structs have no
+//! `Drop` that reaches the GPU and no `ModelResource`, so nothing frees them:
+//! `TransformerModel::release_pools` walks buffers, KV cache, SSM pools,
+//! `DerivedWeights` and the store, and every one of these falls through to
+//! `AtlasCudaBackend::sweep_unreleased`. On 1xH100, 2026-09-11,
+//! `Qwen/Qwen3.8-27B-FP8`, that sweep reclaimed **28.01 GB across 1,980
+//! allocations** and warned that each was "memory whose owner is unaccounted
+//! for". The sweep is a backstop, not an owner: it cannot run before the
+//! backend is torn down, so those bytes are unreclaimable for the life of the
+//! model even when the layer that holds them has been replaced.
+//!
+//! This is the owner. The [`WeightStore`](super::WeightStore) is the right home
+//! for it because these buffers are *derived from* store tensors, have exactly
+//! the store's lifetime (the layers read both until teardown), and the store is
+//! already the last `ModelResource` released before the sweep — so adopting a
+//! derived buffer here moves it from "swept" to "released", which is the
+//! difference the ledger reports.
+//!
+//! Interior mutability because loaders take `&WeightStore`: threading a `&mut`
+//! through `ModelWeightLoader::load_layers` would change the signature of every
+//! architecture's loader to fix a bookkeeping gap in one of them.
+
+use parking_lot::Mutex;
+
+use crate::gpu::{DevicePtr, GpuBackend};
+
+/// One adopted buffer: the pointer to free, its size, and a label for the
+/// residency report.
+#[derive(Clone, Copy, Debug)]
+struct Derived {
+    label: &'static str,
+    ptr: DevicePtr,
+    bytes: usize,
+}
+
+/// Device buffers a loader derived from this store's tensors.
+#[derive(Default)]
+pub struct DerivedStore {
+    // parking_lot: no poisoning, so a panic elsewhere cannot block teardown.
+    owned: Mutex<Vec<Derived>>,
+}
+
+impl DerivedStore {
+    /// Take ownership of a derived buffer.
+    ///
+    /// `label` is a static category ("ssm qkvz fp8 concat", "attn fp8 twin"),
+    /// not a per-tensor name: the report aggregates, and a `String` per buffer
+    /// would allocate once per layer per twin for text nobody reads per entry.
+    pub fn adopt(&self, label: &'static str, ptr: DevicePtr, bytes: usize) {
+        if ptr.0 == 0 {
+            return;
+        }
+        self.owned.lock().push(Derived { label, ptr, bytes });
+    }
+
+    /// Give up ownership of a buffer the caller is about to free itself.
+    ///
+    /// The transient half of a fused concat is adopted by the generic loader
+    /// that produced it and then freed by the loader that consumed it
+    /// (`qwen35_dense.rs`, the GDN `[QKV|Z]` arm). Without this the pointer
+    /// would be freed twice — once there, once at teardown. Returns the bytes
+    /// that left the ledger, or `None` if this store never held it.
+    pub fn disown(&self, ptr: DevicePtr) -> Option<usize> {
+        let mut owned = self.owned.lock();
+        let i = owned.iter().position(|d| d.ptr == ptr)?;
+        Some(owned.swap_remove(i).bytes)
+    }
+
+    /// Total adopted bytes still live.
+    pub fn bytes(&self) -> usize {
+        self.owned.lock().iter().map(|d| d.bytes).sum()
+    }
+
+    pub fn len(&self) -> usize {
+        self.owned.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// `label -> (bytes, count)`, biggest first, for the residency summary.
+    pub fn by_label(&self) -> Vec<(&'static str, usize, usize)> {
+        let mut rows: Vec<(&'static str, usize, usize)> = Vec::new();
+        for d in self.owned.lock().iter() {
+            match rows.iter_mut().find(|r| r.0 == d.label) {
+                Some(r) => {
+                    r.1 += d.bytes;
+                    r.2 += 1;
+                }
+                None => rows.push((d.label, d.bytes, 1)),
+            }
+        }
+        rows.sort_by(|a, b| b.1.cmp(&a.1));
+        rows
+    }
+
+    /// Free everything adopted. Drains first, so a failure part-way through
+    /// cannot leave a freed pointer in the list to be freed again.
+    pub fn release(&self, gpu: &dyn GpuBackend) -> anyhow::Result<()> {
+        let doomed: Vec<Derived> = self.owned.lock().drain(..).collect();
+        let mut first_error = None;
+        for d in doomed {
+            if let Err(e) = gpu.free(d.ptr)
+                && first_error.is_none()
+            {
+                first_error = Some(e.context(format!("freeing derived weight ({})", d.label)));
+            }
+        }
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu::mock::MockGpuBackend;
+
+    #[test]
+    fn an_adopted_buffer_is_freed_by_release() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        let a = gpu.alloc(1024).unwrap();
+        let b = gpu.alloc(2048).unwrap();
+        d.adopt("twin", a, 1024);
+        d.adopt("twin", b, 2048);
+        assert_eq!(d.len(), 2);
+        assert_eq!(d.bytes(), 3072);
+        d.release(&gpu).unwrap();
+        assert!(d.is_empty(), "release must drain, not merely free");
+        assert_eq!(d.bytes(), 0);
+    }
+
+    #[test]
+    fn release_is_idempotent() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        d.adopt("twin", gpu.alloc(64).unwrap(), 64);
+        d.release(&gpu).unwrap();
+        // A second release must not double-free: the list is already drained.
+        d.release(&gpu).unwrap();
+    }
+
+    #[test]
+    fn a_null_pointer_is_not_adopted() {
+        let d = DerivedStore::default();
+        d.adopt("twin", DevicePtr::NULL, 0);
+        assert!(d.is_empty(), "a NULL twin is 'not built', not 'owned'");
+    }
+
+    #[test]
+    fn disown_removes_the_buffer_so_release_cannot_double_free() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        let transient = gpu.alloc(512).unwrap();
+        d.adopt("transient", transient, 512);
+        assert_eq!(d.disown(transient), Some(512));
+        assert!(d.is_empty());
+        // A pointer this store never held is not silently "disowned".
+        assert_eq!(d.disown(transient), None);
+    }
+
+    #[test]
+    fn by_label_aggregates_biggest_first() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        d.adopt("small", gpu.alloc(16).unwrap(), 16);
+        d.adopt("big", gpu.alloc(1000).unwrap(), 1000);
+        d.adopt("big", gpu.alloc(1000).unwrap(), 1000);
+        assert_eq!(d.by_label(), vec![("big", 2000, 2), ("small", 16, 1)]);
+    }
+}

--- a/crates/spark-runtime/src/weights/teardown_tests.rs
+++ b/crates/spark-runtime/src/weights/teardown_tests.rs
@@ -96,3 +96,65 @@ fn teardown_releases_in_reverse_registration_order() {
     assert_eq!(gpu.alloc_count(), 0);
     assert!(teardown.is_empty());
 }
+
+/// #736/#915: a buffer a loader DERIVED from these tensors must be released
+/// here, not left for `AtlasCudaBackend::sweep_unreleased` to reclaim unowned.
+///
+/// The mock backend's live-allocation count is the same instrument the CUDA
+/// ledger is: "every allocation this backend made and nobody released".
+#[test]
+fn releasing_frees_adopted_derived_buffers_too() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 4);
+    // Two derived copies per tensor, the shape the dense loader produces:
+    // a fused concat and its widened block-scale grid.
+    for _ in 0..4 {
+        store
+            .derived()
+            .adopt("fused concat", gpu.alloc(2048).expect("alloc"), 2048);
+        store
+            .derived()
+            .adopt("block scale", gpu.alloc(64).expect("alloc"), 64);
+    }
+    assert_eq!(gpu.alloc_count(), 12);
+    assert_eq!(store.derived().len(), 8);
+    assert_eq!(store.derived().bytes(), 4 * (2048 + 64));
+
+    store.release(&gpu).expect("released");
+    assert_eq!(
+        gpu.alloc_count(),
+        0,
+        "an owned derived buffer must leave nothing for the teardown sweep"
+    );
+    assert!(store.derived().is_empty());
+}
+
+/// The negative control, and the pre-#915 state: a derived buffer nobody
+/// adopted survives `release` and is exactly what the H100 sweep reported as
+/// "28.01 GB ... had no owner".
+#[test]
+fn an_unadopted_derived_buffer_is_what_the_sweep_would_report() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 2);
+    let orphan = gpu.alloc(4096).expect("alloc");
+    store.release(&gpu).expect("released");
+    assert_eq!(
+        gpu.alloc_count(),
+        1,
+        "the orphan outlives teardown — adopt it via `store.derived()`"
+    );
+    gpu.free(orphan).expect("freed");
+}
+
+/// Releasing twice must not double-free an adopted buffer either.
+#[test]
+fn releasing_twice_is_harmless_for_derived_buffers() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 1);
+    store
+        .derived()
+        .adopt("twin", gpu.alloc(128).expect("alloc"), 128);
+    store.release(&gpu).expect("released");
+    store.release(&gpu).expect("released again");
+    assert_eq!(gpu.alloc_count(), 0);
+}

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -246,6 +246,36 @@ pub struct ServeArgs {
     #[arg(long, default_value = "snapshot")]
     pub ssm_rollback_mode: String,
 
+    /// Phase-C SSM decode-rollback ring depth: `auto` (default) or an
+    /// explicit slot count in `0..=8`.
+    ///
+    /// The ring retains boundary SSM-state snapshots so a watchdog re-steer
+    /// can rewind the recurrent state; its cost is `depth x
+    /// --max-batch-size x the per-sequence SSM state blob`, which on the 27B
+    /// (151.5 MiB/seq) at the default depth 8 and `--max-batch-size 32` is
+    /// 37.88 GiB — the whole reason an 80 GB H100 refused the hopper recipe
+    /// (#915, rental H100 2026-09-05: inference reserve 45,823 MiB against a
+    /// 71.3 GiB budget carrying 57.2 GiB of weights).
+    ///
+    /// `auto` keeps the depth at 8 (or the existing skips — the ring is
+    /// unreachable under `--speculative`/`--dflash` and with watchdogs off)
+    /// and lets preflight SHRINK it down `8, 4, 2, 1, 0` until the reserve
+    /// fits, logging the formula at WARN. Depth degrades gracefully: fewer
+    /// retained boundaries means fewer reachable re-steer anchors, and a
+    /// sequence that finds none hard-stops instead of re-steering — never a
+    /// partial SSM rewind.
+    ///
+    /// An explicit `N` pins the depth on BOTH sides (reserve and allocation)
+    /// and disables the fit: a serve that does not fit at `N` is REFUSED with
+    /// the formula, rather than booted at a depth the recipe does not record.
+    /// `0` disables the ring outright; 8 is the wired default and the
+    /// arithmetic ceiling.
+    ///
+    /// Legacy: `ATLAS_SSM_DECODE_RING=1|0` still means depth 8 and 0. It is
+    /// only consulted when this flag is `auto` — absent is not a value.
+    #[arg(long, default_value = "auto", value_name = "AUTO_OR_N")]
+    pub ssm_decode_ring_slots: String,
+
     /// Fused GDN output-norm kernel on the decode path (default: off).
     ///
     /// Required by `--ssm-h-dtype f16`: the FP16 h-state twins live on the

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -180,6 +180,19 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
             "use snapshot (default, wired) or replay (experimental scaffold).",
         ));
     }
+    // `--ssm-decode-ring-slots`: same SSOT rule — the parse that validates is
+    // the parse `publish_kernel_flags` publishes through (#915).
+    if let Err(why) = spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+    {
+        v.push(Violation::new(
+            format!(
+                "--ssm-decode-ring-slots '{}' is not a valid value.",
+                args.ssm_decode_ring_slots
+            ),
+            why,
+            "use auto (default: preflight sizes the ring from free memory) or 0..=8.",
+        ));
+    }
     // #435: the exact-verify arm's kernels are FP32 readers, so an FP16
     // h-state pool disables it (`GdnFlags::verify_exact_active`). Honouring
     // `--ssm-h-dtype f16` by SILENTLY ignoring an explicit `--exact-verify`

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -234,6 +234,27 @@ fn ssm_rollback_mode_values_and_typos() {
 }
 
 #[test]
+fn ssm_decode_ring_slots_values_and_typos() {
+    // `auto` is the default and must validate: it is what lets preflight size
+    // the ring from free memory instead of refusing the boot (#915).
+    let a = parse(&[]);
+    assert_eq!(a.ssm_decode_ring_slots, "auto");
+    assert!(validate_serve_args(&a).is_ok());
+    for depth in ["0", "1", "2", "4", "8"] {
+        assert!(
+            validate_serve_args(&parse(&["--ssm-decode-ring-slots", depth])).is_ok(),
+            "depth {depth} is inside the ring's range"
+        );
+    }
+    // Above the wired ceiling, and anything non-numeric, is refused through
+    // the model-side parse (SSOT with the publication parse) — never clamped.
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "9"])).unwrap_err();
+    assert!(err.contains("--ssm-decode-ring-slots"), "{err}");
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "AUTO"])).unwrap_err();
+    assert!(err.contains("auto"), "names the valid values: {err}");
+}
+
+#[test]
 fn a_mistyped_mtp_gate_is_still_caught() {
     // Making the flag optional must not make its typo check optional.
     let err = validate_serve_args(&parse(&["--mtp-gate", "always"])).unwrap_err();

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -81,6 +81,24 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
              line's ({rollback:?}) did NOT take effect"
         );
     }
+    // `--ssm-decode-ring-slots`: ABSENT IS NOT A VALUE. `auto` (the clap
+    // default) publishes NOTHING, so the documented `ATLAS_SSM_DECODE_RING`
+    // fallback stays reachable AND preflight can publish the depth it fitted
+    // to free memory later in the same boot (#915). An explicit N is
+    // published here, before preflight runs, which is exactly what makes the
+    // auto-fit's later write a no-op — an operator's pinned depth is refused
+    // rather than silently shrunk.
+    if let Some(slots) =
+        spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+            .expect("validated by validate_serve_args")
+    {
+        let in_force = spark_model::ssm_reserve::set_decode_ring_slots(slots);
+        if in_force != slots {
+            tracing::warn!(
+                "ssm-decode-ring-slots was already resolved ({in_force}); the command                  line's ({slots}) did NOT take effect"
+            );
+        }
+    }
     // `--prefill-varlen-batch`: its own single-value cell, so it publishes
     // independently of the GDN trio. Absent publishes nothing and the
     // documented `ATLAS_PREFILL_VARLEN` fallback stays reachable.
@@ -116,7 +134,7 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
          exact_verify={} ssm_tail_midchunk={} mtp_gate={} ssm_rollback_mode={:?} \
-         prefill_varlen_batch={}",
+         ssm_decode_ring_slots={} prefill_varlen_batch={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
@@ -130,6 +148,12 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
             "auto"
         },
         spark_model::ssm_reserve::ssm_rollback_mode(),
+        // RESOLVED: `auto` until something publishes a depth. Preflight logs
+        // the fitted depth (and the formula behind it) when it shrinks one.
+        match spark_model::ssm_reserve::published_decode_ring_slots() {
+            Some(slots) => slots.to_string(),
+            None => "auto".to_string(),
+        },
         // RESOLVED, not the raw argument — may come from the environment.
         spark_model::layers::ops::prefill_varlen_enabled(),
     );

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -8,7 +8,9 @@ use atlas_core::config::ModelConfig;
 
 use crate::cli;
 
+mod decode_ring;
 mod per_sequence_state;
+mod refusal;
 mod ssm_h_fp16;
 use {per_sequence_state::per_sequence_reserve, ssm_h_fp16::ssm_h_fp16_preconditions};
 
@@ -156,35 +158,6 @@ pub(crate) fn preflight_reserve(
         args.max_batch_size,
     )
     .total_bytes();
-    // SSM snapshot pool = Marconi prefix-cache region + Phase-C
-    // decode-rollback ring. The decode ring is sized per active
-    // sequence (ring slots × `max_batch_size`) and only allocated for SSM
-    // models. SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots`
-    // makes the SAME decision (same env vars, same constant) the runtime
-    // allocation in `TransformerModel::new` makes — including the skip under
-    // `--speculative`/`--dflash` (the ring's save/rollback path only runs on
-    // plain decode; the spec path rolls back through the verify snapshot).
-    // Reserving the ring unconditionally while the runtime skipped it
-    // stranded ~38 GB at bs32 on the 27B (75.2 GB SSM reserve vs an 85.2 GB
-    // budget at util 0.70) and capped the native batch at ~20.
-    // `use_speculative` here MUST mirror what `build_model` passes:
-    // `args.speculative || args.dflash`.
-    // Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present ⇒ restore the old
-    // unconditional reservation (accounting-only, safe over-reserve;
-    // presence-style — `=0` is NOT "off").
-    let decode_ring_slots = if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
-        if config.num_ssm_layers() > 0 {
-            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
-        } else {
-            0
-        }
-    } else {
-        spark_model::ssm_reserve::decode_rollback_ring_slots(
-            config.num_ssm_layers(),
-            args.speculative || args.dflash,
-        )
-        .slots
-    };
     // Marconi snapshot region. SSOT:
     // `spark_model::ssm_reserve::marconi_snapshot_slots` makes the SAME
     // decision (same env var, same predicate) the runtime allocation in
@@ -212,9 +185,12 @@ pub(crate) fn preflight_reserve(
                 / (1024 * 1024),
         );
     }
-    let ssm_snapshot_bytes = (marconi.slots + decode_ring_slots * args.max_batch_size)
-        * config.num_ssm_layers()
-        * (h_state_bytes + conv_state_bytes);
+    // The per-sequence SSM state blob — `num_ssm_layers x (h + conv)`, 151.5
+    // MiB on the 27B. Both snapshot regions are whole multiples of it:
+    // Marconi reserves one per cache slot, the decode ring one per active
+    // sequence per ring slot.
+    let per_seq_blob = config.num_ssm_layers() * (h_state_bytes + conv_state_bytes);
+    let marconi_bytes = marconi.slots * per_seq_blob;
     // Same predicate as the pool term: DFlash IS a speculative serve and
     // pays the same graph/JIT/scratch overheads the 4 GB headroom exists for.
     let cuda_headroom: usize = if spec_on_pool {
@@ -234,59 +210,60 @@ pub(crate) fn preflight_reserve(
             0
         }
     };
-    let inference_reserve: usize = ssm_pool_bytes
+    // Everything the reserve needs that does NOT scale with ring depth. The
+    // ring is separated out because it is the only term preflight is allowed
+    // to shrink (#915): rollback depth degrades gracefully, the batch and the
+    // pools it sizes do not.
+    let fixed_reserve: usize = ssm_pool_bytes
         + ssm_h_stage_bytes
         + ssm_replay_ring
-        + ssm_snapshot_bytes
+        + marconi_bytes
         + gdn_two_phase_bytes
         + cuda_headroom
         + per_sequence_reserve(args, config);
+    // Phase-C decode-rollback ring: the depth the flags/env ask for, then the
+    // largest depth that actually fits alongside everything above. Both steps
+    // are SSOT'd in `decode_ring` (which publishes the fitted depth so
+    // `TransformerModel::new` allocates exactly what was reserved).
+    let ring_requested = decode_ring::requested_slots(args, config);
+    let ring_slot_bytes = decode_ring::slot_bytes(args, per_seq_blob);
+    let fit = decode_ring::autofit(
+        args,
+        ring_requested,
+        ring_slot_bytes,
+        per_seq_blob,
+        fixed_reserve + buffer_arena_bytes,
+        free_mem,
+    );
+    if let Some(warning) = &fit.warning {
+        tracing::warn!("SSM decode-rollback ring auto-fit — {}", warning);
+    }
+    let ssm_snapshot_bytes = marconi_bytes + fit.slots * ring_slot_bytes;
+    let inference_reserve: usize = fixed_reserve + fit.slots * ring_slot_bytes;
     let total_reserve = inference_reserve + buffer_arena_bytes;
     if total_reserve > free_mem {
-        let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
-        let free_gb = free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
-        let fixed = ssm_pool_bytes + ssm_h_stage_bytes + ssm_snapshot_bytes + cuda_headroom;
-        let budget_for_seq_term = free_mem.saturating_sub(fixed) / 2;
-        let per_tok_bytes = {
-            let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
-            let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
-            let nv = config.linear_num_value_heads;
-            let conv_dim = key_dim * 2 + value_dim;
-            if conv_dim > 0 && config.num_ssm_layers() > 0 {
-                (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
-            } else {
-                0
-            }
-        };
-        let suggested = budget_for_seq_term
-            .checked_div(per_tok_bytes)
-            .map(|q| q.max(2048))
-            .unwrap_or(0);
-        let hint = if suggested > 0 && suggested < args.max_seq_len {
-            format!(
-                " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
-                suggested
-            )
-        } else if args.max_batch_size > 1 {
-            " Reduce --max-batch-size.".to_string()
-        } else {
-            " Use a smaller model or a GPU with more memory.".to_string()
-        };
-        anyhow::bail!(
-            "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
-             (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}",
-            need_gb,
-            free_gb,
-            args.max_seq_len,
-            args.max_batch_size,
-            hint,
-        );
+        return Err(refusal::reserve_refusal(
+            args,
+            config,
+            refusal::Refusal {
+                total_reserve,
+                free_mem,
+                seq_len_independent: ssm_pool_bytes
+                    + ssm_h_stage_bytes
+                    + ssm_snapshot_bytes
+                    + cuda_headroom,
+                ring_requested,
+                ring_slots: fit.slots,
+                per_seq_blob,
+            },
+        ));
     }
     tracing::info!(
-        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB)",
+        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB); {}",
         inference_reserve / (1024 * 1024),
         buffer_arena_bytes / (1024 * 1024),
         free_mem as f64 / (1024.0 * 1024.0 * 1024.0),
+        decode_ring::formula(fit.slots, args.max_batch_size, per_seq_blob),
     );
     // Q09: per-component breakdown so future MTP/spec-decode reserve
     // jumps are diagnosable from the log alone. Each line is dropped at

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The decode-rollback ring reserve term and its #915 auto-fit.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), following
+//! the `per_sequence_state.rs` precedent: the term, the formula it prints and
+//! the shrink decision live here; `preflight.rs` gains only the calls.
+//!
+//! # Why this term needed a fit and not just a number
+//!
+//! `ssm_snapshot_bytes` multiplies a CONSTANT ring depth (8) by
+//! `--max-batch-size`, a flag that says nothing about what the card can hold.
+//! Serving Qwen/Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) that
+//! is 8 x 32 x 151.5 MiB = 37.88 GiB of ring inside a 45,823 MiB inference
+//! reserve, against a 71.3 GiB budget already carrying 57.2 GiB of weights —
+//! and the serve REFUSED to boot (rental H100, 2026-09-05, evidence cell
+//! `qwen38.atlas.a.lat.c1`). The shipped workaround was `--max-batch-size 4`
+//! (cell `qwen38.atlas.c.lat.c1`, reserve 8.54 GiB, GO in 22 s): paying for
+//! rollback depth with four fifths of the serve's concurrency.
+//!
+//! Ring depth degrades GRACEFULLY (fewer retained boundaries = fewer
+//! reachable re-steer anchors; a sequence that finds none hard-stops through
+//! `RollbackFallback::NoSsmSnapshot`, which is an honest decline, never a
+//! partial SSM rewind). Batch does not: it is the serve's concurrency. So the
+//! term that yields is the ring, and it yields down
+//! `ssm_reserve::DECODE_RING_FIT_LADDER` until the whole reserve fits.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+const MIB: f64 = 1024.0 * 1024.0;
+const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// The ring depth preflight will reserve for, and the warning the operator
+/// must see when it is not the depth the flags asked for.
+pub(super) struct RingFit {
+    pub(super) slots: usize,
+    /// `Some` only when the auto-fit SHRANK the ring — logged at WARN by the
+    /// caller, because a serve that quietly kept less rollback depth than its
+    /// recipe records is a serve whose re-steer behaviour cannot be
+    /// reproduced from the recipe.
+    pub(super) warning: Option<String>,
+}
+
+/// The ring depth the flags and environment ask for, before any fit.
+///
+/// SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots` makes the
+/// SAME decision (same published cell, same env vars, same constant) the
+/// runtime allocation in `TransformerModel::new` makes — including the skip
+/// under `--speculative`/`--dflash` (the ring's save/rollback path only runs
+/// on plain decode; the spec path rolls back through the verify snapshot).
+/// Reserving the ring unconditionally while the runtime skipped it stranded
+/// ~38 GB at bs32 on the 27B and capped the native batch at ~20.
+/// `use_speculative` here MUST mirror what `build_model` passes:
+/// `args.speculative || args.dflash`.
+///
+/// Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present => restore the old
+/// unconditional reservation (accounting-only, safe over-reserve;
+/// presence-style — `=0` is NOT "off").
+pub(super) fn requested_slots(args: &cli::ServeArgs, config: &ModelConfig) -> usize {
+    if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
+        return if config.num_ssm_layers() > 0 {
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        } else {
+            0
+        };
+    }
+    spark_model::ssm_reserve::decode_rollback_ring_slots(
+        config.num_ssm_layers(),
+        args.speculative || args.dflash,
+    )
+    .slots
+}
+
+/// Bytes ONE unit of ring depth costs: `--max-batch-size` x the per-sequence
+/// SSM state blob. The same product `ssm_snapshot_bytes` multiplies the depth
+/// by, factored out so the fit and the reserve cannot use different arithmetic.
+pub(super) fn slot_bytes(args: &cli::ServeArgs, per_seq_blob: usize) -> usize {
+    args.max_batch_size * per_seq_blob
+}
+
+/// `snapshots x batch x per-seq state bytes`, spelled out (issue #915's third
+/// bullet: preflight must print the formula so an operator can see why the
+/// reserve asked for what it asked for). SSOT for the INFO line, the shrink
+/// WARN and the refusal text, so all three quote the same arithmetic.
+pub(super) fn formula(slots: usize, max_batch: usize, per_seq_blob: usize) -> String {
+    format!(
+        "ring: {slots} slots x {max_batch} seqs x {:.1} MB/seq = {:.2} GB",
+        per_seq_blob as f64 / MIB,
+        (slots * max_batch * per_seq_blob) as f64 / GIB,
+    )
+}
+
+/// Shrink the ring until the reserve fits, or leave it alone.
+///
+/// `reserve_without_ring` is the WHOLE reserve minus the ring term
+/// (`inference_reserve + buffer_arena_bytes`), so the caller adds exactly
+/// `slots * slot_bytes` back.
+///
+/// Leaves the depth untouched — returning no warning — when the reserve
+/// already fits, when there is no ring to shrink, or when the depth is
+/// EXPLICIT (`--ssm-decode-ring-slots N`, published before preflight runs):
+/// an operator who named a depth gets that depth or a refusal, never a
+/// silent third answer.
+pub(super) fn autofit(
+    args: &cli::ServeArgs,
+    requested: usize,
+    slot_bytes: usize,
+    per_seq_blob: usize,
+    reserve_without_ring: usize,
+    free_mem: usize,
+) -> RingFit {
+    let asked = reserve_without_ring.saturating_add(requested.saturating_mul(slot_bytes));
+    let explicit = spark_model::ssm_reserve::published_decode_ring_slots().is_some();
+    if asked <= free_mem || requested == 0 || slot_bytes == 0 || explicit {
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    let fitted = spark_model::ssm_reserve::fit_decode_ring_slots(
+        requested,
+        reserve_without_ring,
+        slot_bytes,
+        free_mem,
+    );
+    let fitted_total = reserve_without_ring.saturating_add(fitted.saturating_mul(slot_bytes));
+    if fitted_total > free_mem {
+        // Even a ringless serve does not fit: the ring is not the problem, so
+        // do not shrink it behind the operator's back — the caller refuses
+        // and quotes the formula for the depth that was actually asked for.
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    // Published so `TransformerModel::new` allocates the SAME depth this
+    // reserve was sized for. Both sides read the one cell; without this the
+    // runtime would allocate 8 slots against a reserve that funded fewer.
+    spark_model::ssm_reserve::set_decode_ring_slots(fitted);
+    RingFit {
+        slots: fitted,
+        warning: Some(format!(
+            "{} (was {:.2} GB); reserve {:.2} of {:.2} GB. Sized from free memory, not from \
+             --max-batch-size {} (#915): rollback depth yields, concurrency does not. Pass \
+             --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).",
+            formula(fitted, args.max_batch_size, per_seq_blob),
+            (requested * slot_bytes) as f64 / GIB,
+            fitted_total as f64 / GIB,
+            free_mem as f64 / GIB,
+            args.max_batch_size,
+        )),
+    }
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact-integer pins for the preflight ring term and its #915 auto-fit. No
+//! GPU, no model, no checkpoint — which is the point: this decision is made
+//! before the weights exist.
+//!
+//! The numbers are the 2026-09-05 rental-H100 boot from issue #915
+//! (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe, evidence cell
+//! `qwen38.atlas.a.lat.c1`): 48 GDN layers, 151.5 MiB of SSM state per
+//! sequence, `--max-batch-size 32`, inference reserve 45,823 MiB of which
+//! 37.88 GiB was ring, 57.2 GiB of weights inside a 71.3 GiB budget.
+use super::*;
+use clap::Parser as _;
+
+/// 48 GDN layers x (h 48*128*128*4 + conv (16*128*2 + 48*128)*4*4) =
+/// 158,859,264 B = exactly 151.5 MiB.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// The 45,823 MiB inference reserve minus its 38,784 MiB 8-slot ring.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+fn args() -> cli::ServeArgs {
+    cli::ServeArgs::parse_from(["spark", "Qwen/Qwen3.8-27B-FP8", "--max-batch-size", "32"])
+}
+
+/// The formula issue #915's third bullet asks preflight to print: an operator
+/// staring at 45.8 GiB could not see it was 8 snapshots x batch 32.
+#[test]
+fn the_formula_spells_out_snapshots_times_batch_times_per_seq_state() {
+    assert_eq!(
+        formula(8, 32, PER_SEQ_BLOB),
+        "ring: 8 slots x 32 seqs x 151.5 MB/seq = 37.88 GB"
+    );
+    // The same arithmetic at the depth the fit chose — one function, so the
+    // INFO line, the shrink WARN and the refusal cannot quote three answers.
+    assert_eq!(
+        formula(1, 32, PER_SEQ_BLOB),
+        "ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"
+    );
+    assert_eq!(
+        formula(0, 32, PER_SEQ_BLOB),
+        "ring: 0 slots x 32 seqs x 151.5 MB/seq = 0.00 GB"
+    );
+}
+
+/// The #915 boot itself: 14.1 GiB free (71.3 GiB budget less 57.2 GiB of
+/// weights) against a reserve whose ring alone wants 37.88 GiB. It must
+/// shrink to depth 1 and boot, not refuse.
+#[test]
+fn the_915_boot_shrinks_to_the_largest_fitting_depth_instead_of_refusing() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    assert_eq!(slot, 32 * PER_SEQ_BLOB);
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 1, "8 -> 4 -> 2 -> 1 is the first rung that fits");
+    assert!(
+        RESERVE_WITHOUT_RING + fit.slots * slot <= free,
+        "the depth it kept must actually fit"
+    );
+
+    let warning = fit.warning.expect("a shrink must be logged, never silent");
+    assert!(
+        warning.contains("ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"),
+        "{warning}"
+    );
+    assert!(warning.contains("(was 37.88 GB)"), "{warning}");
+    assert!(warning.contains("reserve 11.61 of 14.10 GB"), "{warning}");
+    assert!(warning.contains("#915"), "{warning}");
+    assert!(
+        warning.contains("--ssm-decode-ring-slots"),
+        "the warning must name the flag that pins a depth: {warning}"
+    );
+}
+
+/// A reserve that already fits is left exactly as the flags asked for, and
+/// says nothing — the WARN is reserved for the case where the serve is
+/// running at a depth its recipe does not record.
+#[test]
+fn a_reserve_that_fits_is_not_touched() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let free = 64 * 1024 * 1024 * 1024;
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// Nothing to shrink is not a shrink: a ringless serve (`--speculative`,
+/// watchdogs off, `--ssm-decode-ring-slots 0`, or a pure-attention model)
+/// goes straight to the refusal with no warning of its own.
+#[test]
+fn a_ringless_serve_is_left_to_the_refusal() {
+    let args = args();
+    let free = RESERVE_WITHOUT_RING / 2;
+    let fit = autofit(
+        &args,
+        0,
+        slot_bytes(&args, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        free,
+    );
+    assert_eq!(fit.slots, 0);
+    assert!(fit.warning.is_none());
+    // Same when the model has no SSM state at all: a zero-byte depth unit.
+    let fit = autofit(&args, 8, 0, 0, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// When even depth 0 is over budget the ring is not what is wrong. Shrinking
+/// it behind the operator's back would swap a clear refusal for a serve with
+/// no rollback depth that still cannot boot, so the depth is returned
+/// UNCHANGED and the caller refuses quoting the full formula.
+#[test]
+fn an_unfittable_reserve_keeps_the_requested_depth_for_the_refusal() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let fit = autofit(
+        &args,
+        8,
+        slot,
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        RESERVE_WITHOUT_RING - 1,
+    );
+    assert_eq!(fit.slots, 8, "the refusal must quote what was asked for");
+    assert!(fit.warning.is_none());
+}
+
+/// `--ssm-decode-ring-slots 0` is a real value the CLI accepts, and the
+/// requested-depth path must honour a published depth rather than the
+/// constant 8 — the allocation side reads the same cell.
+#[test]
+fn the_flag_parses_through_the_model_side_ssot() {
+    use spark_model::ssm_reserve::parse_decode_ring_slots;
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("2"), Ok(Some(2)));
+    assert!(parse_decode_ring_slots("12").is_err());
+    // The clap default is the `auto` this module's fit depends on.
+    assert_eq!(args().ssm_decode_ring_slots, "auto");
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The pre-load reserve REFUSAL: what it suggests, and why it asked for what
+//! it asked for.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), same
+//! precedent as `per_sequence_state.rs` and `decode_ring.rs`.
+//!
+//! Refusal is now the LAST resort, not the first answer: the decode-rollback
+//! ring shrinks to fit before this runs (#915), so reaching here means the
+//! configuration does not fit even with no rollback depth at all. That makes
+//! the text load-bearing — it is the only thing an operator has to act on —
+//! which is why it carries the ring formula as well as a suggested batch.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+use super::decode_ring;
+
+/// The terms the refusal text needs that are not derivable from `args` /
+/// `config`. Grouped so the call site stays one statement.
+pub(super) struct Refusal {
+    /// `inference_reserve + buffer_arena_bytes`.
+    pub(super) total_reserve: usize,
+    pub(super) free_mem: usize,
+    /// The terms that do NOT scale with `--max-seq-len`: SSM pools, h stage,
+    /// both snapshot regions, CUDA headroom. What is left of `free_mem` after
+    /// them is what the suggested sequence length is derived from.
+    pub(super) seq_len_independent: usize,
+    /// Ring depth the flags asked for, and the depth actually reserved for
+    /// (they differ only when an explicit depth was pinned — the auto-fit
+    /// path never reaches this refusal).
+    pub(super) ring_requested: usize,
+    pub(super) ring_slots: usize,
+    pub(super) per_seq_blob: usize,
+}
+
+/// Build the refusal error. Pure formatting over already-computed bytes.
+pub(super) fn reserve_refusal(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    r: Refusal,
+) -> anyhow::Error {
+    let need_gb = r.total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
+    let free_gb = r.free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
+    let budget_for_seq_term = r.free_mem.saturating_sub(r.seq_len_independent) / 2;
+    let per_tok_bytes = {
+        let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
+        let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+        let nv = config.linear_num_value_heads;
+        let conv_dim = key_dim * 2 + value_dim;
+        if conv_dim > 0 && config.num_ssm_layers() > 0 {
+            (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
+        } else {
+            0
+        }
+    };
+    let suggested = budget_for_seq_term
+        .checked_div(per_tok_bytes)
+        .map(|q| q.max(2048))
+        .unwrap_or(0);
+    let hint = if suggested > 0 && suggested < args.max_seq_len {
+        format!(
+            " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
+            suggested
+        )
+    } else if args.max_batch_size > 1 {
+        " Reduce --max-batch-size.".to_string()
+    } else {
+        " Use a smaller model or a GPU with more memory.".to_string()
+    };
+    anyhow::anyhow!(
+        "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
+         (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}{}",
+        need_gb,
+        free_gb,
+        args.max_seq_len,
+        args.max_batch_size,
+        hint,
+        ring_note(args, &r),
+    )
+}
+
+/// Issue #915's third bullet: an operator staring at a 45.8 GiB refusal could
+/// not see that 37.9 GiB of it was 8 rollback snapshots x batch 32. Print the
+/// arithmetic, and say why shrinking the ring did not rescue the boot.
+fn ring_note(args: &cli::ServeArgs, r: &Refusal) -> String {
+    if r.ring_requested == 0 {
+        return String::new();
+    }
+    format!(
+        " {} — {}.",
+        decode_ring::formula(r.ring_slots, args.max_batch_size, r.per_seq_blob),
+        if spark_model::ssm_reserve::published_decode_ring_slots().is_some() {
+            "an explicit --ssm-decode-ring-slots pins the depth, so it was not shrunk"
+        } else {
+            "even 0 ring slots does not fit, so shrinking it cannot rescue this boot"
+        },
+    )
+}

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -224,9 +224,15 @@ pub fn rollback_to_boundary(
     };
 
     // A hybrid model needs the SSM state rewound too — restrict boundary
-    // selection to one with a live snapshot. `has_ssm_layers()` false
-    // (pure attention) keeps the original any-boundary search.
-    let hybrid = model.has_ssm_layers() && a.ssm_rollback_ring.is_enabled();
+    // selection to one with a live snapshot. A DISABLED ring is a DECLINE,
+    // not the pure-attention any-boundary path: depth 0 (spec on, watchdogs
+    // off, or the #915 auto-fit floor) means no snapshot exists, and rewinding
+    // tokens while the recurrent state stays conditioned on the discarded tail
+    // is silent corruption. This is the fail-open the ring's SSOT documents.
+    let hybrid = model.has_ssm_layers();
+    if hybrid && !a.ssm_rollback_ring.is_enabled() {
+        return RollbackOutcome::Fallback(RollbackFallback::NoSsmSnapshot);
+    }
     let (boundary_idx, ssm_slot) = if hybrid {
         match find_last_boundary_with_snapshot(
             &a.output_tokens,

--- a/crates/spark-server/src/scheduler/ssm_decode_ring.rs
+++ b/crates/spark-server/src/scheduler/ssm_decode_ring.rs
@@ -21,9 +21,11 @@
 //! cost bounded: at most `capacity` D2D copies are live per sequence,
 //! and the ring evicts oldest-first so a long generation never grows
 //! the set. `capacity` is the model's
-//! `decode_rollback_ring_slots()` — sized `ROLLBACK_RESTEER_CAP + 1`
-//! so every permitted rollback has a distinct snapshot plus the current
-//! boundary.
+//! `decode_rollback_ring_slots()` — 8 by default, so every permitted
+//! rollback has a distinct snapshot plus the current boundary, but as
+//! low as 0 when `--ssm-decode-ring-slots` or preflight's free-memory
+//! fit (#915) says so. A smaller ring retains fewer boundaries and so
+//! reaches fewer re-steer anchors; 0 declines every rollback.
 //!
 //! Memory cost: each slot stores `h_state + conv_state` for **all** SSM
 //! layers. Per marconi.md that is ~77 MB/slot for a 122B/36-layer model;


### PR DESCRIPTION
## Summary

On a native-FP8 checkpoint the dense loader builds a full set of **NVFP4 fallback weights and transposed twins that no kernel on that route can reach**. Measured on 1×H100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`: the checkpoint is **28.75 GB**, but **58.1 GB** was live before the KV cache was sized. The extra 28 GB is derived copies — 18.4 GiB of it provably unreadable — and none of it had an owner, so the teardown sweep reclaimed **28.01 GB across 1,980 allocations** and warned that each was "memory whose owner is unaccounted for".

This stops building the unreachable copies, gives the ones that stay a real owner on the `WeightStore`, and frees the four SSM store tensors the fused `[QKV|Z]` FP8 concat had already consumed. Pre-KV residency falls **58.1 → 33.2 GB**; the KV cache goes 5.2 → 13.6 GB (137,216 → 355,280 tokens) on the same card.

Refs #915, #916, #917 and #736.

**On #736 specifically — this is `Refs`, not `Fixes`.** That issue asks for ledger owners at five named loader sites. This PR removes four of them from existence (`loaders_fp8.rs:229/230`, `quantized.rs:261/262`) and adopts what stays, and the sweep's unowned total falls 28.01 GB → 1.12 GB with **zero** contribution from `load_layers`. But `quant_helpers.rs:98` — one of the five — is still unowned in the after-log (710 MB ×7, the quantizer scratch buffers), and `dense_ffn.rs:653` / `load_fns.rs:200` are not addressed by name. The issue's exact ask is not fully met by this PR alone.

**No arithmetic changes in this PR.** Every GEMM, every scale, every epilogue is untouched. This is a residency change: the same math over the same bytes, with the copies nothing reads no longer allocated.

## What was wrong

`ATLAS_MEM_PROFILE` recorded GPU-free falling a perfectly linear **437 MB per layer across all 64 layers (28.0 GB)** *after* the checkpoint was already resident, so all of it was derived, not loaded. The ledger named six sites:

| site | bytes × count | tensor |
|---|---|---|
| `weight_map/loaders_fp8.rs:229` | 8,960 MB ×256 | `quantize_to_nvfp4` packed `[N,K/2]` |
| `weight_map/quantized.rs:261` | 8,960 MB ×256 | the transposed twin of the same |
| `weight_loader/qwen35_dense.rs:135` | 3,840 MB ×48 | SSM fused `[QKV\|Z]` FP8 concat |
| `weight_map/quantized.rs:643` | 1,600 MB ×64 | attention `Fp8WeightTransposed::weight_t` |
| `weight_map/loaders_fp8.rs:230` | 1,120 MB ×256 | NVFP4 per-16 group scales |
| `weight_map/quantized.rs:262` | 1,120 MB ×256 | the transposed twin of those scales |

The ×256 counts are `64 layers × 3` dense-FFN projections plus `16 attention layers × 4` q/k/v/o — 8,160 + 800 MB, which is exactly the 8,960 reported.

Three families, **two of them unreachable**:

- **NVFP4 gate/up/down + twins, 64 layers — 18.4 GiB.** `DenseFfnLayer::forward` and `forward_prefill_inner` both return from inside their `if let Some(ref fp8w) = self.fp8_weights` arm; `forward_k2`/`k3`/`km` redirect through `native_small_batch_uses_prefill`; and the `w8_gemm!` macro binds `gate_t`/`up_t`/`down_t` to a **literal `None`** on every rung, so even the W8A16 fallback reads the original `[N,K]` E4M3 bytes. Nothing on the route can read an NVFP4 buffer.
- **NVFP4 q/k/v/o + twins + the fused `[q|k|v]` twin, 16 layers — ~2.4 GiB.** `set_fp8_weights` **overwrites** `q/k/v/o_weight`, so these were orphaned the instant they were installed.
- **FP8 prefill twins, 16 layers — 1,600 MB.** Q and O are reached only after the W8A8 arm declines. **K and V are not** — `prefill/cache_skip_qkv.rs` has no W8A8 arm at all and is the first-chunk path of every request. K/V twins stay.

Separately, the native-FP8 GDN arm copies `in_proj_qkv` and `in_proj_z` into one fused device buffer and rebuilds `in_proj_ba` through a host interleave, then leaves all four store originals resident for the life of the model — 80 MiB + ~1 MB per SSM layer, **~3.9 GB across the 48 GDN layers**. That is exactly what the fused copy costs, so the pair was a straight duplicate charged to the KV budget.

## What the fix does

**`fp8_residency.rs`, a new child module** of `qwen35_dense.rs`, is the decision table. The loader runs *before* dispatch exists, so it cannot read a `ForwardContext`; instead it derives the route from **the same resolvers the forward pass uses** — `GemmDispatch::from_env`, the exact constructor `model/impl_a1.rs:836` calls, plus the four un-memoised `ATLAS_ATTN_*` reads the hot arms make. Both are pure functions of the environment and a serve never rewrites its own environment, so the loader's answer and the context's answer cannot disagree. `DenseFp8Plan::resolve` is a pure function of `DenseFp8Inputs`, which is why the CPU tests can pin every clause without touching the process environment.

`ATLAS_FFN_W8A16_ONLY` is deliberately **not** an input: it steers between rungs of the same `w8_gemm!` match, whose transposed operand is that literal `None`, so it selects between two kernels that both read the original FP8 bytes and cannot resurrect an NVFP4 reader.

**`ATLAS_DENSE_FP8_KEEP_NVFP4`** (presence, not `=1` — `…=0` meaning "on" is a trap for an operator reaching for an escape hatch mid-incident) restores the pre-#915 footprint wholesale, for bisecting a suspected gap in that table.

**`dense_ffn.rs`** — `QuantizedWeight::null()` becomes a legal shape for a layer carrying an FP8 overlay. `finalize_q4k_load` and `finalize_nvfp4_mmq_load` return early when `fp8_weights` is installed, for the same reason they already do for packed-Q2: the repack is dead work, and over NULL NVFP4 sources it is a CUDA-700. `finalize_nvfp4_mmq_load` is the sharper case — it is active **by default** wherever its four kernels exist, and it also **frees** the transposed copies on the assumption that the MMQ arm will serve prefill.

`can_forward_km` keeps answering `true` for an FP8 layer. It gates the 4..=8-row verify branch in `multi_seq/ffn.rs:145`; letting a NULL `gate_proj` flip it to `false` would quietly reroute that branch, and **this change must shrink the footprint without moving the dispatch**. `forward_km` redirects to `forward_prefill` for an FP8 layer anyway.

**`DerivedStore` (`spark-runtime/src/weights/derived.rs`)** is the owner for what stays. It hangs off `WeightStore` because these buffers are derived from store tensors, share the store's lifetime, and the store is already the last `ModelResource` released before the sweep — so adopting a buffer moves it from "swept" to "released", which is the difference the ledger reports. Interior mutability (`parking_lot::Mutex`, no poisoning, so a panic elsewhere cannot block teardown) because loaders take `&WeightStore`; threading a `&mut` through `ModelWeightLoader::load_layers` would change every architecture's loader to fix a bookkeeping gap in one of them. `disown()` exists for the transient half of a fused concat — adopted by the generic loader that produced it, freed by the loader that consumed it — because without it that pointer would be freed twice. `release()` drains first, so a failure part-way through cannot leave a freed pointer in the list to be freed again.

Adopted: the SSM fused `[QKV|Z]` FP8 concat (3,840 MB ×48, the hottest tensor on that route, with no un-fused dispatch to fall back to), its block-scale grid, the interleaved BA weight, and every widened FP8 block scale.

**`prune_after_load`** frees the four SSM store names the fused concat consumed, and **only for layers where the arm actually ran**. The arm's condition moves into `gdn_fp8_arm_selected` so the loader and the pruner cannot drift — a drift here is a use-after-free with no diagnostic. `out_proj.weight` is **not** pruned (it *is* `out_proj_fp8w.weight`, bound zero-copy), and neither are conv1d / A_log / dt_bias / norm, which are aliased or not depending on their on-disk dtype.

Load ends with one INFO line — weights / derived / twins / freed / not built — so the next serve log proves the residency without a profiling rerun.

## Oracle and evidence

**Diagnostic single-H100 evidence, not certified campaign numbers.** 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8 profile, `--lm-head-dtype bf16`, 2026-09-11. Before = round 3/5 at `c1b67f022`; after = round 6 at integration tip `456109bf3`.

### The residency lines, verbatim

```
native FP8 dense residency: weights 30.87 GB, derived 4.24 GB
  (twins: attn-fp8-t, ssm-qkvz-fp8), freed 0.00 GB, not built 23.31 GB

native FP8 GDN: released 288 store tensors (4.07 GB) consumed by the fused
  [QKV|Z] concat and the BA interleave; out_proj/conv1d/A_log/dt_bias/norm
  kept (still aliased)
```

### Memory — this PR's own receipt

| line | before (`c1b67f022`) | after (`456109bf3`) | Δ |
|---|---|---|---|
| `build residency: load_layers` | **−26.045 GiB** | **−3.996 GiB** | −22.05 GiB |
| `build residency: prune_after_load` | +0.000 GiB | **+3.750 GiB** | the prune now returns memory |
| cumulative after build | 26.738 GiB | **0.939 GiB** | −25.8 GiB |
| **pre-KV** | **58.1 GB** | **33.2 GB** | **−24.9 GB** |
| **KV** | **5.2 GB** | **13.6 GB** | **+161%** |
| **max KV tokens** | **137,216** | **355,280** | **2.59×** |
| teardown unowned | **28.01 GB / 1,980 allocs** | **1.12 GB / 124 allocs** | **−96%** |

A `grep -c` for the four sidecar/twin ledger sites (`loaders_fp8.rs:229`, `:230`, `quantized.rs:261`, `:262`) over the whole after-serve log returns **0**. By file, `loaders_fp8.rs` collapses 10,080 MB → **4.7 MB**, `quantized.rs` 11,680 MB → 160 MB, and `quantized.rs:643` (1,600 MB) is gone. The 76.14 GB ledger *total* is unchanged only because the freed memory was immediately re-spent on the ring and the KV cache.

The remaining 1.12 GB of unowned bytes is `quant_helpers.rs:98` (710 MB ×7) and four `impl_a1_init.rs` sites (352 MB) — **nothing from `load_layers`**. Both before and after also emit `backend drop reclaimed …` after the sweep, so nothing leaked in either case; what changed is the accounting.

Coherency gate `4/4` (`COH_EXIT=0`) on the after-build, 16/16 on a concurrent arithmetic probe, and `nvidia-smi` moved **+16 MiB across a full ladder** — memory flat, no leak.

### Throughput — read this carefully

At that config, with the other levers in the round-6 recipe (batched GDN, head band 16, cuBLASLt FFN prefill, `ATLAS_FFN_NO_BATCH16=1`) and the **full 8-slot SSM decode ring at batch 16** (`ring: 8 slots x 16 seqs x 151.5 MB/seq = 18.94 GB`), which the freed memory is what made bootable:

| shape | C | tok/s before → after | TPOT before → after |
|---|---|---|---|
| 1193 / 256 | 1 | 43.63 (TTFT 442 ms) | — |
| 1193 / 256 | 16 | 135.80 → **228.02** agg (+67.9%) | 100.74 → **55.62 ms** |
| 4593 / 512 | 1 | 37.41 (TTFT 1,420 ms) | — |
| 4593 / 512 | 16 | 118.62 → **177.60** agg (+49.7%) | — |

**Say plainly what that delta is.** It is **the ring depth the freed memory funded, not this PR's arithmetic** — which is unchanged. Before the fix the 8-slot ring at batch 16 could not fit and the serve ran on 1 slot; after it, `--ssm-decode-ring-slots auto` was accepted on the first boot. The throughput numbers belong to the recipe. **The memory numbers above are this PR's own receipt.**

**What this evidence does not establish.** One box, one model, one session. It says nothing about GB10. The C=16 throughput leg is confounded by the rest of the round-6 recipe by construction and is reported as context, not as a claim.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda loader` — **61 passed, 0 failed** (1 ignored)
- [x] `cargo test -p spark-model --features cuda dense` — **98 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda residency` — **29 passed, 0 failed** (the new decision-table suite)
- [x] `cargo test -p spark-model --features cuda ledger` — **3 passed, 0 failed**
- [x] `cargo test -p spark-runtime --lib --features cuda derived` — **8 passed, 0 failed**
- [x] `cargo test -p spark-runtime --lib --features cuda teardown` — **8 passed, 0 failed**
- [x] `cargo test -p spark-runtime --lib --features cuda weights` — **93 passed, 0 failed** (3 ignored)
- [x] `cargo clippy -p spark-model -p spark-runtime -p spark-server --tests --features cuda,nccl` — clean, no warnings emitted. `spark-server` is in the invocation only because `nccl` is its feature; the two crates this PR edits are both covered.
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] Tested against real hardware — the H100 receipts above (2026-09-11).

- [ ] `scripts/hopper_ptx_gate.sh` — **not applicable**: these five commits touch **no `.cu`, no `.cuh` and no `kernels/` file at all**. Nothing new is compiled; this PR only decides which buffers get allocated.

The new CPU tests are the load-bearing part, because the claim they pin is a negative — "no kernel on this route reads an NVFP4 buffer" — and a negative cannot be proved by a benchmark:

- `fp8_residency_tests.rs` (17 cases) is the decision table under test: the default route builds no NVFP4 and only the KV FP8 twins; the KV twins survive **every** default route variation; the FFN and attention overlays are decided independently; `ATLAS_FP8_SINGLE_SCALE` brings the Q and O twins back; a target without the W8A8 kernels keeps every FP8 twin; each `ATLAS_ATTN_*` lever keeps exactly the NVFP4 copies it can reach; the escape hatch restores the pre-#915 loader and **cannot invent FP8 twins on a non-FP8 layer**; and the H100 ledger rows reproduce from the model shapes.
- `dense_ffn_fp8_residency_tests.rs` pins the claim the 18.4 GiB rested on — `every_small_batch_entry_point_runs_without_nvfp4_weights`, `the_mmq_finalizers_are_no_ops_under_a_native_fp8_overlay`, `the_verify_arm_still_selects_this_layer_without_nvfp4_weights`. **Each is red before this change.**
- `teardown_tests.rs` adds `releasing_frees_adopted_derived_buffers_too`, `releasing_twice_is_harmless_for_derived_buffers`, and `an_unadopted_derived_buffer_is_what_the_sweep_would_report` — the last one is the regression the whole PR is about, written so it fails if adoption is ever dropped.

## GB10 perf-gate records

This diff touches `crates/`, a `PERF_PATH`, so `record_covers` invalidates every committed `.benchmarks/` record on landing. **A GB10 re-measure is owed before merge.** The H100 evidence above is from a different card and does not substitute for it.

## Notes for reviewers

**The risk in this diff is a false negative in the decision table, not a wrong number.** If `DenseFp8Plan::resolve` says "not reachable" about a buffer some lever *can* route to, the failure is a NULL read at a dispatch site — a CUDA-700, loud and immediate, not a silent precision loss. That is the intended failure mode and it is why the table is a pure function with 17 CPU cases over it rather than a set of `if`s at the allocation sites. The contract is stated in the module header: **any new lever that can route a native-FP8 layer back onto an NVFP4 kernel must be added to `DenseFp8Plan::resolve` as well as to the dispatch site.**

**Why K and V twins stay and Q and O go.** `prefill/cache_skip_qkv.rs` has no W8A8 arm, and it is the first-chunk path of *every* request. Dropping the K/V twins would have been the same 1,600 MB and would have broken the common case. This asymmetry is the one place the residency rule is not "FP8 means no twin", and it is pinned by `the_kv_fp8_twins_survive_every_default_route_variation`.

**`prune_after_load` is the use-after-free surface.** It frees store tensors by name, and the only thing keeping it honest is that the loader and the pruner ask `gdn_fp8_arm_selected` the same question. Reviewers should check that single shared predicate rather than the two call sites — if those ever drift, the symptom is a corrupted weight with no diagnostic, not a crash.

**`can_forward_km` deliberately still returns `true` for a layer with NULL NVFP4 weights.** That reads like a bug and is not: it is a dispatch gate, and this PR's whole discipline is to change the footprint without moving the dispatch. `forward_km` redirects FP8 layers to `forward_prefill` before any NVFP4 pointer is touched.

All five commits **cherry-picked cleanly onto `main`** with `-x` provenance lines — **no conflicts**, no adaptation, every hunk applied to an identical pre-image. `dense_ffn.rs` (the file most likely to have moved under #987/#988) auto-merged. This PR is **not stacked** on anything.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
