### PR TITLE
spark-server: size the SSM rollback ring against the predicted post-load KV headroom (#915)

### DIFF
--- a/crates/spark-model/src/layers/dense_ffn.rs
+++ b/crates/spark-model/src/layers/dense_ffn.rs
@@ -467,6 +467,14 @@ impl DenseFfnLayer {
         if self.q2_weights.is_some() {
             return Ok(());
         }
+        // Native FP8 (#915): `forward_prefill_inner` returns from inside its
+        // `self.fp8_weights` arm long before the Q4_K/MMQ arm, so this repack
+        // is dead work — and since #915 the loader installs NULL NVFP4 source
+        // weights on that route, over which `ensure_q4k_weight`'s dequant is a
+        // CUDA-700 illegal access. Same reason as the packed-Q2 guard above.
+        if self.fp8_weights.is_some() {
+            return Ok(());
+        }
         let q4k_active = self.q4k_mmq_nc_k.0 != 0
             && self.q4k_quant_act_k.0 != 0
             && self.q4k_quant_w_k.0 != 0
@@ -563,6 +571,13 @@ impl DenseFfnLayer {
         // present) and repacks the NVFP4 gate/up — over NULL pointers that's a
         // CUDA-700 illegal access. Packed-Q2 uses its own decode/prefill path.
         if self.q2_weights.is_some() {
+            return Ok(());
+        }
+        // Native FP8 (#915): same reasoning as `finalize_q4k_load`, and this
+        // one is active by DEFAULT wherever the W4A4-MMQ kernels exist — so on
+        // a target that ships them it would repack NULL NVFP4 gate/up AND free
+        // `_t` copies for a prefill arm the FP8 early-return never reaches.
+        if self.fp8_weights.is_some() {
             return Ok(());
         }
         let active = self.nvfp4_mmq_nc_k.0 != 0
@@ -1552,7 +1567,15 @@ impl DenseFfnLayer {
     /// (batchm kernel present AND NVFP4 weights loaded — the batchm GEMV
     /// reads the non-transposed NVFP4 layout).
     pub fn can_forward_km(&self, m: u32) -> bool {
-        self.batchm_kernel(m).0 != 0 && !self.weights.gate_proj.weight.is_null()
+        self.batchm_kernel(m).0 != 0
+            && (!self.weights.gate_proj.weight.is_null()
+                // Native FP8 (#915): the loader no longer builds the NVFP4
+                // fallback, but `forward_km` redirects to `forward_prefill` for
+                // an FP8 layer anyway (`native_small_batch_uses_prefill`), so
+                // the answer must stay `true` or the n=4..8 verify arm in
+                // `multi_seq/ffn.rs:145` would fall through to a DIFFERENT
+                // branch and quietly change the routing this fix must not touch.
+                || self.fp8_weights.is_some())
     }
 
     /// K=m (m<=8) speculative verify: batched GEMV for m tokens.
@@ -2704,6 +2727,12 @@ mod native_batch_tests;
 #[cfg(test)]
 #[path = "dense_ffn_kernel_tests.rs"]
 mod kernel_tests;
+
+/// #915: the native-FP8 route must work with NO NVFP4 fallback weights, so the
+/// loader can stop allocating 18.4 GiB of them.
+#[cfg(test)]
+#[path = "dense_ffn_fp8_residency_tests.rs"]
+mod fp8_residency_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/spark-model/src/layers/dense_ffn_fp8_residency_tests.rs
+++ b/crates/spark-model/src/layers/dense_ffn_fp8_residency_tests.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The native-FP8 dense FFN must work with NO NVFP4 fallback weights (#915).
+//!
+//! WHY. On 1xH100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`, the loader built an
+//! NVFP4 gate/up/down plus a transposed twin for all 64 layers — 18.4 GiB — on
+//! the strength of a comment that said the batched spec-decode paths had no FP8
+//! branch. They do: `forward_k2`/`forward_k3`/`forward_km` all redirect through
+//! `native_small_batch_uses_prefill`, and `w8_gemm!` binds its transposed
+//! operand to a literal `None`. These tests pin that, so the loader can install
+//! `QuantizedWeight::null()` and the 18.4 GiB stays unallocated.
+//!
+//! Every case here is RED before #915: with a NULL `gate_proj`,
+//! `can_forward_km` returned false (silently rerouting the 4..8-row verify arm)
+//! and `finalize_nvfp4_mmq_load` — active by DEFAULT wherever its kernels
+//! exist — repacked over the null pointers.
+
+use super::{DenseFfnLayer, DenseFfnWeights};
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::ops::{DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::weight_map::{Fp8Weight, QuantizedWeight, WeightQuantFormat};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+
+fn config() -> ModelConfig {
+    let mut config = ModelConfig::qwen3_next_80b_nvfp4();
+    config.hidden_size = 128;
+    config.intermediate_size = 128;
+    config.num_experts = 1;
+    config.num_experts_per_tok = 1;
+    config.moe_intermediate_size = 128;
+    config.vocab_size = 128;
+    config
+}
+
+/// Exactly what `qwen35_dense.rs` now builds on the native-FP8 route: NULL
+/// NVFP4 fallbacks, no transposed twins, an FP8 overlay on top.
+fn native_fp8_layer(gpu: &MockGpuBackend) -> DenseFfnLayer {
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: QuantizedWeight::null(),
+            up_proj: QuantizedWeight::null(),
+            down_proj: QuantizedWeight::null(),
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        gpu,
+    )
+    .unwrap();
+    layer.w8a16_gemm_k = KernelHandle(0xF08);
+    layer.act_mul = KernelHandle(0xAC7);
+    let fp8 = Fp8Weight {
+        weight: gpu.alloc(128 * 128).unwrap(),
+        row_scale: gpu.alloc(4).unwrap(),
+        n: 128,
+        k: 128,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    };
+    layer.set_fp8_weights(fp8, fp8, fp8);
+    layer
+}
+
+/// Turn on every handle the two load-time MMQ finalizers check, so the test
+/// exercises the arm a real Blackwell/GB10 kernel set would enable rather than
+/// passing because the handles happen to be zero.
+fn arm_the_mmq_finalizers(layer: &mut DenseFfnLayer) {
+    for h in [
+        &mut layer.q4k_mmq_nc_k,
+        &mut layer.q4k_quant_act_k,
+        &mut layer.q4k_quant_w_k,
+        &mut layer.dequant_nvfp4_bf16_k,
+        &mut layer.nvfp4_mmq_nc_k,
+        &mut layer.nvfp4_quant_act_k,
+        &mut layer.nvfp4_repack_k,
+        &mut layer.nvfp4_silu_scaled_k,
+    ] {
+        *h = KernelHandle(0xBEEF);
+    }
+}
+
+fn with_ctx(gpu: &MockGpuBackend, f: impl FnOnce(&ForwardContext, &BufferArena)) {
+    let config = config();
+    let buffers = BufferArena::new(&config, 8, 256, 256, 8, gpu).unwrap();
+    let dispatch = GemmDispatch::defaults();
+    let derived = DerivedWeights::new();
+    let levers = ModelLevers::defaults();
+    let stats = ModelStats::new();
+    let ctx = ForwardContext {
+        buffers: &buffers,
+        hc_row_offset: 0,
+        gpu,
+        config: &config,
+        dispatch: &dispatch,
+        derived: &derived,
+        levers: &levers,
+        stats: &stats,
+        attn_metadata: None,
+        profile: false,
+        comm: None,
+        graph_capture: false,
+        decode_step: false,
+        gdn_exact_replay: false,
+        token_ids: None,
+        host_token_ids: None,
+        routed_lora_layers: None,
+        midchunk_capture: None,
+        moe_lora_route: MoeLoraRoute::Fold,
+    };
+    f(&ctx, &buffers);
+}
+
+#[test]
+fn the_verify_arm_still_selects_this_layer_without_nvfp4_weights() {
+    // `multi_seq/ffn.rs:145` gates the 4..=8-row verify branch on this. It must
+    // not change answer just because the NVFP4 fallback is gone, or the fix
+    // would silently reroute decode as well as shrink it.
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_layer(&gpu);
+    for rows in 1..=8 {
+        assert!(
+            layer.can_forward_km(rows),
+            "native FP8 layer must stay eligible at m={rows}"
+        );
+    }
+}
+
+#[test]
+fn a_layer_with_neither_nvfp4_nor_fp8_weights_is_not_eligible() {
+    // The guard `can_forward_km` actually exists for: packed-Q2 and any other
+    // route whose NVFP4 weights are NULL with nothing installed over them.
+    let gpu = MockGpuBackend::new();
+    let mut layer = DenseFfnLayer::new(
+        DenseFfnWeights {
+            gate_proj: QuantizedWeight::null(),
+            up_proj: QuantizedWeight::null(),
+            down_proj: QuantizedWeight::null(),
+            gate_proj_t: None,
+            up_proj_t: None,
+            down_proj_t: None,
+        },
+        &gpu,
+    )
+    .unwrap();
+    layer.act_mul = KernelHandle(0xAC7);
+    assert!(!layer.can_forward_km(4));
+}
+
+#[test]
+fn the_mmq_finalizers_are_no_ops_under_a_native_fp8_overlay() {
+    // `finalize_nvfp4_mmq_load` is active by DEFAULT (no opt-in env) wherever
+    // its four kernels exist. Over NULL NVFP4 sources that is a CUDA-700; and
+    // even over real ones it is dead work, because `forward_prefill_inner`
+    // returns from the FP8 arm long before the MMQ arm.
+    let gpu = MockGpuBackend::new();
+    let mut layer = native_fp8_layer(&gpu);
+    arm_the_mmq_finalizers(&mut layer);
+    let allocs = gpu.alloc_count();
+    let launches = gpu.launch_count();
+    layer.finalize_q4k_load(&gpu, 128, 128, 7).unwrap();
+    layer.finalize_nvfp4_mmq_load(&gpu, 128, 128, 7).unwrap();
+    assert_eq!(gpu.alloc_count(), allocs, "no MMQ repack may be allocated");
+    assert_eq!(gpu.launch_count(), launches, "no kernel may be launched");
+}
+
+#[test]
+fn every_small_batch_entry_point_runs_without_nvfp4_weights() {
+    // The claim the 18.4 GiB rested on: "the batched spec-decode forward_k2/k3
+    // paths have no FP8 branch". They redirect to `forward_prefill`; if any of
+    // these reached a w4a16 dispatch it would read a NULL pointer, which on the
+    // mock backend surfaces as a launch carrying the null buffer.
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_layer(&gpu);
+    with_ctx(&gpu, |ctx, buffers| {
+        let start = gpu.launch_count();
+        let allocs = gpu.alloc_count();
+        let input = buffers.norm_output();
+        layer.forward(input, ctx, 7).unwrap();
+        layer.forward_k2(input, ctx, 7).unwrap();
+        layer.forward_k3(input, ctx, 7).unwrap();
+        layer.forward_km(input, 4, ctx, 7).unwrap();
+        layer.forward_prefill(input, 64, ctx, 7).unwrap();
+        assert_eq!(
+            gpu.alloc_count(),
+            allocs,
+            "dispatch must not allocate weight copies"
+        );
+        let launches = gpu.launches_snapshot();
+        assert!(launches.len() > start, "the forwards must have dispatched");
+        for launch in &launches[start..] {
+            for arg in &launch.args {
+                if let spark_runtime::gpu::mock::MockArg::Buffer(p) = arg {
+                    assert!(
+                        !p.is_null(),
+                        "a NULL NVFP4 weight reached a kernel launch: {launch:?}"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -188,15 +188,18 @@ impl Qwen3AttentionLayer {
                 "w8a16_gemm_t_m128",
                 "w8a16_gemm_t_m128",
             ),
+            // Spelled through `W8A8_PREFILL_KERNELS` (#915): preflight asks
+            // the backend for the SAME two kernels to predict, before the
+            // load, whether the Q/O FP8 prefill twins will be built.
             per_token_group_quant_fp8_k: super::super::try_kernel(
                 gpu,
-                "per_token_group_quant_fp8",
-                "per_token_group_quant_fp8",
+                super::types_weights::W8A8_PREFILL_KERNELS[0].0,
+                super::types_weights::W8A8_PREFILL_KERNELS[0].1,
             ),
             fp8_gemm_t_blockscaled_k: super::super::try_kernel(
                 gpu,
-                "fp8_gemm_t_blockscaled",
-                "fp8_gemm_t_blockscaled",
+                super::types_weights::W8A8_PREFILL_KERNELS[1].0,
+                super::types_weights::W8A8_PREFILL_KERNELS[1].1,
             ),
             rms_norm_k: gpu.kernel("norm", "rms_norm")?,
             rms_norm_w_k: if crate::ships_vanilla_norm_weights(config) {

--- a/crates/spark-model/src/layers/qwen3_attention/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/mod.rs
@@ -43,7 +43,7 @@ pub use innerq_driver::InnerQDriver;
 pub(crate) use types::HeadGateActivation;
 pub use types::Qwen3AttentionLayer;
 pub use types_weights::{
-    CompressorWeights, HcHeadWeights, HcLowRank, HcSiteWeights, HcWeights, MlaWeights,
+    CompressorWeights, Fp8TwinSet, HcHeadWeights, HcLowRank, HcSiteWeights, HcWeights, MlaWeights,
 };
 
 /// Startup fail-fast for `--kv-cache-dtype`: resolve every kernel handle the

--- a/crates/spark-model/src/layers/qwen3_attention/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/mod.rs
@@ -44,6 +44,7 @@ pub(crate) use types::HeadGateActivation;
 pub use types::Qwen3AttentionLayer;
 pub use types_weights::{
     CompressorWeights, Fp8TwinSet, HcHeadWeights, HcLowRank, HcSiteWeights, HcWeights, MlaWeights,
+    W8A8_PREFILL_KERNELS, w8a8_prefill_kernels_loaded,
 };
 
 /// Startup fail-fast for `--kv-cache-dtype`: resolve every kernel handle the

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_weights.rs
@@ -9,7 +9,8 @@ use anyhow::Result;
 use spark_runtime::gpu::{DevicePtr, GpuBackend};
 
 use super::types::Qwen3AttentionLayer;
-use crate::weight_map::{Fp8Weight, QuantWeight, QuantizedWeight};
+use super::types_weights::Fp8TwinSet;
+use crate::weight_map::{Fp8Weight, Fp8WeightTransposed, QuantWeight, QuantizedWeight};
 
 impl Qwen3AttentionLayer {
     /// Dispatch the M=128 W4A16 prefill GEMM. Routes to the v2 shadow
@@ -342,13 +343,40 @@ impl Qwen3AttentionLayer {
         anyhow::bail!("LoRA: router/expert deltas installed on a layer with no MoE FFN component")
     }
 
+    /// Whether BOTH kernels the W8A8 block-scaled prefill arm needs are
+    /// loaded for this target (`prefill/paged_qkv.rs:220`,
+    /// `prefill/paged_oproj.rs:94`). The loader asks this to decide whether the
+    /// Q and O FP8 prefill twins are reachable at all (#915).
+    pub fn has_w8a8_prefill_kernels(&self) -> bool {
+        self.per_token_group_quant_fp8_k.0 != 0 && self.fp8_gemm_t_blockscaled_k.0 != 0
+    }
+
     /// Transpose FP8 weights for fast prefill (`w8a16_gemm_t`: coalesced
     /// reads). Must be called after [`Self::set_fp8_weights`]. Allocates
     /// new GPU buffers.
+    ///
+    /// Builds all four twins and gives them no owner — the pre-#915 behaviour,
+    /// kept for the loaders that have not been given a residency plan.
     pub fn transpose_fp8_for_prefill(
         &mut self,
         gpu: &dyn GpuBackend,
         stream: u64,
+    ) -> anyhow::Result<()> {
+        self.transpose_fp8_for_prefill_selected(gpu, stream, Fp8TwinSet::ALL, None)
+    }
+
+    /// [`Self::transpose_fp8_for_prefill`], building only `want` and handing
+    /// each result to `derived` so teardown RELEASES it instead of the backend
+    /// sweep reclaiming it unowned (#736, #915).
+    ///
+    /// `want` comes from the loader's residency plan; which projection is
+    /// reachable on which prefill chain is documented on [`Fp8TwinSet`].
+    pub fn transpose_fp8_for_prefill_selected(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        stream: u64,
+        want: Fp8TwinSet,
+        derived: Option<&spark_runtime::weights::DerivedStore>,
     ) -> anyhow::Result<()> {
         // Load-time decision, taken in the weight loader before any
         // `TransformerModel` exists to carry the config. Resolved at the point
@@ -360,27 +388,43 @@ impl Qwen3AttentionLayer {
             );
             return Ok(());
         }
+        if !want.any() {
+            return Ok(());
+        }
         if self.w8a16_gemm_t_k.0 == 0 {
             return Ok(()); // kernel not available
         }
         let transpose_k = gpu.kernel("w8a16_gemm_t", "transpose_fp8")?;
         let transpose_scale_k = gpu.kernel("w8a16_gemm_t", "transpose_block_scale")?;
 
-        if let Some(w) = self.q_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.q_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        let build = |src: Option<&QuantWeight>| -> anyhow::Result<Option<Fp8WeightTransposed>> {
+            let Some(w) = src.and_then(|w| w.as_fp8()) else {
+                return Ok(None);
+            };
+            let t = w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?;
+            if let Some(d) = derived {
+                let (n, k) = (w.n as usize, w.k as usize);
+                d.adopt("attn fp8 prefill twin (weight_t)", t.weight_t, n * k);
+                d.adopt(
+                    "attn fp8 prefill twin (scale_t)",
+                    t.scale_t,
+                    n.div_ceil(128) * k.div_ceil(128) * 4,
+                );
+            }
+            Ok(Some(t))
+        };
+
+        if want.q {
+            self.q_fp8w_t = build(self.q_weight.as_ref())?;
         }
-        if let Some(w) = self.k_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.k_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.k {
+            self.k_fp8w_t = build(self.k_weight.as_ref())?;
         }
-        if let Some(w) = self.v_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.v_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.v {
+            self.v_fp8w_t = build(self.v_weight.as_ref())?;
         }
-        if let Some(w) = self.o_weight.as_ref().and_then(|w| w.as_fp8()) {
-            self.o_fp8w_t =
-                Some(w.transpose_for_gemm(gpu, transpose_k, transpose_scale_k, stream)?);
+        if want.o {
+            self.o_fp8w_t = build(self.o_weight.as_ref())?;
         }
         Ok(())
     }

--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -276,3 +276,30 @@ impl Fp8TwinSet {
         self.q || self.k || self.v || self.o
     }
 }
+
+/// The two `(module, function)` pairs the W8A8 block-scaled prefill arm needs
+/// (`prefill/paged_qkv.rs:220`, `prefill/paged_oproj.rs:94`).
+///
+/// SSOT for three readers that must not drift (#915): `init.rs` resolves the
+/// handles, `Qwen3AttentionLayer::has_w8a8_prefill_kernels` tests them, and
+/// [`w8a8_prefill_kernels_loaded`] asks the BACKEND the same question before
+/// any layer exists — which is what lets preflight predict, pre-load, whether
+/// the Q and O FP8 prefill twins will be built. A name typo'd in one of the
+/// three would mis-predict ~1.5 GB of residency on the 27B in silence.
+pub const W8A8_PREFILL_KERNELS: [(&str, &str); 2] = [
+    ("per_token_group_quant_fp8", "per_token_group_quant_fp8"),
+    ("fp8_gemm_t_blockscaled", "fp8_gemm_t_blockscaled"),
+];
+
+/// Whether BOTH [`W8A8_PREFILL_KERNELS`] are loaded for this target, asked of
+/// the backend rather than of a constructed layer.
+///
+/// Same answer `Qwen3AttentionLayer::has_w8a8_prefill_kernels` gives — the
+/// layer just caches the handles `init.rs` already resolved through
+/// `try_kernel`, and `try_kernel` returns `KernelHandle(0)` for an absent
+/// kernel exactly as this does.
+pub fn w8a8_prefill_kernels_loaded(gpu: &dyn spark_runtime::gpu::GpuBackend) -> bool {
+    W8A8_PREFILL_KERNELS
+        .iter()
+        .all(|(module, func)| crate::layers::try_kernel(gpu, module, func).0 != 0)
+}

--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -226,3 +226,50 @@ pub struct HcWeights {
     /// final norm and the checkpoint ships no `model.norm.weight`.
     pub is_last_model_layer: bool,
 }
+
+/// Which of the four attention projections get an FP8 `[K, N]` transposed twin
+/// built by [`Qwen3AttentionLayer::transpose_fp8_for_prefill`].
+///
+/// WHY per projection and not one flag (#915): the four are reached by
+/// DIFFERENT prefill chains and only two of them are W8A8-gated.
+///
+/// * **K and V** are read by `prefill/cache_skip_qkv.rs:218` / `:235`, whose
+///   dispatch chain has **no W8A8 arm at all** — and `cache_skip` is the
+///   first-chunk path (`trait_impl/prefill_inner.rs:138`, `seq_len_start == 0`)
+///   taken by every request. Their twins are never dead.
+/// * **Q** on that chain is behind `ATLAS_ATTN_PREFILL_Q_T=1`
+///   (`cache_skip_qkv.rs:142`); otherwise it is reached only after the W8A8
+///   arm in `prefill/paged_qkv.rs:220` declines.
+/// * **O** is routed to `prefill/paged_oproj.rs` from both chains, so it is
+///   reached only after the W8A8 arm at `paged_oproj.rs:94` declines.
+///
+/// On 1xH100 (Qwen3.8-27B-FP8) the four cost 100 MiB/layer x 16 layers =
+/// 1,600 MB — the `weight_map/quantized.rs:643` ledger row.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Fp8TwinSet {
+    pub q: bool,
+    pub k: bool,
+    pub v: bool,
+    pub o: bool,
+}
+
+impl Fp8TwinSet {
+    pub const NONE: Self = Self {
+        q: false,
+        k: false,
+        v: false,
+        o: false,
+    };
+    /// Every twin — what a loader that has not opted into the #915 plan asks
+    /// for, i.e. the pre-#915 behaviour.
+    pub const ALL: Self = Self {
+        q: true,
+        k: true,
+        v: true,
+        o: true,
+    };
+
+    pub fn any(self) -> bool {
+        self.q || self.k || self.v || self.o
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/types_weights.rs
@@ -230,6 +230,9 @@ pub struct HcWeights {
 /// Which of the four attention projections get an FP8 `[K, N]` transposed twin
 /// built by [`Qwen3AttentionLayer::transpose_fp8_for_prefill`].
 ///
+/// [`Qwen3AttentionLayer::transpose_fp8_for_prefill`]:
+///     super::Qwen3AttentionLayer::transpose_fp8_for_prefill
+///
 /// WHY per projection and not one flag (#915): the four are reached by
 /// DIFFERENT prefill chains and only two of them are W8A8-gated.
 ///

--- a/crates/spark-model/src/model/impl_a1.rs
+++ b/crates/spark-model/src/model/impl_a1.rs
@@ -275,8 +275,9 @@ impl TransformerModel {
         // therefore unreachable, and on this model it is NOT cheap: 8 slots x
         // max_batch x the full SSM blob (27B: 158.9 MB) = ~19.9 GB at batch 16,
         // allocated up front. Skip it when speculative decode is on.
-        // The ring-depth decision (env overrides + speculative/watchdog
-        // skip) is SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
+        // The ring-depth decision (the published `--ssm-decode-ring-slots` /
+        // #915 auto-fit depth, env overrides, speculative/watchdog skip) is
+        // SSOT'd in `crate::ssm_reserve::decode_rollback_ring_slots`
         // — spark-server's `preflight_reserve` calls the SAME helper, so the
         // GPU reservation and this allocation cannot drift. The scheduler
         // keys off `decode_rollback_ring_slots()`, so a 0 here disables save

--- a/crates/spark-model/src/ssm_reserve.rs
+++ b/crates/spark-model/src/ssm_reserve.rs
@@ -1,48 +1,32 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! SSOT for the Phase-C decode-rollback ring depth.
+//! SSOT for the SSM/linear-attention GPU reserve terms.
 //!
-//! Two call sites MUST agree on this number or a serve either
-//! under-reserves (runtime CUDA alloc failure after weights load) or
-//! over-reserves (preflight refuses batch sizes the runtime could fund):
+//! Every term here is computed TWICE — once by `spark-server`'s
+//! `preflight_reserve` before the weights load, once by the allocating call
+//! site (`SsmStatePool::new`, `TransformerModel::new`) after — and the two
+//! MUST agree or a serve either under-reserves (runtime CUDA alloc failure)
+//! or over-reserves (preflight refuses a configuration the runtime could
+//! fund). Each function below is the one place that decision is made.
 //!
-//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
-//!   reservation before weights load;
-//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
-//!
-//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
-//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
-//! speculative path does its rejection rollback through the verify snapshot,
-//! never this ring. Under `--speculative` the ring is unreachable, and it is
-//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
-//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
-//! while the runtime skipped it capped the native batch at ~20 on GB10
-//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
-//!
-//! Env contract (read HERE and nowhere else):
-//!
-//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
-//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
-//!   should keep loop re-steer); `=0` force-disables it even without spec.
-//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
-//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
-//!   never fire, so the ring is skipped.
+//! The Phase-C decode-rollback ring DEPTH — its publication cell, the
+//! `ATLAS_SSM_DECODE_RING` / `ATLAS_DISABLE_WATCHDOGS` contract and the #915
+//! auto-fit — lives in the `decode_ring` sibling module and is re-exported
+//! here, so every existing `ssm_reserve::decode_rollback_ring_slots` path is
+//! unchanged.
 
-/// Outcome of the ring-depth decision.
-///
-/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
-/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
-/// override — so the allocating call site can log the savings once.
-pub struct DecodeRingDecision {
-    pub slots: usize,
-    pub skip_reason: Option<&'static str>,
-}
+mod decode_ring;
+pub use decode_ring::{
+    DECODE_RING_FIT_LADDER, DecodeRingDecision, decode_rollback_ring_slots,
+    decode_rollback_ring_slots_with, fit_decode_ring_slots, parse_decode_ring_slots,
+    published_decode_ring_slots, set_decode_ring_slots, watchdogs_disabled_from_value,
+};
 
 /// Number of SSM-pool slots the MTP/DFlash VERIFY state pools (per-token
 /// intermediates + pre-verify checkpoints) must cover.
 ///
 /// Three call sites MUST agree on this number (same contract as the decode
-/// ring above):
+/// ring in `decode_ring`):
 ///
 /// * `spark-server` `preflight_reserve` — sizes the pre-load GPU reserve;
 /// * `SsmStatePool::new` — allocates the intermediate/checkpoint pools;
@@ -425,71 +409,6 @@ pub fn ssm_replay_ring_bytes(
     mtp_state_slots: usize,
 ) -> usize {
     mtp_state_slots * k_ceiling.saturating_sub(1) * num_ssm_layers * row_bytes
-}
-
-/// Decide the per-sequence decode-rollback ring depth.
-///
-/// `use_speculative` MUST be the same flag `factory::build_model` receives
-/// (`--speculative || --dflash` as plumbed by spark-server) at every call
-/// site, or preflight and allocation diverge.
-pub fn decode_rollback_ring_slots(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-) -> DecodeRingDecision {
-    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
-    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
-    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
-    decode_rollback_ring_slots_with(
-        num_ssm_layers,
-        use_speculative,
-        ring_override.as_deref(),
-        watchdogs_disabled,
-    )
-}
-
-fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
-    value
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v == "1" || v == "true"
-        })
-        .unwrap_or(false)
-}
-
-fn decode_rollback_ring_slots_with(
-    num_ssm_layers: usize,
-    use_speculative: bool,
-    ring_override: Option<&str>,
-    watchdogs_disabled: bool,
-) -> DecodeRingDecision {
-    if num_ssm_layers == 0 {
-        return DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        };
-    }
-    match ring_override {
-        Some("1") => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-        Some("0") => DecodeRingDecision {
-            slots: 0,
-            skip_reason: None,
-        },
-        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
-            slots: 0,
-            skip_reason: Some(if use_speculative {
-                "speculative decode active"
-            } else {
-                "watchdogs disabled"
-            }),
-        },
-        _ => DecodeRingDecision {
-            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
-            skip_reason: None,
-        },
-    }
 }
 
 /// Outcome of the Marconi snapshot-slot decision.

--- a/crates/spark-model/src/ssm_reserve/decode_ring.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT for the Phase-C decode-rollback ring DEPTH.
+//!
+//! A sibling of `ssm_reserve.rs` (which sits over the 500-line cap),
+//! following the `per_sequence_state.rs` precedent: the depth decision, its
+//! publication cell and the #915 auto-fit live here.
+//!
+//! Two call sites MUST agree on this number or a serve either under-reserves
+//! (runtime CUDA alloc failure after weights load) or over-reserves
+//! (preflight refuses batch sizes the runtime could fund):
+//!
+//! * `spark-server` `preflight_reserve` — sizes the SSM-snapshot GPU
+//!   reservation before weights load;
+//! * `TransformerModel::new` (`impl_a1.rs`) — allocates the actual ring.
+//!
+//! The ring's ONLY writer (scheduler `snapshot_boundary_if_ssm`) and reader
+//! (content-loop `rollback_to_boundary`) live on the PLAIN decode path — the
+//! speculative path does its rejection rollback through the verify snapshot,
+//! never this ring. Under `--speculative` the ring is unreachable, and it is
+//! NOT cheap: 8 slots × max_batch × the full SSM blob (27B: 158.9 MB) is
+//! ~19 GB at batch 16 and ~38 GB at batch 32. Reserving it unconditionally
+//! while the runtime skipped it capped the native batch at ~20 on GB10
+//! (SSM reserve 75.2 GB vs an 85.2 GB budget at util 0.70).
+//!
+//! ## Why the depth is now sized from free memory (#915)
+//!
+//! The depth was a CONSTANT (8) multiplied by `--max-batch-size`, so it grew
+//! with a flag that says nothing about what the card can hold. Serving
+//! Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) asked
+//! for 8 × 32 × 151.5 MiB = 37.88 GiB of ring alone — an inference reserve of
+//! 45,823 MiB against a 71.3 GiB budget with 57.2 GiB of weights — and the
+//! serve REFUSED to boot (rental H100, 2026-09-05). The recipe workaround was
+//! `--max-batch-size 4`, i.e. paying for rollback depth with four fifths of
+//! the serve's concurrency.
+//!
+//! The ring degrades gracefully with depth (fewer retained boundaries = fewer
+//! reachable re-steer anchors, never wrong output), so preflight now SHRINKS
+//! it down the [`DECODE_RING_FIT_LADDER`] until the reserve fits and publishes
+//! the chosen depth through [`set_decode_ring_slots`], instead of refusing.
+//! Refusal is kept only for the case where even depth 0 does not fit.
+//!
+//! Env contract (read HERE and nowhere else):
+//!
+//! * `ATLAS_SSM_DECODE_RING=1` force-allocates the ring even under spec
+//!   (mixed workloads whose grammar-bound sequences fall to plain decode and
+//!   should keep loop re-steer); `=0` force-disables it even without spec.
+//! * `ATLAS_DISABLE_WATCHDOGS=1|true` (trimmed, case-insensitive — mirrors
+//!   spark-server's `parse_disable_watchdogs`): the ring's only reader can
+//!   never fire, so the ring is skipped.
+
+/// Outcome of the ring-depth decision.
+///
+/// `skip_reason` is `Some` only for the IMPLICIT skip (speculative decode /
+/// watchdogs off) — never for an explicit `ATLAS_SSM_DECODE_RING=0`
+/// override, a published `--ssm-decode-ring-slots N` or the #915 auto-fit —
+/// so the allocating call site can log the savings once.
+pub struct DecodeRingDecision {
+    pub slots: usize,
+    pub skip_reason: Option<&'static str>,
+}
+
+/// Depths preflight's #915 auto-fit may choose from, LARGEST FIRST.
+///
+/// Halving rather than decrementing: each rung halves the ring's share of
+/// the reserve, so at most four steps separate "the default" from "no ring",
+/// and every rung is a power of two — the ring's slot assignment is
+/// `(next_slot + 1) % capacity` (`SsmDecodeRing::record`), which is exact at
+/// any capacity but wraps most evenly at these.
+///
+/// 8 is [`atlas_kernels::DECODE_ROLLBACK_RING_SLOTS`] and covers the
+/// 3-repeat fuzzy loop detector with margin; 1 still anchors a single clean
+/// boundary; 0 means the sequence hard-stops instead of re-steering
+/// (`RollbackFallback::NoSsmSnapshot` — an honest decline, never a partial
+/// rewind).
+pub const DECODE_RING_FIT_LADDER: [usize; 5] = [8, 4, 2, 1, 0];
+
+/// The depth published by the serve command line (`--ssm-decode-ring-slots
+/// N`) or by preflight's auto-fit. Written once, read by BOTH sizing call
+/// sites — same first-write-wins cell pattern as
+/// [`super::set_ssm_rollback_mode`].
+///
+/// Absent is NOT a value: `--ssm-decode-ring-slots auto` publishes nothing,
+/// so the documented `ATLAS_SSM_DECODE_RING` fallback stays reachable and
+/// preflight can publish the auto-fit depth later in the same boot.
+static DECODE_RING_SLOTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// Publish the decode-ring depth. Returns the value in force (first write
+/// wins, matching `gdn_flags::set_from_cli`): an explicit
+/// `--ssm-decode-ring-slots N` is published before preflight runs, so the
+/// auto-fit's later write is a no-op and an operator's explicit depth is
+/// never silently shrunk.
+pub fn set_decode_ring_slots(slots: usize) -> usize {
+    let _ = DECODE_RING_SLOTS.set(slots);
+    *DECODE_RING_SLOTS.get().expect("just set")
+}
+
+/// The published depth, or `None` when nothing has been published.
+///
+/// Does NOT initialize the cell — preflight asks this to tell an EXPLICIT
+/// depth (auto-fit disabled, refuse as before) from `auto` (auto-fit
+/// allowed), and asking must not itself seal the decision.
+pub fn published_decode_ring_slots() -> Option<usize> {
+    DECODE_RING_SLOTS.get().copied()
+}
+
+/// SSOT parse for the `--ssm-decode-ring-slots` value: `auto` (`None` — size
+/// it from free memory at preflight) or an explicit `0..=8`.
+///
+/// `validate_serve_args` and `publish_kernel_flags` both go through THIS, so
+/// what the CLI accepts and what it publishes cannot drift.
+pub fn parse_decode_ring_slots(s: &str) -> Result<Option<usize>, String> {
+    if s == "auto" {
+        return Ok(None);
+    }
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("unknown ssm-decode-ring-slots '{s}' (valid: auto, 0..=8)"))?;
+    if n > atlas_kernels::DECODE_ROLLBACK_RING_SLOTS {
+        return Err(format!(
+            "ssm-decode-ring-slots {n} exceeds the {} the ring is sized for",
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        ));
+    }
+    Ok(Some(n))
+}
+
+/// Decide the per-sequence decode-rollback ring depth.
+///
+/// `use_speculative` MUST be the same flag `factory::build_model` receives
+/// (`--speculative || --dflash` as plumbed by spark-server) at every call
+/// site, or preflight and allocation diverge.
+pub fn decode_rollback_ring_slots(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+) -> DecodeRingDecision {
+    let watchdogs_value = std::env::var("ATLAS_DISABLE_WATCHDOGS").ok();
+    let watchdogs_disabled = watchdogs_disabled_from_value(watchdogs_value.as_deref());
+    let ring_override = std::env::var("ATLAS_SSM_DECODE_RING").ok();
+    decode_rollback_ring_slots_with(
+        num_ssm_layers,
+        use_speculative,
+        published_decode_ring_slots(),
+        ring_override.as_deref(),
+        watchdogs_disabled,
+    )
+}
+
+/// `ATLAS_DISABLE_WATCHDOGS` truthiness — trimmed, case-insensitive, `1` or
+/// `true` only (mirrors spark-server's `parse_disable_watchdogs`).
+pub fn watchdogs_disabled_from_value(value: Option<&str>) -> bool {
+    value
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true"
+        })
+        .unwrap_or(false)
+}
+
+/// Pure core of [`decode_rollback_ring_slots`] (env-free, unit-testable).
+///
+/// Precedence, highest first:
+///
+/// 1. no SSM layers — there is no recurrent state to snapshot;
+/// 2. `published` — `--ssm-decode-ring-slots N`, or the depth preflight's
+///    auto-fit chose. It outranks the env override AND the implicit skips for
+///    the same reason `ATLAS_SSM_DECODE_RING=1` always has: an operator (or a
+///    reserve that has already been sized against free memory) asking for a
+///    specific depth must get that depth on BOTH sides, or the two diverge;
+/// 3. `ATLAS_SSM_DECODE_RING=1|0` — the legacy spelling of "8" and "0";
+/// 4. the implicit skips (speculative decode, watchdogs off);
+/// 5. the default depth.
+pub fn decode_rollback_ring_slots_with(
+    num_ssm_layers: usize,
+    use_speculative: bool,
+    published: Option<usize>,
+    ring_override: Option<&str>,
+    watchdogs_disabled: bool,
+) -> DecodeRingDecision {
+    if num_ssm_layers == 0 {
+        return DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        };
+    }
+    if let Some(slots) = published {
+        return DecodeRingDecision {
+            slots,
+            skip_reason: None,
+        };
+    }
+    match ring_override {
+        Some("1") => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+        Some("0") => DecodeRingDecision {
+            slots: 0,
+            skip_reason: None,
+        },
+        _ if use_speculative || watchdogs_disabled => DecodeRingDecision {
+            slots: 0,
+            skip_reason: Some(if use_speculative {
+                "speculative decode active"
+            } else {
+                "watchdogs disabled"
+            }),
+        },
+        _ => DecodeRingDecision {
+            slots: atlas_kernels::DECODE_ROLLBACK_RING_SLOTS,
+            skip_reason: None,
+        },
+    }
+}
+
+/// Largest [`DECODE_RING_FIT_LADDER`] depth `<= start_slots` whose ring term
+/// still fits in `free_mem` alongside everything else the reserve needs
+/// (#915). Pure — preflight owns the bytes, this owns the ladder.
+///
+/// `bytes_per_ring_slot` is ONE depth unit: `max_batch_size × the per-seq SSM
+/// state blob`, the same product `ssm_snapshot_bytes` multiplies the depth by.
+///
+/// Returns 0 when nothing fits — including the case where the rest of the
+/// reserve ALONE exceeds `free_mem`, which is the caller's cue to refuse with
+/// the existing suggested-batch text rather than to boot a ringless serve.
+pub fn fit_decode_ring_slots(
+    start_slots: usize,
+    reserve_without_ring: usize,
+    bytes_per_ring_slot: usize,
+    free_mem: usize,
+) -> usize {
+    DECODE_RING_FIT_LADDER
+        .iter()
+        .copied()
+        .filter(|&slots| slots <= start_slots)
+        .find(|&slots| {
+            reserve_without_ring.saturating_add(slots.saturating_mul(bytes_per_ring_slot))
+                <= free_mem
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod decode_ring_tests;

--- a/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
+++ b/crates/spark-model/src/ssm_reserve/decode_ring_tests.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for [`super`] (`ssm_reserve::decode_ring`). A sibling file via
+//! `#[path]` — the `ssm_reserve_tests.rs` idiom — so both stay under the
+//! 500-line cap.
+//!
+//! Every byte figure below is the 2026-09-05 rental-H100 configuration from
+//! issue #915 (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe): 48 GDN
+//! layers, 151.5 MiB of SSM state per sequence, `--max-batch-size 32`,
+//! inference reserve 45,823 MiB, 57.2 GiB of weights inside a 71.3 GiB
+//! budget. Pinning the arithmetic here is what stops the fit and the reserve
+//! from drifting apart.
+use super::*;
+
+/// Per-sequence SSM state blob: 48 GDN layers x (h + conv) = 158,859,264 B,
+/// the "151.5 MiB/seq" every #915 log line quotes. Same derivation as the
+/// `H_BLOB`/`CONV_BLOB` constants in `ssm_reserve_tests.rs`.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// One unit of ring depth at `--max-batch-size 32`.
+const SLOT_BYTES: usize = 32 * PER_SEQ_BLOB;
+/// The 45,823 MiB inference reserve MINUS its 8-slot ring (38,784 MiB): the
+/// part of the #915 reserve that does not scale with ring depth.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+#[test]
+fn decode_ring_decision_matrix() {
+    let decide = |layers, spec, override_value, watchdogs| {
+        let decision =
+            decode_rollback_ring_slots_with(layers, spec, None, override_value, watchdogs);
+        (decision.slots, decision.skip_reason)
+    };
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+
+    for value in ["1", "true", " TRUE "] {
+        assert!(
+            watchdogs_disabled_from_value(Some(value)),
+            "value={value:?}"
+        );
+    }
+    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
+        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
+    }
+
+    assert_eq!(decide(0, false, Some("1"), false), (0, None));
+    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
+    assert_eq!(decide(48, false, Some("0"), false), (0, None));
+    assert_eq!(
+        decide(48, true, None, false),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(
+        decide(48, false, None, true),
+        (0, Some("watchdogs disabled"))
+    );
+    assert_eq!(
+        decide(48, true, Some("invalid"), true),
+        (0, Some("speculative decode active"))
+    );
+    assert_eq!(decide(48, false, None, false), (ring, None));
+}
+
+/// A published depth is what BOTH sizing call sites must see — preflight
+/// sized the reserve against it, so `TransformerModel::new` allocating
+/// anything else re-opens the divergence this module exists to close.
+#[test]
+fn a_published_depth_outranks_the_default_the_env_and_the_skips() {
+    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
+    let d = decode_rollback_ring_slots_with(48, false, Some(2), None, false);
+    assert_eq!((d.slots, d.skip_reason), (2, None));
+    // Against the legacy env spelling of "8" ...
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, false, Some(2), Some("1"), false).slots,
+        2
+    );
+    // ... and against BOTH implicit skips, exactly as ATLAS_SSM_DECODE_RING=1
+    // already did: an explicit depth is an explicit depth.
+    assert_eq!(
+        decode_rollback_ring_slots_with(48, true, Some(4), None, true).slots,
+        4
+    );
+    // A published 0 is an explicit off, not an implicit skip: no skip_reason,
+    // so the allocating call site does not log a saving nobody asked for.
+    let zero = decode_rollback_ring_slots_with(48, false, Some(0), None, false);
+    assert_eq!((zero.slots, zero.skip_reason), (0, None));
+    // No SSM layers still outranks everything — no recurrent state to snapshot.
+    assert_eq!(
+        decode_rollback_ring_slots_with(0, false, Some(ring), None, false).slots,
+        0
+    );
+}
+
+/// The value the CLI accepts and the value it publishes come from ONE parse.
+#[test]
+fn parse_accepts_auto_and_zero_through_eight() {
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("0"), Ok(Some(0)));
+    assert_eq!(
+        parse_decode_ring_slots("8"),
+        Ok(Some(atlas_kernels::DECODE_ROLLBACK_RING_SLOTS))
+    );
+    // Above the ceiling the ring is sized for, and anything non-numeric, is a
+    // startup refusal — never a silent clamp to 8.
+    assert!(parse_decode_ring_slots("9").is_err());
+    assert!(parse_decode_ring_slots("AUTO").is_err());
+    assert!(parse_decode_ring_slots("").is_err());
+    assert!(parse_decode_ring_slots("-1").is_err());
+}
+
+/// The #915 boot: 7,039 MiB of non-ring reserve, 14.1 GiB free after 57.2 GiB
+/// of weights inside a 71.3 GiB budget. Depth 8 asks 37.88 GiB and refuses;
+/// depth 1 fits and boots.
+#[test]
+fn autofit_picks_the_largest_fitting_depth() {
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+    let fitted = fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free);
+    assert_eq!(fitted, 1, "largest ladder depth that fits in 14.1 GiB");
+    assert!(RESERVE_WITHOUT_RING + fitted * SLOT_BYTES <= free);
+    assert!(
+        RESERVE_WITHOUT_RING + 2 * SLOT_BYTES > free,
+        "and 2 does not"
+    );
+
+    // With more room the ladder lands on 4 — it never picks 5, 6 or 7, so a
+    // fitted depth is always a rung the operator can recognise.
+    let roomier = 30 * 1024 * 1024 * 1024;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, roomier),
+        4
+    );
+    // Already fitting at the requested depth is left alone.
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        8
+    );
+    // The fit never RAISES a depth: a request below the ladder top is a
+    // ceiling, not a target.
+    assert_eq!(
+        fit_decode_ring_slots(2, RESERVE_WITHOUT_RING, SLOT_BYTES, 64 * 1024 * 1024 * 1024),
+        2
+    );
+}
+
+/// When the rest of the reserve alone exceeds free memory the ring is not the
+/// problem: the fit bottoms out at 0 and the caller must still refuse.
+#[test]
+fn autofit_is_zero_when_even_a_ringless_reserve_does_not_fit() {
+    let free = RESERVE_WITHOUT_RING - 1;
+    assert_eq!(
+        fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, SLOT_BYTES, free),
+        0
+    );
+    assert!(
+        RESERVE_WITHOUT_RING > free,
+        "0 slots is still over budget — the caller refuses rather than booting ringless"
+    );
+    // A zero-byte ring (pure-attention model) is a no-op, not a division trap.
+    assert_eq!(fit_decode_ring_slots(8, RESERVE_WITHOUT_RING, 0, free), 0);
+}
+
+#[test]
+fn the_fit_ladder_is_descending_and_starts_at_the_wired_default() {
+    assert_eq!(
+        DECODE_RING_FIT_LADDER[0],
+        atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+    );
+    assert_eq!(*DECODE_RING_FIT_LADDER.last().unwrap(), 0);
+    assert!(
+        DECODE_RING_FIT_LADDER.windows(2).all(|w| w[0] > w[1]),
+        "`fit_decode_ring_slots` returns the FIRST fitting rung, so the ladder \
+         must be strictly descending or it would return a smaller depth than fits"
+    );
+}

--- a/crates/spark-model/src/ssm_reserve_tests.rs
+++ b/crates/spark-model/src/ssm_reserve_tests.rs
@@ -383,41 +383,9 @@ fn rollback_mode_parses_and_rejects() {
     assert!(SsmRollbackMode::from_str("").is_err());
 }
 
-#[test]
-fn decode_ring_decision_matrix() {
-    let decide = |layers, spec, override_value, watchdogs| {
-        let decision = decode_rollback_ring_slots_with(layers, spec, override_value, watchdogs);
-        (decision.slots, decision.skip_reason)
-    };
-    let ring = atlas_kernels::DECODE_ROLLBACK_RING_SLOTS;
-
-    for value in ["1", "true", " TRUE "] {
-        assert!(
-            watchdogs_disabled_from_value(Some(value)),
-            "value={value:?}"
-        );
-    }
-    for value in [None, Some(""), Some("0"), Some("false"), Some("yes")] {
-        assert!(!watchdogs_disabled_from_value(value), "value={value:?}");
-    }
-
-    assert_eq!(decide(0, false, Some("1"), false), (0, None));
-    assert_eq!(decide(48, true, Some("1"), true), (ring, None));
-    assert_eq!(decide(48, false, Some("0"), false), (0, None));
-    assert_eq!(
-        decide(48, true, None, false),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(
-        decide(48, false, None, true),
-        (0, Some("watchdogs disabled"))
-    );
-    assert_eq!(
-        decide(48, true, Some("invalid"), true),
-        (0, Some("speculative decode active"))
-    );
-    assert_eq!(decide(48, false, None, false), (ring, None));
-}
+// The decode-rollback ring's depth decision, its publication cell and the
+// #915 auto-fit are tested in `ssm_reserve/decode_ring_tests.rs`, next to the
+// module that owns them.
 
 // ─────────────────── Marconi snapshot-slot gate (2026-08-31) ───────────────────
 //

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -514,7 +514,9 @@ pub trait Model: Send + Sync {
     /// model keeps no decode-rollback snapshots — appropriate for
     /// pure-attention models and for SSM models when the snapshot pool
     /// has no capacity reserved. SSM models with a populated pool
-    /// override to `ROLLBACK_RESTEER_CAP + 1`.
+    /// override to the depth `ssm_reserve::decode_rollback_ring_slots`
+    /// decided — 8 by default, or whatever `--ssm-decode-ring-slots` /
+    /// preflight's free-memory fit published (#915).
     fn decode_rollback_ring_slots(&self) -> usize {
         0
     }

--- a/crates/spark-model/src/weight_loader/mod.rs
+++ b/crates/spark-model/src/weight_loader/mod.rs
@@ -52,6 +52,12 @@ pub use qwen3_vl::Qwen3VLWeightLoader;
 pub use qwen4_exp::Qwen4ExpWeightLoader;
 pub use qwen35::Qwen35WeightLoader;
 pub use qwen35_dense::Qwen35DenseWeightLoader;
+/// The native-FP8 dense loader's derived-copy decision table and the shape
+/// arithmetic that prices it (#915).
+pub use qwen35_dense::fp8_residency;
+/// That table evaluated BEFORE the checkpoint loads, so preflight can size
+/// the SSM decode ring against the predicted post-load KV headroom (#915).
+pub use qwen35_dense::predicted_residency;
 pub use step3p7::Step3p7WeightLoader;
 
 use anyhow::Result;

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -1688,7 +1688,7 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
     /// `norm.weight` are aliased or conditionally aliased depending on their
     /// on-disk dtype, and every attention / FFN tensor is bound zero-copy.
     /// Only the four names below are freed, and only for layers where
-    /// [`gdn_fp8_arm_selected`] says that arm actually ran.
+    /// `gdn_fp8_arm_selected` (private to this module) says that arm actually ran.
     fn prune_after_load(
         &self,
         store: &mut WeightStore,

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -197,8 +197,13 @@ fn ffn_inter(config: &ModelConfig) -> usize {
     }
 }
 
-mod fp8_residency;
+// `pub` (re-exported from `weight_loader/mod.rs`): the pre-load residency
+// PREDICTION in `predicted_residency` is read by spark-server's preflight,
+// and it prices its terms with this module's shape helpers so the prediction
+// and the loader's own tally cannot be two different arithmetics (#915).
+pub mod fp8_residency;
 mod loaders_b;
+pub mod predicted_residency;
 mod rowwise_fp8;
 
 use crate::layers::qwen3_attention::Fp8TwinSet;

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -167,6 +167,24 @@ fn dense_fp8_enabled() -> bool {
     std::env::var("ATLAS_DENSE_FP8").as_deref() == Ok("1")
 }
 
+/// Whether the native block-scaled FP8 GDN arm runs for this SSM layer.
+///
+/// ONE predicate, called by `load_layers` and by `prune_after_load`: the
+/// second frees the store tensors the first copied into the fused `[QKV|Z]`
+/// weight, and a drift between the two is a use-after-free with no
+/// diagnostic. The keep-packed Q2 arm `continue`s ahead of this one, so it is
+/// part of the condition (#915).
+fn gdn_fp8_arm_selected(store: &WeightStore, la: &str, tp_size: usize) -> bool {
+    let q2 = tp_size.max(1) == 1
+        && std::env::var_os("ATLAS_NO_Q2_GDN").is_none()
+        && proj_q2_group(store, &format!("{la}.in_proj_qkv")).is_some()
+        && proj_q2_group(store, &format!("{la}.in_proj_z")).is_some();
+    !q2 && std::env::var_os("ATLAS_NO_GDN_FP8").is_none()
+        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_qkv"))
+        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_z"))
+        && proj_is_fp8_any_scale(store, &format!("{la}.out_proj"))
+}
+
 /// The dense-FFN width. `moe_intermediate_size` is the PER-EXPERT width and is
 /// unset (=0) on dense Qwen3.6/3.8-*-FP8, so reading it first would size a
 /// 0-byte allocation; `intermediate_size` is unset on the older MoE-style
@@ -1104,11 +1122,7 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     // Internal opt-out for the FP8-vs-NVFP4 GDN A/B + KL-drift
                     // gate (not a user choice; mirrors the `ATLAS_NO_*` debug
                     // levers). Default engages native FP8.
-                    if std::env::var_os("ATLAS_NO_GDN_FP8").is_none()
-                        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_qkv"))
-                        && proj_is_fp8_any_scale(store, &format!("{la}.in_proj_z"))
-                        && proj_is_fp8_any_scale(store, &format!("{la}.out_proj"))
-                    {
+                    if gdn_fp8_arm_selected(store, &la, config.tp_world_size) {
                         let in_proj_a = dense(store, &format!("{la}.in_proj_a.weight"))?;
                         let in_proj_b = dense(store, &format!("{la}.in_proj_b.weight"))?;
                         let conv1d = dense(store, &format!("{la}.conv1d.weight"))?;
@@ -1656,6 +1670,72 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         }
 
         Ok(layers)
+    }
+
+    /// Drop the SSM source tensors the native-FP8 GDN arm copied and no longer
+    /// reads (#915).
+    ///
+    /// That arm builds a fused `[QKV|Z]` FP8 weight by device-to-device
+    /// appending `in_proj_qkv` and `in_proj_z` (`concat_fp8_block_scaled`), and
+    /// builds `in_proj_ba` by a D2H -> host interleave -> H2D round trip
+    /// (`interleave_ba`). All four store originals are dead the moment
+    /// `load_layers` returns — 80 MiB + ~1 MB per SSM layer, ~3.9 GB across the
+    /// 48 GDN layers of Qwen3.8-27B-FP8, which is what the fused copy costs.
+    /// Keeping both is the duplicate that came straight out of the KV budget.
+    ///
+    /// 🪤 Narrow on purpose. `out_proj.weight` IS `out_proj_fp8w.weight`
+    /// (zero-copy from the store), `conv1d`, `A_log`, `dt_bias` and
+    /// `norm.weight` are aliased or conditionally aliased depending on their
+    /// on-disk dtype, and every attention / FFN tensor is bound zero-copy.
+    /// Only the four names below are freed, and only for layers where
+    /// [`gdn_fp8_arm_selected`] says that arm actually ran.
+    fn prune_after_load(
+        &self,
+        store: &mut WeightStore,
+        config: &ModelConfig,
+        gpu: &dyn GpuBackend,
+    ) -> Result<()> {
+        // Same resolution `load_layers` uses: an explicit `layer_types` list
+        // wins over the computed pattern, and pruning must be decided from the
+        // list that actually selected the arms.
+        let layer_types = if config.layer_types.is_empty() {
+            (0..config.num_hidden_layers)
+                .map(|i| config.layer_type(i))
+                .collect::<Vec<_>>()
+        } else {
+            config.layer_types.clone()
+        };
+        let mut doomed: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (i, lt) in layer_types.iter().enumerate() {
+            if *lt != LayerType::LinearAttention {
+                continue;
+            }
+            let la = format!("{}.linear_attn", config.layer_prefix(i));
+            if !gdn_fp8_arm_selected(store, &la, config.tp_world_size) {
+                continue;
+            }
+            for leaf in [
+                "in_proj_qkv.weight",
+                "in_proj_qkv.weight_scale_inv",
+                "in_proj_qkv.weight_scale",
+                "in_proj_z.weight",
+                "in_proj_z.weight_scale_inv",
+                "in_proj_z.weight_scale",
+                "in_proj_a.weight",
+                "in_proj_b.weight",
+            ] {
+                doomed.insert(format!("{la}.{leaf}"));
+            }
+        }
+        if doomed.is_empty() {
+            return Ok(());
+        }
+        let (count, bytes) = store.free_matching(gpu, |name| doomed.contains(name))?;
+        tracing::info!(
+            "native FP8 GDN: released {count} store tensors ({:.2} GB) consumed by the fused              [QKV|Z] concat and the BA interleave; out_proj/conv1d/A_log/dt_bias/norm kept              (still aliased)",
+            bytes as f64 / 1e9,
+        );
+        Ok(())
     }
 
     fn load_embedding(

--- a/crates/spark-model/src/weight_loader/qwen35_dense.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense.rs
@@ -167,8 +167,24 @@ fn dense_fp8_enabled() -> bool {
     std::env::var("ATLAS_DENSE_FP8").as_deref() == Ok("1")
 }
 
+/// The dense-FFN width. `moe_intermediate_size` is the PER-EXPERT width and is
+/// unset (=0) on dense Qwen3.6/3.8-*-FP8, so reading it first would size a
+/// 0-byte allocation; `intermediate_size` is unset on the older MoE-style
+/// configs. Same fallback order as `weight_map/fp8_lut.rs::load_dense_ffn`.
+fn ffn_inter(config: &ModelConfig) -> usize {
+    if config.intermediate_size > 0 {
+        config.intermediate_size
+    } else {
+        config.moe_intermediate_size
+    }
+}
+
+mod fp8_residency;
 mod loaders_b;
 mod rowwise_fp8;
+
+use crate::layers::qwen3_attention::Fp8TwinSet;
+use fp8_residency::{DerivedResidency, RouteEnv};
 
 pub struct Qwen35DenseWeightLoader;
 
@@ -264,6 +280,12 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
         };
         log_free("dense-load-start");
 
+        // #915: resolved ONCE, from the same resolvers the forward pass uses —
+        // the loader runs before `ForwardContext` exists. Contract and WHY:
+        // `fp8_residency.rs`.
+        let route_env = RouteEnv::from_env();
+        let mut residency = DerivedResidency::default();
+
         for (i, lt) in layer_types.iter().enumerate() {
             if i % 8 == 0 {
                 log_free(&format!("layer-{i}"));
@@ -280,13 +302,17 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 && config.tp_world_size.max(1) == 1
                 && matches!(variant, Nvfp4Variant::Fp8Dequanted)
                 && proj_is_native_fp8(store, &format!("{lp}.mlp.gate_proj"));
-            // Always load the NVFP4 weights so every dispatch path (incl. the
-            // batched spec-decode forward_k2/k3 paths that have no FP8 branch)
-            // has a valid weight to fall back to — a null NVFP4 weight under a
-            // w4a16 dispatch is the CUDA-700-at-concurrency bug. When native
-            // FP8 is enabled we overlay the block-scaled FP8 weights on top;
-            // the hot forward / forward_prefill paths then use FP8, the rare
-            // batched paths fall back to real NVFP4.
+            // 2026-09-11 (#915), replacing "always load the NVFP4 weights so
+            // every dispatch path has a valid weight to fall back to": there is
+            // no such path any more. `forward_k2`/`k3`/`km` redirect to
+            // `forward_prefill` whenever an FP8 overlay is installed
+            // (`native_small_batch_uses_prefill`), and both `forward` and
+            // `forward_prefill_inner` return from inside their `fp8_weights`
+            // arm. Building the fallback cost 18.4 GiB on Qwen3.8-27B-FP8 that
+            // nothing could read. The CUDA-700-at-concurrency hazard the old
+            // rule guarded is real and is why this is decided by
+            // `fp8_residency.rs` rather than inline: a NULL NVFP4 weight is
+            // only sound when the plan proves no w4a16 dispatch is reachable.
             // Native-BF16 dense-FFN prefill (Holo/Ornith Bf16Raw): the fast
             // tensor-core `dense_gemm_tc` path (dense_ffn::forward_prefill) needs
             // LIVE BF16 gate/up/down. `load_dense_ffn`'s Bf16Raw arm runtime-
@@ -341,9 +367,30 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 None
             };
 
-            let ffn_weights = if ffn_q2 {
-                // NULL NVFP4 fallback: decode uses the packed weights; prefill /
-                // batched paths bail (Tier-2). No NVFP4 allocation → memory win.
+            // #915: the NVFP4 gate/up/down fallback and its transposed twins
+            // are 18.4 GiB on Qwen3.8-27B-FP8 that NO native-FP8 dispatch can
+            // reach — every `DenseFfnLayer` entry point returns from inside its
+            // `self.fp8_weights` arm and `w8_gemm!` binds the transposed
+            // operand to a literal `None`. The comment above ("always load the
+            // NVFP4 weights ... the rare batched paths fall back to real
+            // NVFP4") described the pre-#927 dispatch; `forward_k2`/`k3`/`km`
+            // have redirected to `forward_prefill` since
+            // `native_small_batch_uses_prefill` landed. Decision table and the
+            // loader-runs-before-dispatch contract: `fp8_residency.rs`.
+            let plan = route_env.plan(ffn_fp8, false, false);
+            let ffn_nvfp4 = !ffn_q2 && plan.ffn_nvfp4;
+            let ffn_weights = if ffn_nvfp4 {
+                load_dense_ffn(
+                    store, &lp, gpu, variant, absmax_k, quantize_k, stream, config,
+                )?
+            } else {
+                // NULL NVFP4 fallback. Packed-Q2 (Tier-1c): decode uses the
+                // packed weights; prefill / batched paths bail (Tier-2).
+                // Native FP8: every arm reads the E4M3 bytes installed by
+                // `set_fp8_weights` below. No NVFP4 allocation → memory win.
+                if ffn_fp8 {
+                    residency.skip(fp8_residency::dense_ffn_nvfp4_bytes(h, ffn_inter(config)));
+                }
                 use crate::weight_map::QuantizedWeight;
                 crate::layers::dense_ffn::DenseFfnWeights {
                     gate_proj: QuantizedWeight::null(),
@@ -353,11 +400,8 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     up_proj_t: None,
                     down_proj_t: None,
                 }
-            } else {
-                load_dense_ffn(
-                    store, &lp, gpu, variant, absmax_k, quantize_k, stream, config,
-                )?
             };
+            residency.twins.ffn_nvfp4 |= ffn_nvfp4;
             let mut dffn = DenseFfnLayer::new(ffn_weights, gpu)?;
             if ffn_q2 {
                 dffn.set_q2_weights(
@@ -368,8 +412,21 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                 );
             }
             if ffn_fp8 {
-                let load_ffn_fp8 = |name: &str| {
-                    load_fp8_block_scaled_as_fp8weight(store, &format!("{lp}.mlp.{name}"), gpu)
+                // The FP8 `.weight` bytes are store-owned (zero-copy from the
+                // checkpoint); only the widened FP32 block-scale grid is a
+                // fresh allocation (`loaders_fp8.rs:109`). Adopt it — #736
+                // lists the loader sites that allocate without an owner.
+                let load_ffn_fp8 = |name: &str| -> Result<Fp8Weight> {
+                    let w = load_fp8_block_scaled_as_fp8weight(
+                        store,
+                        &format!("{lp}.mlp.{name}"),
+                        gpu,
+                    )?;
+                    let bytes = (w.n as usize).div_ceil(128) * (w.k as usize).div_ceil(128) * 4;
+                    store
+                        .derived()
+                        .adopt("ffn fp8 block scale (widened)", w.row_scale, bytes);
+                    Ok(w)
                 };
                 dffn.set_fp8_weights(
                     load_ffn_fp8("gate_proj")?,
@@ -494,6 +551,17 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                         }
                         continue;
                     }
+                    // #915: does the native FP8 attention overlay replace
+                    // these weights below? Hoisted out of the overlay block so
+                    // the NVFP4 build can be skipped rather than built and
+                    // immediately orphaned — `set_fp8_weights` OVERWRITES
+                    // `q/k/v/o_weight`, so on this route the NVFP4 q/k/v/o were
+                    // unreachable the moment they were installed.
+                    let attn_fp8 = dense_fp8_enabled()
+                        && config.tp_world_size.max(1) == 1
+                        && matches!(variant, Nvfp4Variant::Fp8Dequanted)
+                        && proj_is_native_fp8(store, &format!("{p}.q_proj"));
+                    let attn_nvfp4 = route_env.attn_nvfp4(attn_fp8);
                     let (attn, q_nvfp4, k_nvfp4, v_nvfp4) = match variant {
                         Nvfp4Variant::CompressedTensors => {
                             // NVFP4-from-disk path: column-parallel Q/K/V, row-parallel O.
@@ -557,6 +625,50 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                                 v_scale,
                             };
                             (attn, Some(q), Some(k), Some(v))
+                        }
+                        Nvfp4Variant::Standard | Nvfp4Variant::Fp8Dequanted if !attn_nvfp4 => {
+                            // #915: the FP8 overlay below replaces q/k/v/o, and
+                            // nothing reads the NVFP4 copies afterwards — the
+                            // transposed twins only under `ATLAS_CUTLASS_NVFP4_*`
+                            // and the base `o_proj` only under `ATLAS_ATTN_W4A4`,
+                            // both of which `RouteEnv::attn_nvfp4` accounts for.
+                            // Skipping the build also skips the BF16 dequant of
+                            // every FP8 projection that fed `quantize_to_nvfp4`.
+                            // Same NULL-o_proj shape the Bf16Raw arm below uses.
+                            let (k_scale, v_scale) = load_kv_scales(store, &p, gpu);
+                            let (nh, hd) = (config.num_attention_heads, config.head_dim);
+                            let (nkv, hh) = (config.num_key_value_heads, config.hidden_size);
+                            let q_n = nh * hd * if config.attn_gated { 2 } else { 1 };
+                            residency.skip(fp8_residency::attn_nvfp4_bytes(
+                                q_n,
+                                nkv * hd,
+                                nh * hd,
+                                hh,
+                            ));
+                            let null = || DenseWeight {
+                                weight: spark_runtime::gpu::DevicePtr::NULL,
+                            };
+                            let attn = AttentionWeights {
+                                q_proj: null(),
+                                k_proj: null(),
+                                v_proj: null(),
+                                o_proj: crate::weight_map::QuantizedWeight::null(),
+                                q_norm: dense(store, &format!("{p}.q_norm.weight"))?,
+                                k_norm: dense(store, &format!("{p}.k_norm.weight"))?,
+                                q_norm_full: None,
+                                k_norm_full: None,
+                                k_scale,
+                                v_scale,
+                            };
+                            // The NULL o_proj is only sound while the FP8
+                            // overlay is installed below — a null NVFP4 weight
+                            // reached by a w4a16 dispatch is the
+                            // CUDA-700-at-concurrency failure mode.
+                            debug_assert!(
+                                attn_fp8,
+                                "attn_nvfp4=false must imply a native FP8 overlay"
+                            );
+                            (attn, None, None, None)
                         }
                         Nvfp4Variant::Standard | Nvfp4Variant::Fp8Dequanted => {
                             // BF16 → NVFP4 path: shard BF16 then quantize per-rank.
@@ -778,21 +890,34 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                     if let Some(o_dense) = o_dense_bf16 {
                         attn_layer.set_o_dense_bf16(o_dense);
                     }
-                    // Overlay native FP8 q/k/v/o on top of the NVFP4 weights when
-                    // enabled (single-GPU FP8 checkpoint). Hot decode/prefill paths
-                    // dispatch FP8 (w8a16); any path without an FP8 branch falls back
-                    // to the real NVFP4 weights above (never a null → no CUDA-700).
-                    if dense_fp8_enabled()
-                        && config.tp_world_size.max(1) == 1
-                        && matches!(variant, Nvfp4Variant::Fp8Dequanted)
-                        && proj_is_native_fp8(store, &format!("{p}.q_proj"))
-                    {
+                    // Install native FP8 q/k/v/o (single-GPU FP8 checkpoint).
+                    // `set_fp8_weights` REPLACES `q/k/v/o_weight`, so on this
+                    // route the NVFP4 weights above are not a fallback — they
+                    // are unreachable, which is why `attn_nvfp4` skipped
+                    // building them (#915). The paths that could still read
+                    // NVFP4 (`ATLAS_CUTLASS_NVFP4_*`, `ATLAS_ATTN_W4A4`) are
+                    // exactly what `RouteEnv::attn_nvfp4` checks.
+                    if attn_fp8 {
                         let load_fp8_proj = |name: &str,
                                              _n: usize,
                                              _k: usize,
                                              _kind: TpShardKind|
                          -> Result<Fp8Weight> {
-                            load_fp8_block_scaled_as_fp8weight(store, &format!("{p}.{name}"), gpu)
+                            // Only `row_scale` is allocated here; the E4M3
+                            // bytes are store-owned. Adopt it (#736).
+                            let w = load_fp8_block_scaled_as_fp8weight(
+                                store,
+                                &format!("{p}.{name}"),
+                                gpu,
+                            )?;
+                            let bytes =
+                                (w.n as usize).div_ceil(128) * (w.k as usize).div_ceil(128) * 4;
+                            store.derived().adopt(
+                                "attn fp8 block scale (widened)",
+                                w.row_scale,
+                                bytes,
+                            );
+                            Ok(w)
                         };
                         let [q_fp8, k_fp8, v_fp8, o_fp8] = load_qkvo_tp(config, load_fp8_proj)?;
                         attn_layer.set_fp8_weights(
@@ -801,7 +926,28 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                             Some(v_fp8),
                             Some(o_fp8),
                         );
-                        if let Err(e) = attn_layer.transpose_fp8_for_prefill(gpu, stream) {
+                        // #915: build only the twins a selected kernel reads,
+                        // and hand each to the store so teardown RELEASES it.
+                        // K/V are NOT optional — `prefill/cache_skip_qkv.rs` has
+                        // no W8A8 arm and is the first-chunk path of every
+                        // request. Table: `Fp8TwinSet` + `fp8_residency.rs`.
+                        let want =
+                            route_env.attn_fp8_twins(true, attn_layer.has_w8a8_prefill_kernels());
+                        let (nh, hd) = (config.num_attention_heads, config.head_dim);
+                        let (nkv, hh) = (config.num_key_value_heads, config.hidden_size);
+                        let q_n = nh * hd * if config.attn_gated { 2 } else { 1 };
+                        let twin_bytes = |set| {
+                            fp8_residency::attn_fp8_twin_bytes(set, q_n, nkv * hd, nh * hd, hh)
+                        };
+                        residency.twins.attn_fp8 |= want.any();
+                        residency.skip(twin_bytes(Fp8TwinSet::ALL) - twin_bytes(want));
+                        residency.keep(twin_bytes(want));
+                        if let Err(e) = attn_layer.transpose_fp8_for_prefill_selected(
+                            gpu,
+                            stream,
+                            want,
+                            Some(store.derived()),
+                        ) {
                             tracing::warn!("Layer {i}: dense FP8 transpose failed: {e}");
                         }
                     }
@@ -988,8 +1134,38 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
                         let qkvz_f = concat_fp8_block_scaled(&qkv_f, &z_f, h, gpu)?;
                         // The concat copied both grids; free the per-projection
                         // scale allocs (weight bytes are store-owned, not freed).
+                        let scale_bytes =
+                            |n: usize, k: usize| n.div_ceil(128) * k.div_ceil(128) * 4;
                         gpu.free(qkv_f.row_scale)?;
                         gpu.free(z_f.row_scale)?;
+                        residency.free(
+                            scale_bytes(qkv_f.n as usize, h) + scale_bytes(z_f.n as usize, h),
+                        );
+                        // #736/#915: the fused `[QKV|Z]` weight is the SSM's
+                        // hottest tensor and there is no un-fused dispatch to
+                        // fall back to, so it STAYS — but it is a derived copy
+                        // that no `ModelResource` owned, which is the
+                        // 3,840 MB x48 row of the H100 teardown sweep. Adopt it.
+                        let qkvz_bytes = (qkvz_f.n as usize) * h;
+                        let qkvz_scale_bytes =
+                            scale_bytes(qkv_f.n as usize, h) + scale_bytes(z_f.n as usize, h);
+                        let ba_bytes = nv * 2 * h * 2; // [2*nv, h] BF16
+                        let out_scale_bytes = scale_bytes(out_f.n as usize, out_f.k as usize);
+                        let d = store.derived();
+                        d.adopt("ssm qkvz fp8 concat", qkvz_f.weight, qkvz_bytes);
+                        d.adopt(
+                            "ssm qkvz fp8 block scale",
+                            qkvz_f.row_scale,
+                            qkvz_scale_bytes,
+                        );
+                        d.adopt(
+                            "ssm out_proj fp8 block scale",
+                            out_f.row_scale,
+                            out_scale_bytes,
+                        );
+                        d.adopt("ssm in_proj_ba interleaved", ba_dense.weight, ba_bytes);
+                        residency.keep(qkvz_bytes + qkvz_scale_bytes + out_scale_bytes + ba_bytes);
+                        residency.twins.ssm_fp8_concat = true;
                         let ssm = SsmWeights {
                             in_proj_qkvz: DenseWeight {
                                 weight: spark_runtime::gpu::DevicePtr::NULL,
@@ -1464,6 +1640,20 @@ impl ModelWeightLoader for Qwen35DenseWeightLoader {
             attn_idx,
             layers.len() - attn_idx,
         );
+        // #915: the line the next H100 serve is read against. `weights` is the
+        // checkpoint as the ledger sees it; `derived` is everything this loader
+        // built on top of it and now OWNS (released at teardown, not swept);
+        // `not built` is what the pre-#915 loader allocated here and this one
+        // proved unreachable. Emitted unconditionally — a residency regression
+        // that only shows under a debug flag is one nobody sees.
+        tracing::info!("{}", residency.summary(store.resident_bytes()));
+        for (label, bytes, count) in store.derived().by_label() {
+            tracing::debug!(
+                "  derived-weight owner: {:>9.1} MB x{:<5} {label}",
+                bytes as f64 / (1024.0 * 1024.0),
+                count,
+            );
+        }
 
         Ok(layers)
     }

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Which derived weight copies the native-FP8 dense route actually needs, and
+//! a tally of the ones it still builds.
+//!
+//! **WHY (#915 root cause; O9 of the 2026-09-05 rental; refs #916, #917, #736).**
+//! Measured on 1xH100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8` at `5f78270dc`,
+//! native-FP8 profile (`ATLAS_DENSE_FP8=1`, `--lm-head-dtype bf16`):
+//!
+//! * the checkpoint itself is **28.75 GB** — `WeightStore after prune: 1606
+//!   tensors, 28.747 GiB still resident`, one ledger site
+//!   (`fast_weights/mod.rs:434`, 29,436.7 MB x1606);
+//! * the ledger nevertheless reported **58.1 GB live before the KV cache was
+//!   sized**, and `ATLAS_MEM_PROFILE` recorded GPU-free falling **437 MB per
+//!   layer over all 64 layers (28.0 GB)** *after* the checkpoint was resident;
+//! * the teardown sweep reclaimed **28.01 GB across 1,980 allocations that no
+//!   `ModelResource` owned**.
+//!
+//! The six sites the ledger named, and what each holds per layer:
+//!
+//! | site | bytes x count | tensor |
+//! |---|---|---|
+//! | `weight_map/loaders_fp8.rs:229` | 8,960 MB x256 | `quantize_to_nvfp4` packed `[N,K/2]` |
+//! | `weight_map/quantized.rs:261` | 8,960 MB x256 | the transposed twin of the same |
+//! | `weight_loader/qwen35_dense.rs:135` | 3,840 MB x48 | SSM fused `[QKV\|Z]` FP8 concat |
+//! | `weight_map/quantized.rs:643` | 1,600 MB x64 | attention `Fp8WeightTransposed::weight_t` |
+//! | `weight_map/loaders_fp8.rs:230` | 1,120 MB x256 | the NVFP4 per-16 group scales |
+//! | `weight_map/quantized.rs:262` | 1,120 MB x256 | the transposed twin of those scales |
+//!
+//! The 256 counts are `64 layers x 3` dense-FFN projections (gate/up/down,
+//! 42.5 MiB packed each) plus `16 attention layers x 4` (q/k/v/o, 25/6.25/
+//! 6.25/12.5 MiB) — 8,160 + 800 MB, which is exactly the 8,960 reported.
+//!
+//! **None of the NVFP4 copies is reachable once the native FP8 overlay is
+//! installed.** `DenseFfnLayer::forward` (`dense_ffn.rs:1044`) and
+//! `forward_prefill_inner` (`dense_ffn.rs:1985`) both return from inside their
+//! `if let Some(ref fp8w) = self.fp8_weights` arm, `forward_k2`/`forward_k3`/
+//! `forward_km` redirect to `forward_prefill` via
+//! `native_small_batch_uses_prefill`, and the `w8_gemm!` macro binds
+//! `gate_t`/`up_t`/`down_t` to a literal `None`, so even the W8A16 fallback
+//! rungs read the original `[N,K]` E4M3 bytes. The NVFP4 gate/up/down and
+//! their transposed twins are pure load-time waste: 18.4 GiB of the 28.
+//!
+//! **The loader runs before dispatch exists**, so the route has to be derived
+//! from the same resolvers the forward pass uses rather than from a
+//! `ForwardContext`:
+//!
+//! * [`crate::layers::ops::GemmDispatch::from_env`] — the exact constructor
+//!   `model/impl_a1.rs:836` calls to build the context. It is a pure function
+//!   of the environment and a serve never rewrites its own environment, so the
+//!   loader's answer and the context's answer cannot disagree.
+//!
+//! `ATLAS_FFN_W8A16_ONLY` is deliberately NOT an input: it steers the dense FFN
+//! from the W8A8 arm onto rung 5 of the same `w8_gemm!` match, whose transposed
+//! operand is that literal `None` — so it selects between two kernels that both
+//! read the original FP8 bytes, and cannot resurrect an NVFP4 reader.
+//!
+//! That is the contract: **any new lever that can route a native-FP8 layer back
+//! onto an NVFP4 kernel must be added to [`DenseFp8Plan::resolve`] as well as
+//! to the dispatch site**, or the loader will have freed the weight that site
+//! wants. `ATLAS_DENSE_FP8_KEEP_NVFP4` is the escape hatch that restores the
+//! pre-#915 behaviour wholesale while such a gap is diagnosed.
+
+use crate::layers::ops::GemmDispatch;
+use crate::layers::qwen3_attention::Fp8TwinSet;
+
+/// The per-layer kill switch that restores the pre-#915 behaviour: build every
+/// NVFP4 fallback copy even where the dispatch cannot reach it.
+///
+/// PRESENCE (any value, including empty), matching `ATLAS_FFN_W8A16_ONLY` —
+/// this is an escape hatch an operator reaches for while a serve is
+/// misbehaving, and `ATLAS_DENSE_FP8_KEEP_NVFP4=0` meaning "on" is a trap.
+pub fn keep_nvfp4_fallback() -> bool {
+    static KEEP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *KEEP.get_or_init(|| std::env::var_os("ATLAS_DENSE_FP8_KEEP_NVFP4").is_some())
+}
+
+/// What a native-FP8 dense layer must materialise beyond the checkpoint bytes.
+///
+/// Every field is "build this derived copy": `false` means the selected
+/// kernels provably never read it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenseFp8Plan {
+    /// NVFP4 gate/up/down **and** their `w4a16_gemm_t_m128` transposed twins.
+    pub ffn_nvfp4: bool,
+    /// NVFP4 q/k/v/o, their transposed twins, and the fused `[q|k|v]` twin.
+    pub attn_nvfp4: bool,
+    /// Which `Fp8WeightTransposed` twins `transpose_fp8_for_prefill` builds.
+    pub attn_fp8_twins: Fp8TwinSet,
+}
+
+/// The inputs [`DenseFp8Plan::resolve`] decides from. Taken as a struct so the
+/// CPU decision-table test can pin every clause without touching the process
+/// environment (the `OnceLock` resolvers cannot be toggled per test).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DenseFp8Inputs {
+    /// The native FP8 dense-FFN overlay will be installed on this layer
+    /// (`ATLAS_DENSE_FP8=1`, tp_size 1, `Fp8Dequanted`, gate_proj native FP8).
+    pub ffn_fp8: bool,
+    /// The native FP8 attention overlay will be installed on this layer.
+    pub attn_fp8: bool,
+    /// `ATLAS_DENSE_FP8_KEEP_NVFP4` — restore the pre-#915 behaviour.
+    pub keep_nvfp4: bool,
+    /// Resolved exactly as `model/impl_a1.rs:836` resolves it.
+    pub dispatch: GemmDispatch,
+    /// Whether the target's `per_token_group_quant_fp8` + `fp8_gemm_t_blockscaled`
+    /// kernels are both loaded. Both are required by the W8A8 prefill arm in
+    /// `qwen3_attention/prefill/paged_qkv.rs:220` and
+    /// `prefill/paged_oproj.rs:94`; without them those two chains fall through
+    /// to the transposed W8A16 kernels, which read the FP8 twins.
+    pub w8a8_kernels: bool,
+    /// `ATLAS_ATTN_W4A4` is set. `prefill/paged_oproj.rs:38-42` builds its W4A4
+    /// arm with NO weight-type predicate and then feeds it
+    /// `&self.attn.o_proj` — the NVFP4 o_proj — so this one lever keeps the
+    /// NVFP4 attention weights alive even under a full FP8 overlay. (The QKV
+    /// side at `paged_qkv.rs:51` does check `as_nvfp4()`, so it is already
+    /// closed; the o_proj asymmetry is not.)
+    pub attn_w4a4: bool,
+    /// `ATLAS_ATTN_PREFILL_Q_T=1`. `prefill/cache_skip_qkv.rs:142` reads it per
+    /// projection per prefill and, when set, dispatches Q through `q_fp8w_t`.
+    pub attn_prefill_q_t: bool,
+}
+
+impl DenseFp8Plan {
+    /// The decision table. Pure — no environment reads, no allocation.
+    ///
+    /// * **FFN NVFP4** — unreachable the moment `set_fp8_weights` runs (see the
+    ///   module docs: every entry point returns from inside the FP8 arm and the
+    ///   `w8_gemm!` transposed operands are a literal `None`). Built only under
+    ///   the escape hatch.
+    /// * **Attention NVFP4** — `set_fp8_weights` *overwrites*
+    ///   `q_weight`/`k_weight`/`v_weight`/`o_weight` with `QuantWeight::Fp8`,
+    ///   so the base NVFP4 weights are orphaned at load. The transposed and
+    ///   fused twins survive only behind the `ATLAS_CUTLASS_NVFP4_*` levers,
+    ///   which default off.
+    /// * **Attention FP8 twins, K and V** — KEPT UNCONDITIONALLY. The
+    ///   first prefill chunk (`seq_len_start == 0`, the default for every
+    ///   request) does not go through `paged_qkv.rs` at all: it goes through
+    ///   `prefill/cache_skip_qkv.rs`, whose dispatch chain has **no W8A8 arm**,
+    ///   so `k_fp8w_t`/`v_fp8w_t` are dereferenced at `cache_skip_qkv.rs:218`
+    ///   / `:235` on every request regardless of `fp8_blockscaled_prefill`.
+    ///   Freeing them is a NULL-pointer kernel launch on the first token.
+    /// * **Attention FP8 twins, Q and O** — Q on that same chain is behind
+    ///   `ATLAS_ATTN_PREFILL_Q_T=1` (`cache_skip_qkv.rs:142`) and O is routed
+    ///   to `paged_oproj.rs` from both chains, so both are reachable only after
+    ///   the W8A8 arm declines — block-scaled prefill off, or a target missing
+    ///   one of the two kernels.
+    pub fn resolve(i: DenseFp8Inputs) -> Self {
+        if i.keep_nvfp4 {
+            return Self {
+                ffn_nvfp4: true,
+                attn_nvfp4: true,
+                attn_fp8_twins: if i.attn_fp8 {
+                    Fp8TwinSet::ALL
+                } else {
+                    Fp8TwinSet::NONE
+                },
+            };
+        }
+        let cutlass_nvfp4_attn = i.dispatch.cutlass_nvfp4_gemm
+            || i.dispatch.cutlass_nvfp4_attn_q
+            || i.dispatch.cutlass_nvfp4_attn_kv
+            || i.dispatch.cutlass_nvfp4_attn_o;
+        // `transpose_fp8_for_prefill` already refuses to build anything under
+        // the umbrella NVFP4 flag (`prefill_weights.rs:357`); mirror that here
+        // so the plan and the builder cannot drift.
+        let w8a8_covers_prefill = i.dispatch.fp8_blockscaled_prefill && i.w8a8_kernels;
+        let fp8_twins = if !i.attn_fp8 || i.dispatch.cutlass_nvfp4_gemm {
+            Fp8TwinSet::NONE
+        } else {
+            Fp8TwinSet {
+                q: i.attn_prefill_q_t || !w8a8_covers_prefill,
+                k: true,
+                v: true,
+                o: !w8a8_covers_prefill,
+            }
+        };
+        Self {
+            ffn_nvfp4: !i.ffn_fp8,
+            attn_nvfp4: !i.attn_fp8 || cutlass_nvfp4_attn || i.attn_w4a4,
+            attn_fp8_twins: fp8_twins,
+        }
+    }
+}
+
+/// The environment-resolved half of [`DenseFp8Inputs`], read ONCE per load.
+///
+/// Hoisted out of the per-layer decision because `GemmDispatch::from_env`
+/// walks the environment block for a dozen variables and a 64-layer model
+/// would otherwise do it 64 times — and because resolving once is what makes
+/// "every layer of this model took the same route" a property of the type
+/// rather than of the environment holding still.
+#[derive(Clone, Copy, Debug)]
+pub struct RouteEnv {
+    pub keep_nvfp4: bool,
+    pub dispatch: GemmDispatch,
+    /// Mirrors `prefill/paged_oproj.rs:42` and `prefill/paged_qkv.rs:53`,
+    /// which read this per projection per prefill and are NOT memoised.
+    pub attn_w4a4: bool,
+    /// Mirrors `prefill/cache_skip_qkv.rs:142`, same caveat.
+    pub attn_prefill_q_t: bool,
+}
+
+impl RouteEnv {
+    pub fn from_env() -> Self {
+        Self {
+            keep_nvfp4: keep_nvfp4_fallback(),
+            dispatch: GemmDispatch::from_env(),
+            // Same predicates as the dispatch sites, character for character:
+            // `is_ok()` (presence) for W4A4, `== "1"` for the Q-transpose.
+            attn_w4a4: std::env::var("ATLAS_ATTN_W4A4").is_ok(),
+            attn_prefill_q_t: std::env::var("ATLAS_ATTN_PREFILL_Q_T").ok().as_deref() == Some("1"),
+        }
+    }
+
+    /// This layer's plan. `w8a8_kernels` is a property of the *layer* (its
+    /// resolved kernel handles), which is why it is not part of `RouteEnv`.
+    pub fn plan(&self, ffn_fp8: bool, attn_fp8: bool, w8a8_kernels: bool) -> DenseFp8Plan {
+        DenseFp8Plan::resolve(DenseFp8Inputs {
+            ffn_fp8,
+            attn_fp8,
+            keep_nvfp4: self.keep_nvfp4,
+            dispatch: self.dispatch,
+            w8a8_kernels,
+            attn_w4a4: self.attn_w4a4,
+            attn_prefill_q_t: self.attn_prefill_q_t,
+        })
+    }
+
+    /// The NVFP4 half of the plan. Asked BEFORE the layer exists, so it may
+    /// not depend on any layer-local kernel handle — pinned by
+    /// `attn_nvfp4_does_not_depend_on_the_w8a8_kernels`.
+    pub fn attn_nvfp4(&self, attn_fp8: bool) -> bool {
+        self.plan(false, attn_fp8, true).attn_nvfp4
+    }
+
+    /// Which FP8 prefill twins this layer needs. `w8a8_kernels` is read off
+    /// the constructed layer (`Qwen3AttentionLayer::has_w8a8_prefill_kernels`).
+    pub fn attn_fp8_twins(&self, attn_fp8: bool, w8a8_kernels: bool) -> Fp8TwinSet {
+        self.plan(false, attn_fp8, w8a8_kernels).attn_fp8_twins
+    }
+}
+
+/// Bytes one NVFP4 `QuantizedWeight` costs: packed `[N, K/2]` E2M1 nibbles
+/// plus the `[N, K/16]` per-group scale byte. Mirrors `quantize_to_nvfp4`
+/// (`weight_map/loaders_fp8.rs:229`-`230`) and `transpose_for_gemm_gs`
+/// (`weight_map/quantized.rs:261`-`262`), which allocate the same two sizes.
+pub fn nvfp4_bytes(n: usize, k: usize) -> usize {
+    n * k / 2 + n * k / 16
+}
+
+/// What the pre-#915 loader spent per dense-FFN layer on NVFP4: gate, up and
+/// down, each with a transposed twin of identical size.
+pub fn dense_ffn_nvfp4_bytes(hidden: usize, inter: usize) -> usize {
+    // gate/up are [inter, hidden] and down is [hidden, inter] — the same
+    // element count, so all three cost the same.
+    3 * 2 * nvfp4_bytes(inter, hidden)
+}
+
+/// What the pre-#915 loader spent per full-attention layer on NVFP4: q/k/v/o,
+/// each with a transposed twin, plus the fused `[q|k|v]` transposed twin
+/// (`transpose_concat_for_gemm`).
+///
+/// `q_n` is `num_attention_heads * head_dim`, doubled when `attn_gated`;
+/// `kv_n` is `num_key_value_heads * head_dim`; `o_k` is the o_proj contraction
+/// width `num_attention_heads * head_dim`.
+pub fn attn_nvfp4_bytes(q_n: usize, kv_n: usize, o_k: usize, hidden: usize) -> usize {
+    let qkv = nvfp4_bytes(q_n, hidden) + 2 * nvfp4_bytes(kv_n, hidden);
+    let o = nvfp4_bytes(hidden, o_k);
+    // base + per-projection twin + the fused q|k|v twin
+    2 * (qkv + o) + nvfp4_bytes(q_n + 2 * kv_n, hidden)
+}
+
+/// Bytes one FP8 `[K, N]` transposed twin costs: the E4M3 bytes plus the
+/// transposed `[K/128, N/128]` FP32 block-scale grid. Mirrors
+/// `Fp8Weight::transpose_for_gemm` (`weight_map/quantized.rs:643`/`:660`).
+pub fn fp8_twin_bytes(n: usize, k: usize) -> usize {
+    n * k + n.div_ceil(128) * k.div_ceil(128) * 4
+}
+
+/// The FP8 prefill twins `want` selects, for one full-attention layer.
+pub fn attn_fp8_twin_bytes(
+    want: Fp8TwinSet,
+    q_n: usize,
+    kv_n: usize,
+    o_k: usize,
+    hidden: usize,
+) -> usize {
+    let mut b = 0;
+    if want.q {
+        b += fp8_twin_bytes(q_n, hidden);
+    }
+    if want.k {
+        b += fp8_twin_bytes(kv_n, hidden);
+    }
+    if want.v {
+        b += fp8_twin_bytes(kv_n, hidden);
+    }
+    if want.o {
+        b += fp8_twin_bytes(hidden, o_k);
+    }
+    b
+}
+
+/// Running tally of the derived (non-checkpoint) device bytes this loader
+/// allocated, and of the ones it decided not to build.
+///
+/// Counted in the loader rather than read back from the ledger because the
+/// ledger cannot tell a derived copy from a checkpoint tensor — both are plain
+/// `gpu.alloc` — and because the "not built" number is the one the fix is
+/// judged on and has no allocation to read.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DerivedResidency {
+    /// Derived bytes still resident at the end of load.
+    pub kept: u64,
+    /// Derived bytes the plan declined to build, versus the pre-#915 loader.
+    pub skipped: u64,
+    /// Transient derived bytes allocated and freed during load.
+    pub freed: u64,
+    /// Which twin families were built, for the one-line summary.
+    pub twins: TwinsBuilt,
+}
+
+/// Which derived twin families the plan built. Reported by name so the serve
+/// log says *which* copies are resident rather than only how many bytes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TwinsBuilt {
+    pub ffn_nvfp4: bool,
+    pub attn_nvfp4: bool,
+    pub attn_fp8: bool,
+    pub ssm_fp8_concat: bool,
+}
+
+impl TwinsBuilt {
+    /// `none`, or a comma-separated list, for the summary line.
+    pub fn describe(self) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        if self.ffn_nvfp4 {
+            parts.push("ffn-nvfp4+t");
+        }
+        if self.attn_nvfp4 {
+            parts.push("attn-nvfp4+t");
+        }
+        if self.attn_fp8 {
+            parts.push("attn-fp8-t");
+        }
+        if self.ssm_fp8_concat {
+            parts.push("ssm-qkvz-fp8");
+        }
+        if parts.is_empty() {
+            "none".to_owned()
+        } else {
+            parts.join(", ")
+        }
+    }
+}
+
+impl DerivedResidency {
+    pub fn keep(&mut self, bytes: usize) {
+        self.kept += bytes as u64;
+    }
+
+    pub fn skip(&mut self, bytes: usize) {
+        self.skipped += bytes as u64;
+    }
+
+    pub fn free(&mut self, bytes: usize) {
+        self.freed += bytes as u64;
+    }
+
+    /// The line the next H100 run is read against.
+    ///
+    /// Emitted at the end of `load_layers` so a serve log proves the residency
+    /// without an `ATLAS_MEM_PROFILE` rerun: `weights` is the checkpoint,
+    /// `derived` is everything this loader built on top of it, and `skipped`
+    /// is what the pre-#915 loader would have built and this one did not.
+    pub fn summary(&self, weight_bytes: usize) -> String {
+        let gb = |b: u64| b as f64 / 1e9;
+        format!(
+            "native FP8 dense residency: weights {:.2} GB, derived {:.2} GB \
+             (twins: {}), freed {:.2} GB, not built {:.2} GB",
+            weight_bytes as f64 / 1e9,
+            gb(self.kept),
+            self.twins.describe(),
+            gb(self.freed),
+            gb(self.skipped),
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "fp8_residency_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The native-FP8 dense loader's decision table (#915).
+//!
+//! Every case is a route the H100 serve can actually be put into, expressed
+//! through the SAME `GemmDispatch` the forward pass carries — not through the
+//! process environment, which a `OnceLock` resolver would pin for the whole
+//! test binary.
+
+use super::*;
+use crate::layers::ops::GemmDispatch;
+
+/// The shape a native-FP8 dense serve boots in with no `ATLAS_*` set: FP8
+/// overlays on both the FFN and attention, block-scaled prefill on, the W8A8
+/// kernels present.
+fn h100_default() -> DenseFp8Inputs {
+    DenseFp8Inputs {
+        ffn_fp8: true,
+        attn_fp8: true,
+        keep_nvfp4: false,
+        dispatch: GemmDispatch::defaults(),
+        w8a8_kernels: true,
+        attn_w4a4: false,
+        attn_prefill_q_t: false,
+    }
+}
+
+/// K and V, and nothing else: the measured default route.
+const KV_ONLY: Fp8TwinSet = Fp8TwinSet {
+    q: false,
+    k: true,
+    v: true,
+    o: false,
+};
+
+#[test]
+fn default_native_fp8_route_builds_no_nvfp4_and_only_the_kv_fp8_twins() {
+    let p = DenseFp8Plan::resolve(h100_default());
+    assert_eq!(
+        p,
+        DenseFp8Plan {
+            ffn_nvfp4: false,
+            attn_nvfp4: false,
+            attn_fp8_twins: KV_ONLY,
+        },
+        "the dense FFN and the attention NVFP4 fallbacks are unreachable; K/V \
+         FP8 twins are NOT (cache_skip_qkv.rs has no W8A8 arm)"
+    );
+}
+
+#[test]
+fn the_kv_fp8_twins_survive_every_default_route_variation() {
+    // `cache_skip_qkv.rs:218`/`:235` dereference them on the FIRST prefill
+    // chunk of every request, with no W8A8 arm ahead of them. No lever below
+    // may take them away — this is the NULL-pointer-launch regression guard.
+    for dispatch in [
+        GemmDispatch::defaults(),
+        GemmDispatch {
+            fp8_blockscaled_prefill: false,
+            ..GemmDispatch::defaults()
+        },
+    ] {
+        for w8a8_kernels in [true, false] {
+            for attn_prefill_q_t in [true, false] {
+                let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+                    dispatch,
+                    w8a8_kernels,
+                    attn_prefill_q_t,
+                    ..h100_default()
+                });
+                assert!(p.attn_fp8_twins.k && p.attn_fp8_twins.v, "{p:?}");
+            }
+        }
+    }
+}
+
+#[test]
+fn a_non_fp8_layer_keeps_every_nvfp4_copy_and_gets_no_fp8_twins() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        ffn_fp8: false,
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert!(p.ffn_nvfp4, "no FP8 overlay -> NVFP4 is the only weight");
+    assert!(p.attn_nvfp4);
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet::NONE,
+        "there are no FP8 weights to transpose on a non-FP8 layer"
+    );
+}
+
+#[test]
+fn the_ffn_and_attention_overlays_are_decided_independently() {
+    // `proj_is_native_fp8` is checked per projection family, so a checkpoint
+    // can ship a native-FP8 FFN beside BF16-dequant attention.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert!(!p.ffn_nvfp4);
+    assert!(p.attn_nvfp4);
+
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        ffn_fp8: false,
+        ..h100_default()
+    });
+    assert!(p.ffn_nvfp4);
+    assert!(!p.attn_nvfp4);
+}
+
+#[test]
+fn single_scale_prefill_brings_the_q_and_o_fp8_twins_back() {
+    // ATLAS_FP8_SINGLE_SCALE clears `fp8_blockscaled_prefill`, which makes the
+    // W8A8 arms in `paged_qkv.rs:220` / `paged_oproj.rs:94` decline — prefill
+    // then lands on `w8a16_gemm_n128_m128`, which reads `weight_t`/`scale_t`.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            fp8_blockscaled_prefill: false,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::ALL);
+    assert!(
+        !p.ffn_nvfp4,
+        "the dense FFN still never reads NVFP4: `w8_gemm!` binds its \
+         transposed operand to a literal None on every rung"
+    );
+}
+
+#[test]
+fn a_target_without_the_w8a8_kernels_keeps_every_fp8_twin() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        w8a8_kernels: false,
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::ALL);
+}
+
+#[test]
+fn the_q_transpose_lever_keeps_only_the_q_twin() {
+    // `cache_skip_qkv.rs:142` reads ATLAS_ATTN_PREFILL_Q_T per prefill and is
+    // NOT memoised, so the loader has to mirror it or free a twin a later
+    // getenv re-enables.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_prefill_q_t: true,
+        ..h100_default()
+    });
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet {
+            q: true,
+            k: true,
+            v: true,
+            o: false,
+        }
+    );
+}
+
+#[test]
+fn every_cutlass_nvfp4_attention_lever_keeps_the_nvfp4_attention_copies() {
+    for set in [
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_gemm = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_q = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_kv = true,
+        |d: &mut GemmDispatch| d.cutlass_nvfp4_attn_o = true,
+    ] {
+        let mut dispatch = GemmDispatch::defaults();
+        set(&mut dispatch);
+        let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+            dispatch,
+            ..h100_default()
+        });
+        assert!(
+            p.attn_nvfp4,
+            "a CUTLASS NVFP4 attention lever reads the transposed NVFP4 twin: {dispatch:?}"
+        );
+    }
+}
+
+#[test]
+fn the_umbrella_nvfp4_flag_builds_no_fp8_twins() {
+    // `transpose_fp8_for_prefill` itself early-returns under this flag
+    // (`prefill_weights.rs:357`); the plan must agree or the two drift.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            cutlass_nvfp4_gemm: true,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert_eq!(p.attn_fp8_twins, Fp8TwinSet::NONE);
+    assert!(p.attn_nvfp4);
+}
+
+#[test]
+fn attn_w4a4_keeps_the_nvfp4_o_proj() {
+    // `prefill/paged_oproj.rs:38-42` builds its W4A4 arm with NO weight-type
+    // predicate and feeds it `&self.attn.o_proj`, so a NULL o_proj under this
+    // lever is a NULL-pointer kernel launch. (The QKV side at
+    // `paged_qkv.rs:51` does check `as_nvfp4()` and is already closed.)
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        attn_w4a4: true,
+        ..h100_default()
+    });
+    assert!(p.attn_nvfp4);
+}
+
+#[test]
+fn an_ssm_only_lever_does_not_resurrect_the_attention_copies() {
+    // `cutlass_nvfp4_ssm_out` is deliberately not implied by the umbrella flag
+    // and does not touch attention — see `ops/dispatch_config.rs`.
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        dispatch: GemmDispatch {
+            cutlass_nvfp4_ssm_out: true,
+            ..GemmDispatch::defaults()
+        },
+        ..h100_default()
+    });
+    assert!(!p.attn_nvfp4);
+}
+
+#[test]
+fn attn_nvfp4_does_not_depend_on_the_w8a8_kernels() {
+    // `RouteEnv::attn_nvfp4` is asked BEFORE the layer exists, so it passes a
+    // placeholder for the layer-local handle. That is only sound while this
+    // holds.
+    for w8a8_kernels in [true, false] {
+        for attn_fp8 in [true, false] {
+            let a = DenseFp8Plan::resolve(DenseFp8Inputs {
+                attn_fp8,
+                w8a8_kernels,
+                ..h100_default()
+            });
+            let b = DenseFp8Plan::resolve(DenseFp8Inputs {
+                attn_fp8,
+                w8a8_kernels: !w8a8_kernels,
+                ..h100_default()
+            });
+            assert_eq!(a.attn_nvfp4, b.attn_nvfp4);
+        }
+    }
+}
+
+#[test]
+fn the_escape_hatch_restores_the_pre_915_loader() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        keep_nvfp4: true,
+        ..h100_default()
+    });
+    assert_eq!(
+        p,
+        DenseFp8Plan {
+            ffn_nvfp4: true,
+            attn_nvfp4: true,
+            attn_fp8_twins: Fp8TwinSet::ALL,
+        },
+        "ATLAS_DENSE_FP8_KEEP_NVFP4 must reproduce the old footprint exactly, \
+         or it is useless for bisecting a suspected gap in this table"
+    );
+}
+
+#[test]
+fn the_escape_hatch_cannot_invent_fp8_twins_on_a_non_fp8_layer() {
+    let p = DenseFp8Plan::resolve(DenseFp8Inputs {
+        keep_nvfp4: true,
+        attn_fp8: false,
+        ..h100_default()
+    });
+    assert_eq!(
+        p.attn_fp8_twins,
+        Fp8TwinSet::NONE,
+        "there is no FP8 weight to transpose"
+    );
+}
+
+/// The Qwen3.8-27B-FP8 numbers from the H100 ledger, reproduced from the
+/// shapes. If these drift, the attribution in the module docs is wrong.
+#[test]
+fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
+    const H: usize = 5120;
+    const INTER: usize = 17408;
+    const MIB: usize = 1024 * 1024;
+
+    // `loaders_fp8.rs:229` + `quantized.rs:261` (packed) and `:230` + `:262`
+    // (scales), 8,960 MB + 1,120 MB each across 256 allocations: 64 layers x 3
+    // FFN projections plus 16 attention layers x 4.
+    let ffn = dense_ffn_nvfp4_bytes(H, INTER);
+    assert_eq!(
+        ffn / MIB,
+        3 * 2 * (42 * 2 + 5) + 3,
+        "≈127.5 MiB x2 per layer"
+    );
+    assert_eq!(64 * ffn / MIB, 2 * (8160 + 1020));
+
+    // 16 attention layers: q_n = 10240 (gated), kv_n = 2560, o_k = 5120.
+    let attn = attn_nvfp4_bytes(10240, 2560, 5120, H);
+    // Base + twin for q/k/v/o is 800 MB + 100 MB over the 16 layers; the fused
+    // q|k|v twin is the remainder and is NOT part of the ledger's 8,960 row.
+    let paired = 2 * (nvfp4_bytes(10240, H) + 2 * nvfp4_bytes(2560, H) + nvfp4_bytes(H, 5120));
+    assert_eq!(16 * paired / MIB, 2 * (800 + 100));
+    assert!(attn > paired, "the fused twin is extra");
+
+    // `quantized.rs:643`, 1,600 MB x64 = the four FP8 prefill twins x16 layers.
+    let twins = attn_fp8_twin_bytes(Fp8TwinSet::ALL, 10240, 2560, 5120, H);
+    assert_eq!(16 * (twins / MIB), 1600, "100 MiB of FP8 twins per layer");
+
+    // What the default route now declines: the whole FFN NVFP4 family, the
+    // whole attention NVFP4 family, and the Q+O FP8 twins.
+    let declined =
+        64 * ffn + 16 * attn + 16 * (twins - attn_fp8_twin_bytes(KV_ONLY, 10240, 2560, 5120, H));
+    assert!(
+        (20.0..23.0).contains(&(declined as f64 / 1e9)),
+        "expected ~21 GB not built, got {} GB",
+        declined as f64 / 1e9
+    );
+}
+
+#[test]
+fn the_summary_line_names_the_twins_it_built() {
+    let mut r = DerivedResidency::default();
+    r.keep(3_840 * 1024 * 1024);
+    r.skip(20_000 * 1024 * 1024);
+    r.free(1_024 * 1024 * 1024);
+    r.twins.ssm_fp8_concat = true;
+    let line = r.summary(28_747 * 1024 * 1024);
+    assert!(
+        line.starts_with("native FP8 dense residency: weights "),
+        "{line}"
+    );
+    assert!(line.contains("(twins: ssm-qkvz-fp8)"), "{line}");
+    assert!(line.contains("not built "), "{line}");
+}
+
+#[test]
+fn no_twins_reads_as_none_not_as_an_empty_list() {
+    assert_eq!(TwinsBuilt::default().describe(), "none");
+    assert_eq!(
+        TwinsBuilt {
+            ffn_nvfp4: true,
+            attn_fp8: true,
+            ..TwinsBuilt::default()
+        }
+        .describe(),
+        "ffn-nvfp4+t, attn-fp8-t"
+    );
+}

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -287,12 +287,12 @@ fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
     // (scales), 8,960 MB + 1,120 MB each across 256 allocations: 64 layers x 3
     // FFN projections plus 16 attention layers x 4.
     let ffn = dense_ffn_nvfp4_bytes(H, INTER);
+    assert_eq!(ffn / MIB, 286, "127.5 MiB of NVFP4 per layer, twice over");
     assert_eq!(
-        ffn / MIB,
-        3 * 2 * (42 * 2 + 5) + 3,
-        "≈127.5 MiB x2 per layer"
+        64 * ffn / MIB,
+        2 * (8160 + 1020),
+        "8,160 MB of the 8,960 packed row and 1,020 of the 1,120 scale row"
     );
-    assert_eq!(64 * ffn / MIB, 2 * (8160 + 1020));
 
     // 16 attention layers: q_n = 10240 (gated), kv_n = 2560, o_k = 5120.
     let attn = attn_nvfp4_bytes(10240, 2560, 5120, H);

--- a/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/fp8_residency_tests.rs
@@ -311,8 +311,8 @@ fn the_h100_ledger_rows_reproduce_from_the_model_shapes() {
     let declined =
         64 * ffn + 16 * attn + 16 * (twins - attn_fp8_twin_bytes(KV_ONLY, 10240, 2560, 5120, H));
     assert!(
-        (20.0..23.0).contains(&(declined as f64 / 1e9)),
-        "expected ~21 GB not built, got {} GB",
+        (22.5..23.5).contains(&(declined as f64 / 1e9)),
+        "expected ~23.1 GB of the sweep's 28.01 GB not to be built, got {} GB",
         declined as f64 / 1e9
     );
 }

--- a/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
@@ -91,8 +91,8 @@ pub enum DerivedBytesEstimate {
     /// The native-FP8 dense route will run and its derived bytes are this.
     NativeFp8Dense(PredictedDerived),
     /// No prediction. The `&'static str` is the reason, written to be
-    /// readable in a serve log ("… — falling back to pre-load free memory
-    /// (<reason>)").
+    /// readable in a serve log (`… — falling back to pre-load free memory
+    /// (<reason>)`).
     Unavailable(&'static str),
 }
 

--- a/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The derived-weight residency of the native-FP8 dense route, predicted from
+//! `config.json` alone — BEFORE the checkpoint loads.
+//!
+//! **WHY (#915 second pass).** `fp8_residency::DerivedResidency` tallies the
+//! derived copies as the loader builds them, which is four minutes too late
+//! for the one decision that needs the number: preflight's SSM decode-ring
+//! auto-fit runs before the first byte of the checkpoint is read, and its
+//! first pass therefore fitted the ring against PRE-LOAD free memory (78.6 GB
+//! on an 80 GB H100) instead of against the post-load KV headroom the KV
+//! budget stage actually enforces. Measured on 1xH100 2026-09-11
+//! (`h100-round2-report.md`, stage 3/5): at `--max-batch-size 16` and 32 the
+//! fitter stayed silent — 8 slots, 18.94 / 37.88 GB of ring — and the serve
+//! was refused minutes later by
+//! `factory/build.rs`'s `No memory left for KV cache`. The fit needs the
+//! post-load figure, and the only part of it that is not already known at
+//! preflight is how many bytes the loader will derive on top of the
+//! checkpoint.
+//!
+//! It IS knowable: every derived copy on this route is shape arithmetic over
+//! the config, and which copies get built is
+//! [`fp8_residency::DenseFp8Plan::resolve`], a pure function of the
+//! environment plus one backend question (are the two W8A8 prefill kernels
+//! loaded). This module evaluates both without a `WeightStore`.
+//!
+//! **Round-6 receipt** (`h100-round6-report.md`; serve I, Qwen3.8-27B-FP8,
+//! `ATLAS_DENSE_FP8=1`, `--lm-head-dtype bf16`, tp 1): the loader's own
+//! summary line reported **derived 4.24 GB** on top of a 28.75 GB checkpoint.
+//! Reproduced here from `kernels/hopper/qwen3.8-27b/MODEL.toml`'s shapes:
+//!
+//! | term | per layer | layers | total |
+//! |---|---|---|---|
+//! | attn FP8 K twin + V twin | 10,488,320 B | 16 | 0.168 GB |
+//! | SSM fused `[QKV\|Z]` FP8 weight | 83,886,080 B | 48 | 4.027 GB |
+//! | SSM `[QKV\|Z]` + out_proj block scales | 28,160 B | 48 | 0.001 GB |
+//! | SSM `in_proj_ba` interleaved BF16 | 983,040 B | 48 | 0.047 GB |
+//! | **total** | | | **4.243 GB** |
+//!
+//! Q and O twins are absent from that total because the round-6 target ships
+//! both W8A8 prefill kernels, so `DenseFp8Plan` declines them — which is why
+//! [`Fp8RouteInputs::w8a8_prefill_kernels`] is an input and not an assumption.
+//!
+//! **What this module deliberately refuses to predict.** Anything that
+//! re-opens an NVFP4 fallback (`ATLAS_DENSE_FP8_KEEP_NVFP4`, the
+//! `ATLAS_CUTLASS_NVFP4_*` levers, `ATLAS_ATTN_W4A4`) returns
+//! [`DerivedBytesEstimate::Unavailable`] rather than a guess: those paths
+//! resurrect 18+ GiB of copies whose byte count the loader tallies through
+//! `skip`, not `keep`, so a prediction built on `keep` would be wrong by more
+//! than the quantity being predicted. The caller falls back to its pre-load
+//! behaviour and says so in the log.
+
+use atlas_core::config::ModelConfig;
+
+use super::fp8_residency::{self, RouteEnv, TwinsBuilt};
+use crate::layers::qwen3_attention::Fp8TwinSet;
+use crate::weight_map::Nvfp4Variant;
+
+/// The derived bytes the native-FP8 dense loader will allocate and KEEP,
+/// broken out so the preflight log can name each term.
+///
+/// Mirrors `DerivedResidency::kept` term for term — see the module docs'
+/// receipt table — so `predicted.total()` and the serve log's
+/// `native FP8 dense residency: ... derived X GB` are the same arithmetic
+/// evaluated at two different times.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PredictedDerived {
+    /// `Fp8Weight::transpose_for_gemm` twins for the projections
+    /// [`fp8_residency::DenseFp8Plan`] selects, summed over full-attention
+    /// layers.
+    pub attn_fp8_twins: u64,
+    /// The fused `[QKV|Z]` FP8 weight, its block-scale grid, the `out_proj`
+    /// block-scale grid and the interleaved `in_proj_ba`, summed over
+    /// linear-attention layers.
+    pub ssm_fp8_concat: u64,
+    /// Which twin families the prediction expects, for the log line.
+    pub twins: TwinsBuilt,
+    /// The twin set the attention term was priced at.
+    pub attn_twin_set: Fp8TwinSet,
+}
+
+impl PredictedDerived {
+    pub fn total(&self) -> u64 {
+        self.attn_fp8_twins + self.ssm_fp8_concat
+    }
+}
+
+/// The answer, or an honest refusal to answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DerivedBytesEstimate {
+    /// The native-FP8 dense route will run and its derived bytes are this.
+    NativeFp8Dense(PredictedDerived),
+    /// No prediction. The `&'static str` is the reason, written to be
+    /// readable in a serve log ("… — falling back to pre-load free memory
+    /// (<reason>)").
+    Unavailable(&'static str),
+}
+
+impl DerivedBytesEstimate {
+    /// Predicted bytes, or `None` when unavailable.
+    pub fn bytes(&self) -> Option<u64> {
+        match self {
+            Self::NativeFp8Dense(p) => Some(p.total()),
+            Self::Unavailable(_) => None,
+        }
+    }
+
+    pub fn reason(&self) -> Option<&'static str> {
+        match self {
+            Self::NativeFp8Dense(_) => None,
+            Self::Unavailable(why) => Some(*why),
+        }
+    }
+}
+
+/// The route gates `load_layers` applies, resolved from the things that exist
+/// before the checkpoint does.
+///
+/// One field per clause of the loader's own `ffn_fp8` / `attn_fp8` /
+/// `gdn_fp8_arm_selected` conditions, so a reader can diff this struct
+/// against `qwen35_dense.rs:319`, `:578` and `:172` line by line.
+#[derive(Clone, Copy, Debug)]
+pub struct Fp8RouteInputs {
+    /// `ATLAS_DENSE_FP8=1` — `qwen35_dense::dense_fp8_enabled`.
+    pub dense_fp8: bool,
+    /// `config.tp_world_size.max(1)`. The FP8 dense route is single-GPU only.
+    pub tp_size: usize,
+    /// The variant the CONFIG declares. `None` when config.json does not say
+    /// — the loader would sniff the store, which does not exist yet.
+    pub declared_variant: Option<Nvfp4Variant>,
+    /// `ATLAS_NO_GDN_FP8` is unset — `qwen35_dense::gdn_fp8_arm_selected`.
+    pub gdn_fp8: bool,
+    /// Both `qwen3_attention::W8A8_PREFILL_KERNELS` are loaded for this
+    /// target. Decides whether the Q and O FP8 prefill twins get built.
+    pub w8a8_prefill_kernels: bool,
+    /// The environment-resolved dispatch route the loader itself reads.
+    pub route: RouteEnv,
+}
+
+impl Fp8RouteInputs {
+    /// Resolve every gate from the process environment and the config,
+    /// through the SAME predicates the loader uses.
+    ///
+    /// `w8a8_prefill_kernels` is the caller's, because it is a property of
+    /// the loaded kernel set rather than of the environment — ask
+    /// [`crate::layers::qwen3_attention::w8a8_prefill_kernels_loaded`].
+    pub fn from_env(config: &ModelConfig, w8a8_prefill_kernels: bool) -> Self {
+        Self {
+            // Character for character `qwen35_dense::dense_fp8_enabled`:
+            // `== Ok("1")`, NOT presence. `ATLAS_DENSE_FP8=0` is off.
+            dense_fp8: std::env::var("ATLAS_DENSE_FP8").as_deref() == Ok("1"),
+            tp_size: config.tp_world_size.max(1),
+            declared_variant: crate::weight_map::config_declared_variant(config),
+            // Presence, matching `gdn_fp8_arm_selected`'s `is_none()`.
+            gdn_fp8: std::env::var_os("ATLAS_NO_GDN_FP8").is_none(),
+            w8a8_prefill_kernels,
+            route: RouteEnv::from_env(),
+        }
+    }
+}
+
+/// Bytes the native-FP8 dense loader will derive on top of the checkpoint.
+///
+/// Pure: no environment reads, no allocation, no device access. The `route`
+/// argument carries everything impure (see [`Fp8RouteInputs::from_env`]), so
+/// the decision table below is testable at exact integers.
+pub fn predicted_derived_bytes(
+    config: &ModelConfig,
+    route: &Fp8RouteInputs,
+) -> DerivedBytesEstimate {
+    // ── Gate 1: is this even the Qwen3.5-dense loader? ────────────────────
+    // `factory::loader_for_config` picks `Qwen35DenseWeightLoader` on
+    // `is_qwen35_dense()` and nothing else reaches this arithmetic.
+    if !config.is_qwen35_dense() {
+        return DerivedBytesEstimate::Unavailable("not the Qwen3.5-dense loader");
+    }
+    if !route.dense_fp8 {
+        return DerivedBytesEstimate::Unavailable("ATLAS_DENSE_FP8 is not 1");
+    }
+    if route.tp_size != 1 {
+        return DerivedBytesEstimate::Unavailable("--tp-size > 1 takes the NVFP4 route");
+    }
+    if route.declared_variant != Some(Nvfp4Variant::Fp8Dequanted) {
+        // Either the config declares a non-FP8 scheme, or it declares nothing
+        // and the loader will sniff the store. Both are "ask again after the
+        // load", never "assume FP8".
+        return DerivedBytesEstimate::Unavailable(
+            "config.json does not declare a block-scaled FP8 checkpoint",
+        );
+    }
+    if route.route.keep_nvfp4 {
+        return DerivedBytesEstimate::Unavailable(
+            "ATLAS_DENSE_FP8_KEEP_NVFP4 restores the pre-#915 fallback copies",
+        );
+    }
+
+    // ── Gate 2: does the plan keep any NVFP4 copy alive? ──────────────────
+    // `DerivedResidency` tallies NVFP4 builds through `skip`, never `keep`,
+    // so a prediction of `kept` cannot price them. Rather than guess at
+    // 18+ GiB, decline. Asked at `attn_fp8 = true` because that is the route
+    // under test; `ffn_nvfp4` is `!ffn_fp8` and is false by construction here.
+    let plan = fp8_residency::DenseFp8Plan::resolve(fp8_residency::DenseFp8Inputs {
+        ffn_fp8: true,
+        attn_fp8: true,
+        keep_nvfp4: false,
+        dispatch: route.route.dispatch,
+        w8a8_kernels: route.w8a8_prefill_kernels,
+        attn_w4a4: route.route.attn_w4a4,
+        attn_prefill_q_t: route.route.attn_prefill_q_t,
+    });
+    if plan.ffn_nvfp4 || plan.attn_nvfp4 {
+        return DerivedBytesEstimate::Unavailable(
+            "an NVFP4 fallback lever (ATLAS_CUTLASS_NVFP4_* / ATLAS_ATTN_W4A4) is set",
+        );
+    }
+
+    let hidden = config.hidden_size;
+    let (nh, hd) = (config.num_attention_heads, config.head_dim);
+    let nkv = config.num_key_value_heads;
+    // Same three lines as `qwen35_dense.rs:953`-`:956`.
+    let q_n = nh * hd * if config.attn_gated { 2 } else { 1 };
+    let attn_layers = config.num_attention_layers() as u64;
+    let attn_fp8_twins = attn_layers
+        * fp8_residency::attn_fp8_twin_bytes(plan.attn_fp8_twins, q_n, nkv * hd, nh * hd, hidden)
+            as u64;
+
+    let ssm_layers = config.num_ssm_layers() as u64;
+    let ssm_fp8_concat = if route.gdn_fp8 && ssm_layers > 0 {
+        ssm_layers * ssm_concat_bytes(config) as u64
+    } else {
+        0
+    };
+
+    DerivedBytesEstimate::NativeFp8Dense(PredictedDerived {
+        attn_fp8_twins,
+        ssm_fp8_concat,
+        twins: TwinsBuilt {
+            ffn_nvfp4: false,
+            attn_nvfp4: false,
+            attn_fp8: plan.attn_fp8_twins.any() && attn_layers > 0,
+            ssm_fp8_concat: ssm_fp8_concat > 0,
+        },
+        attn_twin_set: plan.attn_fp8_twins,
+    })
+}
+
+/// What ONE native-FP8 GDN layer keeps beyond the checkpoint bytes.
+///
+/// Mirrors `qwen35_dense.rs:1163`-`:1181` term for term:
+///
+/// * the fused `[QKV|Z]` E4M3 weight `concat_fp8_block_scaled` builds —
+///   `ssm_qkvz_size() x hidden` bytes, and there is no un-fused dispatch to
+///   fall back to, so it stays resident;
+/// * the concatenated `[N/128, K/128]` FP32 block-scale grid, which is the
+///   two source grids copied side by side (hence the sum, not one grid over
+///   the fused N — `ceil` of a sum is not the sum of the `ceil`s);
+/// * the `out_proj` block-scale grid, adopted for the same reason;
+/// * `in_proj_ba`, the `[2*nv, hidden]` BF16 interleave of `in_proj_a` and
+///   `in_proj_b`.
+///
+/// The per-projection source scale allocations are FREED right after the
+/// concat (`residency.free`), so they are transient and correctly absent.
+fn ssm_concat_bytes(config: &ModelConfig) -> usize {
+    let hidden = config.hidden_size;
+    let block_grid = |n: usize, k: usize| n.div_ceil(128) * k.div_ceil(128) * 4;
+    let qkv_n = config.ssm_qkv_size();
+    let z_n = config.ssm_z_size();
+    let qkvz_bytes = config.ssm_qkvz_size() * hidden;
+    let qkvz_scale_bytes = block_grid(qkv_n, hidden) + block_grid(z_n, hidden);
+    // `out_proj` is `[hidden, value_dim]`.
+    let out_scale_bytes = block_grid(hidden, config.ssm_z_size());
+    let ba_bytes = config.linear_num_value_heads * 2 * hidden * 2;
+    qkvz_bytes + qkvz_scale_bytes + out_scale_bytes + ba_bytes
+}
+
+#[cfg(test)]
+#[path = "predicted_residency_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency.rs
@@ -27,7 +27,10 @@
 //! **Round-6 receipt** (`h100-round6-report.md`; serve I, Qwen3.8-27B-FP8,
 //! `ATLAS_DENSE_FP8=1`, `--lm-head-dtype bf16`, tp 1): the loader's own
 //! summary line reported **derived 4.24 GB** on top of a 28.75 GB checkpoint.
-//! Reproduced here from `kernels/hopper/qwen3.8-27b/MODEL.toml`'s shapes:
+//! Reproduced here from `kernels/gb10/qwen3.8-27b/MODEL.toml`'s shapes, plus
+//! the GDN head geometry, which no MODEL.toml carries and which
+//! `ModelConfig` therefore reads from the checkpoint's own `config.json`
+//! (16x128 key heads, 48x128 value heads):
 //!
 //! | term | per layer | layers | total |
 //! |---|---|---|---|

--- a/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency_tests.rs
@@ -2,11 +2,14 @@
 
 //! Exact-integer pins for the pre-load derived-residency prediction (#915).
 //!
-//! The fixture is `kernels/hopper/qwen3.8-27b/MODEL.toml` — the shapes of the
-//! checkpoint the H100 rounds actually served — and the number the prediction
-//! is judged against is the loader's OWN summary line from round 6
-//! (`h100-round6-report.md`, serve I): `native FP8 dense residency: weights
-//! 28.75 GB, derived 4.24 GB`.
+//! The shapes are `kernels/gb10/qwen3.8-27b/MODEL.toml`'s — that is the only
+//! MODEL.toml for this checkpoint on `main`, and its architecture block is
+//! target-independent: the Hopper copy that the H100 rounds ran under repeats
+//! those fields verbatim and adds nothing but `expected_absent` entries. So
+//! the fixture is the checkpoint the H100 rounds served, cited at a path that
+//! exists in this tree. The number the prediction is judged against is the
+//! loader's OWN summary line from round 6 (`h100-round6-report.md`, serve I):
+//! `native FP8 dense residency: weights 28.75 GB, derived 4.24 GB`.
 //!
 //! No GPU, no checkpoint, no environment: `Fp8RouteInputs` is built by hand so
 //! the decision table is pinned rather than the machine the test runs on.
@@ -16,10 +19,15 @@ use atlas_core::config::{LayerType, ModelConfig, QuantizationConfig};
 
 use crate::layers::ops::GemmDispatch;
 
-/// `Qwen/Qwen3.8-27B-FP8` as `kernels/hopper/qwen3.8-27b/MODEL.toml` declares
-/// it: 64 layers on a 4-cycle (16 full attention, 48 GDN), hidden 5120,
-/// head_dim 256, 24 q heads, 4 kv heads, output-gated attention, GDN
-/// 16x128 key heads and 48x128 value heads.
+/// `Qwen/Qwen3.8-27B-FP8` at the shapes `kernels/gb10/qwen3.8-27b/MODEL.toml`
+/// declares: 64 layers on a 4-cycle (16 full attention, 48 GDN), hidden 5120,
+/// head_dim 256, 24 q heads, 4 kv heads, output-gated attention.
+///
+/// The GDN head geometry below — 16x128 key heads, 48x128 value heads — is
+/// NOT from that file. No MODEL.toml carries the linear-attention head
+/// fields; `ModelConfig` reads them from the checkpoint's `config.json`, and
+/// they are reproduced here because the 83,886,080-byte fused `[QKV|Z]` term
+/// is arithmetic over them.
 fn qwen38_27b() -> ModelConfig {
     let mut c = ModelConfig::qwen3_next_80b_nvfp4();
     c.model_type = "qwen3_5".to_string();

--- a/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency_tests.rs
+++ b/crates/spark-model/src/weight_loader/qwen35_dense/predicted_residency_tests.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact-integer pins for the pre-load derived-residency prediction (#915).
+//!
+//! The fixture is `kernels/hopper/qwen3.8-27b/MODEL.toml` — the shapes of the
+//! checkpoint the H100 rounds actually served — and the number the prediction
+//! is judged against is the loader's OWN summary line from round 6
+//! (`h100-round6-report.md`, serve I): `native FP8 dense residency: weights
+//! 28.75 GB, derived 4.24 GB`.
+//!
+//! No GPU, no checkpoint, no environment: `Fp8RouteInputs` is built by hand so
+//! the decision table is pinned rather than the machine the test runs on.
+
+use super::*;
+use atlas_core::config::{LayerType, ModelConfig, QuantizationConfig};
+
+use crate::layers::ops::GemmDispatch;
+
+/// `Qwen/Qwen3.8-27B-FP8` as `kernels/hopper/qwen3.8-27b/MODEL.toml` declares
+/// it: 64 layers on a 4-cycle (16 full attention, 48 GDN), hidden 5120,
+/// head_dim 256, 24 q heads, 4 kv heads, output-gated attention, GDN
+/// 16x128 key heads and 48x128 value heads.
+fn qwen38_27b() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen3_5".to_string();
+    c.num_experts = 0;
+    c.num_experts_per_tok = 0;
+    c.moe_intermediate_size = 0;
+    c.hidden_size = 5120;
+    c.intermediate_size = 17408;
+    c.num_hidden_layers = 64;
+    c.num_attention_heads = 24;
+    c.num_key_value_heads = 4;
+    c.head_dim = 256;
+    c.attn_gated = true;
+    c.linear_num_key_heads = 16;
+    c.linear_key_head_dim = 128;
+    c.linear_num_value_heads = 48;
+    c.linear_value_head_dim = 128;
+    c.full_attention_interval = 4;
+    c.layer_types = (0..64)
+        .map(|i| {
+            if (i + 1) % 4 == 0 {
+                LayerType::FullAttention
+            } else {
+                LayerType::LinearAttention
+            }
+        })
+        .collect();
+    c.quantization_config = Some(QuantizationConfig {
+        quant_method: "fp8".to_string(),
+        quant_algo: String::new(),
+        format: String::new(),
+        ignore_modules: Vec::new(),
+    });
+    c
+}
+
+/// The route the round-6 serve booted in: `ATLAS_DENSE_FP8=1`, tp 1, a
+/// config-declared FP8 checkpoint, no NVFP4 lever, both W8A8 prefill kernels
+/// present in the hopper kernel set.
+fn round6_route() -> Fp8RouteInputs {
+    Fp8RouteInputs {
+        dense_fp8: true,
+        tp_size: 1,
+        declared_variant: Some(Nvfp4Variant::Fp8Dequanted),
+        gdn_fp8: true,
+        w8a8_prefill_kernels: true,
+        route: RouteEnv {
+            keep_nvfp4: false,
+            dispatch: GemmDispatch::defaults(),
+            attn_w4a4: false,
+            attn_prefill_q_t: false,
+        },
+    }
+}
+
+fn predicted(route: &Fp8RouteInputs) -> PredictedDerived {
+    match predicted_derived_bytes(&qwen38_27b(), route) {
+        DerivedBytesEstimate::NativeFp8Dense(p) => p,
+        DerivedBytesEstimate::Unavailable(why) => panic!("expected a prediction, got: {why}"),
+    }
+}
+
+/// The load-bearing assertion: the prediction reproduces the number the H100
+/// serve log printed, to well inside the 5 % the brief allows.
+///
+/// 16 x (K twin + V twin) + 48 x (fused `[QKV|Z]` + its scales + out_proj
+/// scales + interleaved `in_proj_ba`) = 4,242,882,560 B = 4.243 GB, against
+/// round 6's `derived 4.24 GB`.
+#[test]
+fn the_27b_prediction_matches_the_round6_residency_summary() {
+    let p = predicted(&round6_route());
+    assert_eq!(
+        p.attn_fp8_twins, 167_813_120,
+        "16 layers x (K twin + V twin)"
+    );
+    assert_eq!(
+        p.ssm_fp8_concat, 4_075_069_440,
+        "48 GDN layers x 84,897,280"
+    );
+    assert_eq!(p.total(), 4_242_882_560);
+
+    let measured = 4.24_f64;
+    let predicted_gb = p.total() as f64 / 1e9;
+    let err = (predicted_gb - measured).abs() / measured;
+    assert!(
+        err < 0.05,
+        "predicted {predicted_gb:.3} GB vs the round-6 log's {measured} GB ({:.2}% off)",
+        err * 100.0,
+    );
+}
+
+/// Every term is the loader's own arithmetic, recomputed here independently
+/// so a change to `ssm_concat_bytes` cannot silently redefine what is being
+/// predicted.
+#[test]
+fn each_term_is_the_loaders_shape_arithmetic() {
+    let c = qwen38_27b();
+    // Attention: `fp8_twin_bytes(kv_n, hidden)` twice, K and V only.
+    let kv_twin = fp8_residency::fp8_twin_bytes(4 * 256, 5120);
+    assert_eq!(kv_twin, 5_244_160);
+    assert_eq!(
+        predicted(&round6_route()).attn_fp8_twins,
+        16 * 2 * kv_twin as u64
+    );
+
+    // SSM: the fused weight dominates at 16384 x 5120 = 83,886,080 B/layer.
+    assert_eq!(c.ssm_qkvz_size(), 16384);
+    assert_eq!(c.ssm_qkv_size(), 10240);
+    assert_eq!(c.ssm_z_size(), 6144);
+    let per_layer = 83_886_080  // fused [QKV|Z] E4M3
+        + (80 * 40 * 4 + 48 * 40 * 4)  // the two concatenated block-scale grids
+        + 40 * 48 * 4   // out_proj block-scale grid
+        + 48 * 2 * 5120 * 2; // in_proj_ba, [2*nv, hidden] BF16
+    assert_eq!(per_layer, 84_897_280);
+    assert_eq!(
+        predicted(&round6_route()).ssm_fp8_concat,
+        48 * per_layer as u64,
+    );
+}
+
+/// A target missing either W8A8 prefill kernel builds the Q and O twins too —
+/// which is why the kernel set is an input and not an assumption. The 27B
+/// pays 16 x (Q twin + O twin) = 1.51 GB more.
+#[test]
+fn a_target_without_the_w8a8_prefill_kernels_pays_for_the_q_and_o_twins() {
+    let mut route = round6_route();
+    route.w8a8_prefill_kernels = false;
+    let p = predicted(&route);
+    assert!(
+        p.attn_twin_set.q && p.attn_twin_set.o,
+        "{:?}",
+        p.attn_twin_set
+    );
+    let q_twin = fp8_residency::fp8_twin_bytes(24 * 256 * 2, 5120) as u64;
+    let o_twin = fp8_residency::fp8_twin_bytes(5120, 24 * 256) as u64;
+    assert_eq!(
+        p.attn_fp8_twins,
+        predicted(&round6_route()).attn_fp8_twins + 16 * (q_twin + o_twin),
+    );
+    assert!(p.total() > predicted(&round6_route()).total());
+}
+
+/// `ATLAS_ATTN_PREFILL_Q_T=1` adds the Q twin on the W8A8-covered route: the
+/// `cache_skip_qkv.rs:142` dispatch reads it per prefill.
+#[test]
+fn the_q_transpose_lever_adds_exactly_the_q_twin() {
+    let mut route = round6_route();
+    route.route.attn_prefill_q_t = true;
+    let p = predicted(&route);
+    assert!(p.attn_twin_set.q && !p.attn_twin_set.o);
+    let q_twin = fp8_residency::fp8_twin_bytes(24 * 256 * 2, 5120) as u64;
+    assert_eq!(
+        p.attn_fp8_twins,
+        predicted(&round6_route()).attn_fp8_twins + 16 * q_twin,
+    );
+}
+
+/// `ATLAS_NO_GDN_FP8` takes the GDN layers off the fused-concat arm, so the
+/// 4.03 GB that dominates the prediction is not spent.
+#[test]
+fn disabling_the_gdn_fp8_arm_drops_the_fused_concat_term() {
+    let mut route = round6_route();
+    route.gdn_fp8 = false;
+    let p = predicted(&route);
+    assert_eq!(p.ssm_fp8_concat, 0);
+    assert!(!p.twins.ssm_fp8_concat);
+    assert_eq!(p.total(), 167_813_120);
+}
+
+/// Every gate that must DECLINE rather than guess. Each of these routes
+/// either does not reach the native-FP8 dense loader at all, or reaches it
+/// with NVFP4 copies alive whose bytes `DerivedResidency` tallies through
+/// `skip` — a quantity a prediction built on `keep` cannot price.
+#[test]
+fn the_prediction_declines_rather_than_guessing() {
+    let cases: Vec<(&str, Box<dyn Fn(&mut Fp8RouteInputs)>, &str)> = vec![
+        (
+            "flag off",
+            Box::new(|r: &mut Fp8RouteInputs| r.dense_fp8 = false),
+            "ATLAS_DENSE_FP8 is not 1",
+        ),
+        (
+            "tp > 1",
+            Box::new(|r: &mut Fp8RouteInputs| r.tp_size = 2),
+            "--tp-size > 1 takes the NVFP4 route",
+        ),
+        (
+            "config declares nothing",
+            Box::new(|r: &mut Fp8RouteInputs| r.declared_variant = None),
+            "config.json does not declare a block-scaled FP8 checkpoint",
+        ),
+        (
+            "config declares NVFP4",
+            Box::new(|r: &mut Fp8RouteInputs| {
+                r.declared_variant = Some(Nvfp4Variant::CompressedTensors)
+            }),
+            "config.json does not declare a block-scaled FP8 checkpoint",
+        ),
+        (
+            "keep-nvfp4 escape hatch",
+            Box::new(|r: &mut Fp8RouteInputs| r.route.keep_nvfp4 = true),
+            "ATLAS_DENSE_FP8_KEEP_NVFP4 restores the pre-#915 fallback copies",
+        ),
+        (
+            "W4A4 o_proj lever",
+            Box::new(|r: &mut Fp8RouteInputs| r.route.attn_w4a4 = true),
+            "an NVFP4 fallback lever (ATLAS_CUTLASS_NVFP4_* / ATLAS_ATTN_W4A4) is set",
+        ),
+    ];
+    for (name, mutate, want) in cases {
+        let mut route = round6_route();
+        mutate(&mut route);
+        assert_eq!(
+            predicted_derived_bytes(&qwen38_27b(), &route),
+            DerivedBytesEstimate::Unavailable(want),
+            "case: {name}",
+        );
+    }
+}
+
+/// A model that is not the Qwen3.5-dense loader's is declined on the FIRST
+/// gate — the arithmetic above is specific to this loader's derived copies.
+#[test]
+fn another_architecture_is_declined_on_the_loader_gate() {
+    let other = ModelConfig::qwen3_next_80b_nvfp4();
+    assert_eq!(
+        predicted_derived_bytes(&other, &round6_route()),
+        DerivedBytesEstimate::Unavailable("not the Qwen3.5-dense loader"),
+    );
+}
+
+/// `bytes()` / `reason()` are what the preflight log reads; neither may
+/// invent a value for the other's case.
+#[test]
+fn the_estimate_reports_either_bytes_or_a_reason_never_both() {
+    let ok = predicted_derived_bytes(&qwen38_27b(), &round6_route());
+    assert_eq!(ok.bytes(), Some(4_242_882_560));
+    assert_eq!(ok.reason(), None);
+    let no = DerivedBytesEstimate::Unavailable("because");
+    assert_eq!(no.bytes(), None);
+    assert_eq!(no.reason(), Some("because"));
+}

--- a/crates/spark-model/src/weight_map/nvfp4_detect.rs
+++ b/crates/spark-model/src/weight_map/nvfp4_detect.rs
@@ -10,6 +10,42 @@ use spark_runtime::weights::{WeightDtype, WeightStore};
 
 use super::*;
 
+/// Step (1) of [`detect_nvfp4_variant`]: the variant the CONFIG declares,
+/// asked WITHOUT a [`WeightStore`].
+///
+/// Factored out (#915, 2026-09-11) so a caller that has only `config.json` —
+/// the pre-load residency prediction in
+/// `weight_loader::predicted_residency`, which runs before the store
+/// exists — asks exactly the question the loader will later answer instead
+/// of keeping a second copy of this precedence. `None` means "the config
+/// does not say"; it is NEVER a guess, and the sniffing half of
+/// [`detect_nvfp4_variant`] is what resolves it once the store is loaded.
+pub fn config_declared_variant(config: &atlas_core::config::ModelConfig) -> Option<Nvfp4Variant> {
+    let qc = config.quantization_config.as_ref()?;
+    match qc.quant_method.as_str() {
+        "modelopt" if qc.quant_algo.eq_ignore_ascii_case("NVFP4") => Some(Nvfp4Variant::Standard),
+        "modelopt" if qc.quant_algo.eq_ignore_ascii_case("FP8") => Some(Nvfp4Variant::Fp8Dequanted),
+        "compressed-tensors" => {
+            // `format` is the sub-selector here. Block-scaled FP8 is tagged
+            // either with a literal "fp8" OR with compressed-tensors'
+            // `"float-quantized"` (8-bit float = FP8 E4M3, e.g.
+            // Hcompany/Holo-3.1-*-FP8); the rest ("nvfp4-pack-quantized",
+            // "pack-quantized") are NVFP4.
+            let fmt = qc.format.to_ascii_lowercase();
+            if fmt.contains("fp8") || fmt.contains("float-quant") {
+                Some(Nvfp4Variant::Fp8Dequanted)
+            } else {
+                Some(Nvfp4Variant::CompressedTensors)
+            }
+        }
+        "fp8" => Some(Nvfp4Variant::Fp8Dequanted),
+        // Unknown method with non-empty ignore list — the caller falls
+        // through to heuristic detection. A warning was already emitted by
+        // `quant_format::detect_quant_format`.
+        _ => None,
+    }
+}
+
 /// Detect the weight quantization variant from the weight store.
 ///
 /// Dispatch order matches vLLM / TRT-LLM / SGLang:
@@ -30,36 +66,11 @@ pub fn detect_nvfp4_variant(
 ) -> Nvfp4Variant {
     // (1) Config-first dispatch. See module docs on `quant_format` for
     // the full rationale — this is the fix for the Discord 2026-04-17
-    // `CUDA_ERROR_ILLEGAL_ADDRESS` bug.
-    if let Some(qc) = &config.quantization_config {
-        match qc.quant_method.as_str() {
-            "modelopt" if qc.quant_algo.eq_ignore_ascii_case("NVFP4") => {
-                return Nvfp4Variant::Standard;
-            }
-            "modelopt" if qc.quant_algo.eq_ignore_ascii_case("FP8") => {
-                return Nvfp4Variant::Fp8Dequanted;
-            }
-            "compressed-tensors" => {
-                // `format` is the sub-selector here. Block-scaled FP8 is tagged
-                // either with a literal "fp8" OR with compressed-tensors'
-                // `"float-quantized"` (8-bit float = FP8 E4M3, e.g.
-                // Hcompany/Holo-3.1-*-FP8); the rest ("nvfp4-pack-quantized",
-                // "pack-quantized") are NVFP4.
-                let fmt = qc.format.to_ascii_lowercase();
-                if fmt.contains("fp8") || fmt.contains("float-quant") {
-                    return Nvfp4Variant::Fp8Dequanted;
-                }
-                return Nvfp4Variant::CompressedTensors;
-            }
-            "fp8" => {
-                return Nvfp4Variant::Fp8Dequanted;
-            }
-            _ => {
-                // Unknown method with non-empty ignore list — fall
-                // through to heuristic detection. A warning was already
-                // emitted by `quant_format::detect_quant_format`.
-            }
-        }
+    // `CUDA_ERROR_ILLEGAL_ADDRESS` bug. `None` = the config does not declare
+    // one (or declares a method this engine does not know), which is the only
+    // case that falls through to sniffing.
+    if let Some(declared) = config_declared_variant(config) {
+        return declared;
     }
 
     let lp = config.layer_prefix(0);

--- a/crates/spark-runtime/src/weights.rs
+++ b/crates/spark-runtime/src/weights.rs
@@ -165,6 +165,10 @@ impl WeightTensor {
 /// All model weights loaded onto the GPU, keyed by HuggingFace name.
 pub struct WeightStore {
     weights: HashMap<String, WeightTensor>,
+    /// Buffers a loader derived from these tensors — fused concats, transposed
+    /// twins, requants. Owned here so teardown RELEASES them instead of the
+    /// backend sweep reclaiming them unowned (#736, #915); see `derived.rs`.
+    derived: DerivedStore,
     /// Tensors deliberately NOT uploaded, with where they live on disk.
     ///
     /// The n-gram embedding tables of the LongCat / Qwen3.8-Flash-Next family
@@ -196,6 +200,7 @@ impl WeightStore {
         Self {
             weights: HashMap::new(),
             deferred: HashMap::new(),
+            derived: DerivedStore::default(),
         }
     }
 
@@ -226,6 +231,7 @@ impl WeightStore {
         Self {
             weights,
             deferred: HashMap::new(),
+            derived: DerivedStore::default(),
         }
     }
 
@@ -297,6 +303,15 @@ impl WeightStore {
             count += 1;
         }
         Ok((count, bytes))
+    }
+
+    /// The owner for buffers a loader derives from these tensors.
+    ///
+    /// `&self` because `ModelWeightLoader::load_layers` takes `&WeightStore`;
+    /// the interior `Mutex` is the whole reason `DerivedStore` exists as a
+    /// type rather than a `Vec` field. See `weights/derived.rs`.
+    pub fn derived(&self) -> &DerivedStore {
+        &self.derived
     }
 
     /// Total bytes across all weight tensors on the GPU.
@@ -447,6 +462,8 @@ impl SafetensorsLoader {
 /// `embedders.2` must precede `embedders.10`; a plain lexicographic sort puts
 /// `10` first and silently mis-maps every table after the ninth.
 pub mod adapter;
+mod derived;
+pub use derived::DerivedStore;
 mod gguf;
 mod loader;
 pub mod mlx_int8;
@@ -483,7 +500,11 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for WeightStore {
     }
 
     fn release(&mut self, gpu: &dyn GpuBackend) -> anyhow::Result<()> {
-        let mut first_error = None;
+        // Derived buffers FIRST: they are re-encodings of the tensors below and
+        // nothing reads one after the other is gone, but freeing the source a
+        // derivation was built from while the derivation is still listed would
+        // make a later failure here impossible to attribute.
+        let mut first_error = self.derived.release(gpu).err();
         // `drain` rather than iterate: the map must not be left holding
         // pointers to memory that is gone, and it makes this idempotent.
         for (name, tensor) in self.weights.drain() {

--- a/crates/spark-runtime/src/weights/derived.rs
+++ b/crates/spark-runtime/src/weights/derived.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Load-time derived weight buffers, and who frees them.
+//!
+//! **WHY (#736, #915).** A loader that re-encodes a checkpoint tensor — a
+//! transposed twin, a row-concatenation of two projections, an NVFP4 requant —
+//! allocates a buffer that lives in a *layer struct*. Layer structs have no
+//! `Drop` that reaches the GPU and no `ModelResource`, so nothing frees them:
+//! `TransformerModel::release_pools` walks buffers, KV cache, SSM pools,
+//! `DerivedWeights` and the store, and every one of these falls through to
+//! `AtlasCudaBackend::sweep_unreleased`. On 1xH100, 2026-09-11,
+//! `Qwen/Qwen3.8-27B-FP8`, that sweep reclaimed **28.01 GB across 1,980
+//! allocations** and warned that each was "memory whose owner is unaccounted
+//! for". The sweep is a backstop, not an owner: it cannot run before the
+//! backend is torn down, so those bytes are unreclaimable for the life of the
+//! model even when the layer that holds them has been replaced.
+//!
+//! This is the owner. The [`WeightStore`](super::WeightStore) is the right home
+//! for it because these buffers are *derived from* store tensors, have exactly
+//! the store's lifetime (the layers read both until teardown), and the store is
+//! already the last `ModelResource` released before the sweep — so adopting a
+//! derived buffer here moves it from "swept" to "released", which is the
+//! difference the ledger reports.
+//!
+//! Interior mutability because loaders take `&WeightStore`: threading a `&mut`
+//! through `ModelWeightLoader::load_layers` would change the signature of every
+//! architecture's loader to fix a bookkeeping gap in one of them.
+
+use parking_lot::Mutex;
+
+use crate::gpu::{DevicePtr, GpuBackend};
+
+/// One adopted buffer: the pointer to free, its size, and a label for the
+/// residency report.
+#[derive(Clone, Copy, Debug)]
+struct Derived {
+    label: &'static str,
+    ptr: DevicePtr,
+    bytes: usize,
+}
+
+/// Device buffers a loader derived from this store's tensors.
+#[derive(Default)]
+pub struct DerivedStore {
+    // parking_lot: no poisoning, so a panic elsewhere cannot block teardown.
+    owned: Mutex<Vec<Derived>>,
+}
+
+impl DerivedStore {
+    /// Take ownership of a derived buffer.
+    ///
+    /// `label` is a static category ("ssm qkvz fp8 concat", "attn fp8 twin"),
+    /// not a per-tensor name: the report aggregates, and a `String` per buffer
+    /// would allocate once per layer per twin for text nobody reads per entry.
+    pub fn adopt(&self, label: &'static str, ptr: DevicePtr, bytes: usize) {
+        if ptr.0 == 0 {
+            return;
+        }
+        self.owned.lock().push(Derived { label, ptr, bytes });
+    }
+
+    /// Give up ownership of a buffer the caller is about to free itself.
+    ///
+    /// The transient half of a fused concat is adopted by the generic loader
+    /// that produced it and then freed by the loader that consumed it
+    /// (`qwen35_dense.rs`, the GDN `[QKV|Z]` arm). Without this the pointer
+    /// would be freed twice — once there, once at teardown. Returns the bytes
+    /// that left the ledger, or `None` if this store never held it.
+    pub fn disown(&self, ptr: DevicePtr) -> Option<usize> {
+        let mut owned = self.owned.lock();
+        let i = owned.iter().position(|d| d.ptr == ptr)?;
+        Some(owned.swap_remove(i).bytes)
+    }
+
+    /// Total adopted bytes still live.
+    pub fn bytes(&self) -> usize {
+        self.owned.lock().iter().map(|d| d.bytes).sum()
+    }
+
+    pub fn len(&self) -> usize {
+        self.owned.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// `label -> (bytes, count)`, biggest first, for the residency summary.
+    pub fn by_label(&self) -> Vec<(&'static str, usize, usize)> {
+        let mut rows: Vec<(&'static str, usize, usize)> = Vec::new();
+        for d in self.owned.lock().iter() {
+            match rows.iter_mut().find(|r| r.0 == d.label) {
+                Some(r) => {
+                    r.1 += d.bytes;
+                    r.2 += 1;
+                }
+                None => rows.push((d.label, d.bytes, 1)),
+            }
+        }
+        rows.sort_by(|a, b| b.1.cmp(&a.1));
+        rows
+    }
+
+    /// Free everything adopted. Drains first, so a failure part-way through
+    /// cannot leave a freed pointer in the list to be freed again.
+    pub fn release(&self, gpu: &dyn GpuBackend) -> anyhow::Result<()> {
+        let doomed: Vec<Derived> = self.owned.lock().drain(..).collect();
+        let mut first_error = None;
+        for d in doomed {
+            if let Err(e) = gpu.free(d.ptr)
+                && first_error.is_none()
+            {
+                first_error = Some(e.context(format!("freeing derived weight ({})", d.label)));
+            }
+        }
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu::mock::MockGpuBackend;
+
+    #[test]
+    fn an_adopted_buffer_is_freed_by_release() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        let a = gpu.alloc(1024).unwrap();
+        let b = gpu.alloc(2048).unwrap();
+        d.adopt("twin", a, 1024);
+        d.adopt("twin", b, 2048);
+        assert_eq!(d.len(), 2);
+        assert_eq!(d.bytes(), 3072);
+        d.release(&gpu).unwrap();
+        assert!(d.is_empty(), "release must drain, not merely free");
+        assert_eq!(d.bytes(), 0);
+    }
+
+    #[test]
+    fn release_is_idempotent() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        d.adopt("twin", gpu.alloc(64).unwrap(), 64);
+        d.release(&gpu).unwrap();
+        // A second release must not double-free: the list is already drained.
+        d.release(&gpu).unwrap();
+    }
+
+    #[test]
+    fn a_null_pointer_is_not_adopted() {
+        let d = DerivedStore::default();
+        d.adopt("twin", DevicePtr::NULL, 0);
+        assert!(d.is_empty(), "a NULL twin is 'not built', not 'owned'");
+    }
+
+    #[test]
+    fn disown_removes_the_buffer_so_release_cannot_double_free() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        let transient = gpu.alloc(512).unwrap();
+        d.adopt("transient", transient, 512);
+        assert_eq!(d.disown(transient), Some(512));
+        assert!(d.is_empty());
+        // A pointer this store never held is not silently "disowned".
+        assert_eq!(d.disown(transient), None);
+    }
+
+    #[test]
+    fn by_label_aggregates_biggest_first() {
+        let gpu = MockGpuBackend::new();
+        let d = DerivedStore::default();
+        d.adopt("small", gpu.alloc(16).unwrap(), 16);
+        d.adopt("big", gpu.alloc(1000).unwrap(), 1000);
+        d.adopt("big", gpu.alloc(1000).unwrap(), 1000);
+        assert_eq!(d.by_label(), vec![("big", 2000, 2), ("small", 16, 1)]);
+    }
+}

--- a/crates/spark-runtime/src/weights/teardown_tests.rs
+++ b/crates/spark-runtime/src/weights/teardown_tests.rs
@@ -96,3 +96,65 @@ fn teardown_releases_in_reverse_registration_order() {
     assert_eq!(gpu.alloc_count(), 0);
     assert!(teardown.is_empty());
 }
+
+/// #736/#915: a buffer a loader DERIVED from these tensors must be released
+/// here, not left for `AtlasCudaBackend::sweep_unreleased` to reclaim unowned.
+///
+/// The mock backend's live-allocation count is the same instrument the CUDA
+/// ledger is: "every allocation this backend made and nobody released".
+#[test]
+fn releasing_frees_adopted_derived_buffers_too() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 4);
+    // Two derived copies per tensor, the shape the dense loader produces:
+    // a fused concat and its widened block-scale grid.
+    for _ in 0..4 {
+        store
+            .derived()
+            .adopt("fused concat", gpu.alloc(2048).expect("alloc"), 2048);
+        store
+            .derived()
+            .adopt("block scale", gpu.alloc(64).expect("alloc"), 64);
+    }
+    assert_eq!(gpu.alloc_count(), 12);
+    assert_eq!(store.derived().len(), 8);
+    assert_eq!(store.derived().bytes(), 4 * (2048 + 64));
+
+    store.release(&gpu).expect("released");
+    assert_eq!(
+        gpu.alloc_count(),
+        0,
+        "an owned derived buffer must leave nothing for the teardown sweep"
+    );
+    assert!(store.derived().is_empty());
+}
+
+/// The negative control, and the pre-#915 state: a derived buffer nobody
+/// adopted survives `release` and is exactly what the H100 sweep reported as
+/// "28.01 GB ... had no owner".
+#[test]
+fn an_unadopted_derived_buffer_is_what_the_sweep_would_report() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 2);
+    let orphan = gpu.alloc(4096).expect("alloc");
+    store.release(&gpu).expect("released");
+    assert_eq!(
+        gpu.alloc_count(),
+        1,
+        "the orphan outlives teardown — adopt it via `store.derived()`"
+    );
+    gpu.free(orphan).expect("freed");
+}
+
+/// Releasing twice must not double-free an adopted buffer either.
+#[test]
+fn releasing_twice_is_harmless_for_derived_buffers() {
+    let gpu = MockGpuBackend::new();
+    let mut store = store_with(&gpu, 1);
+    store
+        .derived()
+        .adopt("twin", gpu.alloc(128).expect("alloc"), 128);
+    store.release(&gpu).expect("released");
+    store.release(&gpu).expect("released again");
+    assert_eq!(gpu.alloc_count(), 0);
+}

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -246,6 +246,36 @@ pub struct ServeArgs {
     #[arg(long, default_value = "snapshot")]
     pub ssm_rollback_mode: String,
 
+    /// Phase-C SSM decode-rollback ring depth: `auto` (default) or an
+    /// explicit slot count in `0..=8`.
+    ///
+    /// The ring retains boundary SSM-state snapshots so a watchdog re-steer
+    /// can rewind the recurrent state; its cost is `depth x
+    /// --max-batch-size x the per-sequence SSM state blob`, which on the 27B
+    /// (151.5 MiB/seq) at the default depth 8 and `--max-batch-size 32` is
+    /// 37.88 GiB — the whole reason an 80 GB H100 refused the hopper recipe
+    /// (#915, rental H100 2026-09-05: inference reserve 45,823 MiB against a
+    /// 71.3 GiB budget carrying 57.2 GiB of weights).
+    ///
+    /// `auto` keeps the depth at 8 (or the existing skips — the ring is
+    /// unreachable under `--speculative`/`--dflash` and with watchdogs off)
+    /// and lets preflight SHRINK it down `8, 4, 2, 1, 0` until the reserve
+    /// fits, logging the formula at WARN. Depth degrades gracefully: fewer
+    /// retained boundaries means fewer reachable re-steer anchors, and a
+    /// sequence that finds none hard-stops instead of re-steering — never a
+    /// partial SSM rewind.
+    ///
+    /// An explicit `N` pins the depth on BOTH sides (reserve and allocation)
+    /// and disables the fit: a serve that does not fit at `N` is REFUSED with
+    /// the formula, rather than booted at a depth the recipe does not record.
+    /// `0` disables the ring outright; 8 is the wired default and the
+    /// arithmetic ceiling.
+    ///
+    /// Legacy: `ATLAS_SSM_DECODE_RING=1|0` still means depth 8 and 0. It is
+    /// only consulted when this flag is `auto` — absent is not a value.
+    #[arg(long, default_value = "auto", value_name = "AUTO_OR_N")]
+    pub ssm_decode_ring_slots: String,
+
     /// Fused GDN output-norm kernel on the decode path (default: off).
     ///
     /// Required by `--ssm-h-dtype f16`: the FP16 h-state twins live on the

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -180,6 +180,19 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
             "use snapshot (default, wired) or replay (experimental scaffold).",
         ));
     }
+    // `--ssm-decode-ring-slots`: same SSOT rule — the parse that validates is
+    // the parse `publish_kernel_flags` publishes through (#915).
+    if let Err(why) = spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+    {
+        v.push(Violation::new(
+            format!(
+                "--ssm-decode-ring-slots '{}' is not a valid value.",
+                args.ssm_decode_ring_slots
+            ),
+            why,
+            "use auto (default: preflight sizes the ring from free memory) or 0..=8.",
+        ));
+    }
     // #435: the exact-verify arm's kernels are FP32 readers, so an FP16
     // h-state pool disables it (`GdnFlags::verify_exact_active`). Honouring
     // `--ssm-h-dtype f16` by SILENTLY ignoring an explicit `--exact-verify`

--- a/crates/spark-server/src/cli/validate_tests.rs
+++ b/crates/spark-server/src/cli/validate_tests.rs
@@ -234,6 +234,27 @@ fn ssm_rollback_mode_values_and_typos() {
 }
 
 #[test]
+fn ssm_decode_ring_slots_values_and_typos() {
+    // `auto` is the default and must validate: it is what lets preflight size
+    // the ring from free memory instead of refusing the boot (#915).
+    let a = parse(&[]);
+    assert_eq!(a.ssm_decode_ring_slots, "auto");
+    assert!(validate_serve_args(&a).is_ok());
+    for depth in ["0", "1", "2", "4", "8"] {
+        assert!(
+            validate_serve_args(&parse(&["--ssm-decode-ring-slots", depth])).is_ok(),
+            "depth {depth} is inside the ring's range"
+        );
+    }
+    // Above the wired ceiling, and anything non-numeric, is refused through
+    // the model-side parse (SSOT with the publication parse) — never clamped.
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "9"])).unwrap_err();
+    assert!(err.contains("--ssm-decode-ring-slots"), "{err}");
+    let err = validate_serve_args(&parse(&["--ssm-decode-ring-slots", "AUTO"])).unwrap_err();
+    assert!(err.contains("auto"), "names the valid values: {err}");
+}
+
+#[test]
 fn a_mistyped_mtp_gate_is_still_caught() {
     // Making the flag optional must not make its typo check optional.
     let err = validate_serve_args(&parse(&["--mtp-gate", "always"])).unwrap_err();

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -81,6 +81,24 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
              line's ({rollback:?}) did NOT take effect"
         );
     }
+    // `--ssm-decode-ring-slots`: ABSENT IS NOT A VALUE. `auto` (the clap
+    // default) publishes NOTHING, so the documented `ATLAS_SSM_DECODE_RING`
+    // fallback stays reachable AND preflight can publish the depth it fitted
+    // to free memory later in the same boot (#915). An explicit N is
+    // published here, before preflight runs, which is exactly what makes the
+    // auto-fit's later write a no-op — an operator's pinned depth is refused
+    // rather than silently shrunk.
+    if let Some(slots) =
+        spark_model::ssm_reserve::parse_decode_ring_slots(&args.ssm_decode_ring_slots)
+            .expect("validated by validate_serve_args")
+    {
+        let in_force = spark_model::ssm_reserve::set_decode_ring_slots(slots);
+        if in_force != slots {
+            tracing::warn!(
+                "ssm-decode-ring-slots was already resolved ({in_force}); the command                  line's ({slots}) did NOT take effect"
+            );
+        }
+    }
     // `--prefill-varlen-batch`: its own single-value cell, so it publishes
     // independently of the GDN trio. Absent publishes nothing and the
     // documented `ATLAS_PREFILL_VARLEN` fallback stays reachable.
@@ -116,7 +134,7 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
          exact_verify={} ssm_tail_midchunk={} mtp_gate={} ssm_rollback_mode={:?} \
-         prefill_varlen_batch={}",
+         ssm_decode_ring_slots={} prefill_varlen_batch={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
@@ -130,6 +148,12 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
             "auto"
         },
         spark_model::ssm_reserve::ssm_rollback_mode(),
+        // RESOLVED: `auto` until something publishes a depth. Preflight logs
+        // the fitted depth (and the formula behind it) when it shrinks one.
+        match spark_model::ssm_reserve::published_decode_ring_slots() {
+            Some(slots) => slots.to_string(),
+            None => "auto".to_string(),
+        },
         // RESOLVED, not the raw argument — may come from the environment.
         spark_model::layers::ops::prefill_varlen_enabled(),
     );

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -422,13 +422,37 @@ pub(crate) fn load_model(
     } = serve_phases::resolve_topology(&args, &mut config)?;
 
     // ── Pre-load reserve preflight ──
+    //
+    // The four post-load inputs are resolved HERE because they are the
+    // caller's to know (#915 second pass): the device total and the loaded
+    // kernel set come from the backend initialised above, the checkpoint
+    // directory from `resolve_model_dir`, and the KV dtype from the SAME
+    // `resolve_kv_dtype_str` precedence the cache itself uses later in this
+    // function — so preflight's bytes-per-token and the pool's cannot differ.
+    // A `--kv-cache-dtype` that fails to parse is left to the cache's own
+    // error path; the fit falls back to pre-load free memory rather than
+    // failing the boot early with a second, worse-worded copy of it.
+    let (preflight_kv_dtype_str, _) = serve_phases::kv_cache::resolve_kv_dtype_str(
+        args.kv_cache_dtype.as_deref(),
+        ptx_set.behavior.default_kv_dtype,
+    );
+    let post_load_inputs = serve_phases::PostLoadInputs {
+        total_mem: gpu.total_memory().unwrap_or(0),
+        model_dir: &model_dir,
+        kv_dtype: preflight_kv_dtype_str
+            .parse()
+            .unwrap_or(spark_runtime::kv_cache::KvCacheDtype::Bf16),
+        w8a8_prefill_kernels: spark_model::layers::qwen3_attention::w8a8_prefill_kernels_loaded(
+            gpu.as_ref(),
+        ),
+    };
     let serve_phases::ReservePreflight {
         inference_reserve,
         buffer_arena_bytes,
         gdn_two_phase_bytes,
         ssm_prefill_chunk,
         max_batch_tokens_pre,
-    } = serve_phases::preflight_reserve(&args, &config, free_mem)?;
+    } = serve_phases::preflight_reserve(&args, &config, free_mem, &post_load_inputs)?;
     let total_reserve = inference_reserve + buffer_arena_bytes;
 
     // 2a-2. OOM watchdog: background async task that polls GPU memory every 2s.

--- a/crates/spark-server/src/main_modules/serve_phases/mod.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/mod.rs
@@ -27,7 +27,7 @@ pub(super) use kv_cache::{
     KvCacheConfig, PrefillBudget, resolve_kv_cache_config, resolve_prefill_budget,
 };
 pub(super) use preflight::{
-    ReservePreflight, init_gpu_backend, post_load_memory_audit, preflight_reserve,
+    PostLoadInputs, ReservePreflight, init_gpu_backend, post_load_memory_audit, preflight_reserve,
 };
 pub(super) use runtime::{
     SamplingDefaults, load_eos_tokens, load_sampling_defaults, log_behavior_audit,

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -8,7 +8,9 @@ use atlas_core::config::ModelConfig;
 
 use crate::cli;
 
+mod decode_ring;
 mod per_sequence_state;
+mod refusal;
 mod ssm_h_fp16;
 use {per_sequence_state::per_sequence_reserve, ssm_h_fp16::ssm_h_fp16_preconditions};
 
@@ -156,35 +158,6 @@ pub(crate) fn preflight_reserve(
         args.max_batch_size,
     )
     .total_bytes();
-    // SSM snapshot pool = Marconi prefix-cache region + Phase-C
-    // decode-rollback ring. The decode ring is sized per active
-    // sequence (ring slots × `max_batch_size`) and only allocated for SSM
-    // models. SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots`
-    // makes the SAME decision (same env vars, same constant) the runtime
-    // allocation in `TransformerModel::new` makes — including the skip under
-    // `--speculative`/`--dflash` (the ring's save/rollback path only runs on
-    // plain decode; the spec path rolls back through the verify snapshot).
-    // Reserving the ring unconditionally while the runtime skipped it
-    // stranded ~38 GB at bs32 on the 27B (75.2 GB SSM reserve vs an 85.2 GB
-    // budget at util 0.70) and capped the native batch at ~20.
-    // `use_speculative` here MUST mirror what `build_model` passes:
-    // `args.speculative || args.dflash`.
-    // Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present ⇒ restore the old
-    // unconditional reservation (accounting-only, safe over-reserve;
-    // presence-style — `=0` is NOT "off").
-    let decode_ring_slots = if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
-        if config.num_ssm_layers() > 0 {
-            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
-        } else {
-            0
-        }
-    } else {
-        spark_model::ssm_reserve::decode_rollback_ring_slots(
-            config.num_ssm_layers(),
-            args.speculative || args.dflash,
-        )
-        .slots
-    };
     // Marconi snapshot region. SSOT:
     // `spark_model::ssm_reserve::marconi_snapshot_slots` makes the SAME
     // decision (same env var, same predicate) the runtime allocation in
@@ -212,9 +185,12 @@ pub(crate) fn preflight_reserve(
                 / (1024 * 1024),
         );
     }
-    let ssm_snapshot_bytes = (marconi.slots + decode_ring_slots * args.max_batch_size)
-        * config.num_ssm_layers()
-        * (h_state_bytes + conv_state_bytes);
+    // The per-sequence SSM state blob — `num_ssm_layers x (h + conv)`, 151.5
+    // MiB on the 27B. Both snapshot regions are whole multiples of it:
+    // Marconi reserves one per cache slot, the decode ring one per active
+    // sequence per ring slot.
+    let per_seq_blob = config.num_ssm_layers() * (h_state_bytes + conv_state_bytes);
+    let marconi_bytes = marconi.slots * per_seq_blob;
     // Same predicate as the pool term: DFlash IS a speculative serve and
     // pays the same graph/JIT/scratch overheads the 4 GB headroom exists for.
     let cuda_headroom: usize = if spec_on_pool {
@@ -234,59 +210,60 @@ pub(crate) fn preflight_reserve(
             0
         }
     };
-    let inference_reserve: usize = ssm_pool_bytes
+    // Everything the reserve needs that does NOT scale with ring depth. The
+    // ring is separated out because it is the only term preflight is allowed
+    // to shrink (#915): rollback depth degrades gracefully, the batch and the
+    // pools it sizes do not.
+    let fixed_reserve: usize = ssm_pool_bytes
         + ssm_h_stage_bytes
         + ssm_replay_ring
-        + ssm_snapshot_bytes
+        + marconi_bytes
         + gdn_two_phase_bytes
         + cuda_headroom
         + per_sequence_reserve(args, config);
+    // Phase-C decode-rollback ring: the depth the flags/env ask for, then the
+    // largest depth that actually fits alongside everything above. Both steps
+    // are SSOT'd in `decode_ring` (which publishes the fitted depth so
+    // `TransformerModel::new` allocates exactly what was reserved).
+    let ring_requested = decode_ring::requested_slots(args, config);
+    let ring_slot_bytes = decode_ring::slot_bytes(args, per_seq_blob);
+    let fit = decode_ring::autofit(
+        args,
+        ring_requested,
+        ring_slot_bytes,
+        per_seq_blob,
+        fixed_reserve + buffer_arena_bytes,
+        free_mem,
+    );
+    if let Some(warning) = &fit.warning {
+        tracing::warn!("SSM decode-rollback ring auto-fit — {}", warning);
+    }
+    let ssm_snapshot_bytes = marconi_bytes + fit.slots * ring_slot_bytes;
+    let inference_reserve: usize = fixed_reserve + fit.slots * ring_slot_bytes;
     let total_reserve = inference_reserve + buffer_arena_bytes;
     if total_reserve > free_mem {
-        let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
-        let free_gb = free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
-        let fixed = ssm_pool_bytes + ssm_h_stage_bytes + ssm_snapshot_bytes + cuda_headroom;
-        let budget_for_seq_term = free_mem.saturating_sub(fixed) / 2;
-        let per_tok_bytes = {
-            let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
-            let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
-            let nv = config.linear_num_value_heads;
-            let conv_dim = key_dim * 2 + value_dim;
-            if conv_dim > 0 && config.num_ssm_layers() > 0 {
-                (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
-            } else {
-                0
-            }
-        };
-        let suggested = budget_for_seq_term
-            .checked_div(per_tok_bytes)
-            .map(|q| q.max(2048))
-            .unwrap_or(0);
-        let hint = if suggested > 0 && suggested < args.max_seq_len {
-            format!(
-                " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
-                suggested
-            )
-        } else if args.max_batch_size > 1 {
-            " Reduce --max-batch-size.".to_string()
-        } else {
-            " Use a smaller model or a GPU with more memory.".to_string()
-        };
-        anyhow::bail!(
-            "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
-             (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}",
-            need_gb,
-            free_gb,
-            args.max_seq_len,
-            args.max_batch_size,
-            hint,
-        );
+        return Err(refusal::reserve_refusal(
+            args,
+            config,
+            refusal::Refusal {
+                total_reserve,
+                free_mem,
+                seq_len_independent: ssm_pool_bytes
+                    + ssm_h_stage_bytes
+                    + ssm_snapshot_bytes
+                    + cuda_headroom,
+                ring_requested,
+                ring_slots: fit.slots,
+                per_seq_blob,
+            },
+        ));
     }
     tracing::info!(
-        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB)",
+        "Preflight reserve: inference={} MB, buffer_arena={} MB (pre-load free: {:.1} GB); {}",
         inference_reserve / (1024 * 1024),
         buffer_arena_bytes / (1024 * 1024),
         free_mem as f64 / (1024.0 * 1024.0 * 1024.0),
+        decode_ring::formula(fit.slots, args.max_batch_size, per_seq_blob),
     );
     // Q09: per-component breakdown so future MTP/spec-decode reserve
     // jumps are diagnosable from the log alone. Each line is dropped at

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! GPU init + pre-load reserve preflight + post-load OOM check.
+//! GPU init + the pre-load reserve preflight.
+//!
+//! The post-load OOM check that used to live here is `post_load_audit.rs`;
+//! it moved when the #915 second pass brought the decode ring's post-load
+//! yardstick in (`headroom.rs`) and this file reached its 500-line cap.
 
 use anyhow::{Context, Result};
 
@@ -9,9 +13,13 @@ use atlas_core::config::ModelConfig;
 use crate::cli;
 
 mod decode_ring;
+mod headroom;
 mod per_sequence_state;
+mod post_load_audit;
 mod refusal;
 mod ssm_h_fp16;
+pub(crate) use headroom::PostLoadInputs;
+pub(crate) use post_load_audit::post_load_memory_audit;
 use {per_sequence_state::per_sequence_reserve, ssm_h_fp16::ssm_h_fp16_preconditions};
 
 pub(crate) struct ReservePreflight {
@@ -26,6 +34,12 @@ pub(crate) fn preflight_reserve(
     args: &cli::ServeArgs,
     config: &ModelConfig,
     free_mem: usize,
+    // #915 second pass: what the decode-ring auto-fit needs to predict the
+    // POST-load KV headroom instead of fitting against pre-load free memory.
+    // Gathered by the caller because none of it is derivable from `args` +
+    // `config`: the device total, the checkpoint directory, the resolved KV
+    // dtype and whether this target ships the W8A8 prefill kernels.
+    post_load: &PostLoadInputs<'_>,
 ) -> Result<ReservePreflight> {
     let h_state_bytes = config.ssm_h_state_bytes();
     let conv_state_bytes = config.ssm_conv_state_bytes();
@@ -227,6 +241,12 @@ pub(crate) fn preflight_reserve(
     // `TransformerModel::new` allocates exactly what was reserved).
     let ring_requested = decode_ring::requested_slots(args, config);
     let ring_slot_bytes = decode_ring::slot_bytes(args, per_seq_blob);
+    // The yardstick, and why it is that one: the predicted post-load KV
+    // headroom where the route's residency can be predicted, pre-load free
+    // memory (the first pass's behaviour) everywhere else. See `headroom.rs`
+    // for the H100 receipts that made the first yardstick the wrong one.
+    let yardstick =
+        headroom::post_load_yardstick(args, config, post_load, fixed_reserve, buffer_arena_bytes);
     let fit = decode_ring::autofit(
         args,
         ring_requested,
@@ -234,7 +254,9 @@ pub(crate) fn preflight_reserve(
         per_seq_blob,
         fixed_reserve + buffer_arena_bytes,
         free_mem,
+        &yardstick,
     );
+    tracing::info!("{}", fit.decision);
     if let Some(warning) = &fit.warning {
         tracing::warn!("SSM decode-rollback ring auto-fit — {}", warning);
     }
@@ -366,69 +388,6 @@ pub(crate) fn init_gpu_backend(
         free_mem as f64 / (1024.0 * 1024.0 * 1024.0),
     );
     Ok((gpu, free_mem))
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn post_load_memory_audit(
-    args: &cli::ServeArgs,
-    config: &ModelConfig,
-    gpu: &dyn spark_runtime::gpu::GpuBackend,
-    weight_bytes: usize,
-    free_mem: usize,
-    inference_reserve: usize,
-    total_reserve: usize,
-    gdn_two_phase_bytes: usize,
-    max_batch_tokens_pre: usize,
-) -> Result<()> {
-    let estimated_free = free_mem.saturating_sub(weight_bytes);
-    let actual_free = gpu.free_memory().unwrap_or(estimated_free);
-    let available_free = if actual_free > 0 {
-        actual_free
-    } else {
-        estimated_free
-    };
-    if available_free < total_reserve {
-        let avail_gb = available_free as f64 / (1024.0 * 1024.0 * 1024.0);
-        let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
-        let hint = if args.max_batch_size > 1 {
-            format!(
-                " Reduce --max-batch-size (currently {}) or --max-seq-len (currently {}).",
-                args.max_batch_size, args.max_seq_len
-            )
-        } else {
-            format!(
-                " Reduce --max-seq-len (currently {}) or use a smaller model.",
-                args.max_seq_len
-            )
-        };
-        anyhow::bail!(
-            "Insufficient GPU memory for inference buffers. \
-             After loading {:.2} GB of weights, only {:.2} GB remains \
-             but {:.2} GB is needed for SSM state pool ({} slots × {} layers) + scratch buffers.{}",
-            weight_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
-            avail_gb,
-            need_gb,
-            args.max_batch_size,
-            config.num_ssm_layers(),
-            hint,
-        );
-    }
-    if gdn_two_phase_bytes > 0 {
-        tracing::info!(
-            "GDN chunked prefill reserve: {} MB (chunk_size={}, max_seq_len={})",
-            gdn_two_phase_bytes / (1024 * 1024),
-            max_batch_tokens_pre,
-            args.max_seq_len,
-        );
-    }
-    tracing::info!(
-        "Weights: {:.2} GB, estimated free: {:.1} GB, actual free: {:.1} GB (reserve: {} MB)",
-        weight_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
-        estimated_free as f64 / (1024.0 * 1024.0 * 1024.0),
-        actual_free as f64 / (1024.0 * 1024.0 * 1024.0),
-        inference_reserve / (1024 * 1024),
-    );
-    Ok(())
 }
 
 /// Peek the DFlash drafter's trained block size (γ) from its config.json

--- a/crates/spark-server/src/main_modules/serve_phases/preflight.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight.rs
@@ -277,6 +277,7 @@ pub(crate) fn preflight_reserve(
                 ring_requested,
                 ring_slots: fit.slots,
                 per_seq_blob,
+                ring_pinned: spark_model::ssm_reserve::published_decode_ring_slots().is_some(),
             },
         ));
     }

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
@@ -28,15 +28,22 @@
 
 use atlas_core::config::ModelConfig;
 
+use super::headroom::Yardstick;
 use crate::cli;
 
 const MIB: f64 = 1024.0 * 1024.0;
 const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
 
-/// The ring depth preflight will reserve for, and the warning the operator
-/// must see when it is not the depth the flags asked for.
+/// The ring depth preflight will reserve for, why, and the warning the
+/// operator must see when it is not the depth the flags asked for.
 pub(super) struct RingFit {
     pub(super) slots: usize,
+    /// The fit decision with every term spelled out, logged at INFO on EVERY
+    /// boot — including the boots where nothing was shrunk. #915's first pass
+    /// was silent whenever it did not fire, which is precisely why two H100
+    /// rounds could not tell "the fitter approved this" from "the fitter
+    /// never looked" (`h100-round2-report.md`, stages 3 and 5).
+    pub(super) decision: String,
     /// `Some` only when the auto-fit SHRANK the ring — logged at WARN by the
     /// caller, because a serve that quietly kept less rollback depth than its
     /// recipe records is a serve whose re-steer behaviour cannot be
@@ -93,17 +100,22 @@ pub(super) fn formula(slots: usize, max_batch: usize, per_seq_blob: usize) -> St
     )
 }
 
-/// Shrink the ring until the reserve fits, or leave it alone.
+/// Shrink the ring until it fits its yardstick, or leave it alone.
 ///
 /// `reserve_without_ring` is the WHOLE reserve minus the ring term
 /// (`inference_reserve + buffer_arena_bytes`), so the caller adds exactly
-/// `slots * slot_bytes` back.
+/// `slots * slot_bytes` back. `free_mem` is pre-load free memory. Which of
+/// the two the ladder is actually measured against is
+/// [`Yardstick::ladder_basis`]'s decision, and the second pass's whole point:
+/// on the native-FP8 dense route the ring competes with the KV cache inside
+/// the PREDICTED post-load headroom, not with the rest of the reserve inside
+/// pre-load free memory (see `headroom.rs`).
 ///
-/// Leaves the depth untouched — returning no warning — when the reserve
-/// already fits, when there is no ring to shrink, or when the depth is
-/// EXPLICIT (`--ssm-decode-ring-slots N`, published before preflight runs):
-/// an operator who named a depth gets that depth or a refusal, never a
-/// silent third answer.
+/// Leaves the depth untouched — returning no warning — when it already fits,
+/// when there is no ring to shrink, or when the depth is EXPLICIT
+/// (`--ssm-decode-ring-slots N`, published before preflight runs): an
+/// operator who named a depth gets that depth or a refusal, never a silent
+/// third answer.
 pub(super) fn autofit(
     args: &cli::ServeArgs,
     requested: usize,
@@ -111,47 +123,128 @@ pub(super) fn autofit(
     per_seq_blob: usize,
     reserve_without_ring: usize,
     free_mem: usize,
+    yardstick: &Yardstick,
 ) -> RingFit {
-    let asked = reserve_without_ring.saturating_add(requested.saturating_mul(slot_bytes));
+    // The two impure halves, kept OUT of `fit_ring` so the ladder is testable
+    // without a process-global `OnceLock` that one test would seal for the
+    // whole binary.
     let explicit = spark_model::ssm_reserve::published_decode_ring_slots().is_some();
-    if asked <= free_mem || requested == 0 || slot_bytes == 0 || explicit {
-        return RingFit {
-            slots: requested,
-            warning: None,
-        };
-    }
-    let fitted = spark_model::ssm_reserve::fit_decode_ring_slots(
+    let fit = fit_ring(
+        args,
         requested,
-        reserve_without_ring,
         slot_bytes,
+        per_seq_blob,
+        reserve_without_ring,
         free_mem,
+        yardstick,
+        explicit,
     );
-    let fitted_total = reserve_without_ring.saturating_add(fitted.saturating_mul(slot_bytes));
-    if fitted_total > free_mem {
-        // Even a ringless serve does not fit: the ring is not the problem, so
-        // do not shrink it behind the operator's back — the caller refuses
-        // and quotes the formula for the depth that was actually asked for.
+    if fit.slots != requested {
+        // Published so `TransformerModel::new` allocates the SAME depth this
+        // reserve was sized for. Both sides read the one cell; without this
+        // the runtime would allocate 8 slots against a reserve that funded
+        // fewer.
+        spark_model::ssm_reserve::set_decode_ring_slots(fit.slots);
+    }
+    fit
+}
+
+/// Pure core of [`autofit`]: the ladder, the wording, and nothing that reads
+/// or writes global state. `explicit` is
+/// `published_decode_ring_slots().is_some()`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn fit_ring(
+    args: &cli::ServeArgs,
+    requested: usize,
+    slot_bytes: usize,
+    per_seq_blob: usize,
+    reserve_without_ring: usize,
+    free_mem: usize,
+    yardstick: &Yardstick,
+    explicit: bool,
+) -> RingFit {
+    let (beside, limit) = yardstick.ladder_basis(reserve_without_ring, free_mem);
+    let asked = beside.saturating_add(requested.saturating_mul(slot_bytes));
+    let decide = |slots: usize| describe(args, yardstick, slots, slot_bytes, beside, limit);
+    if requested == 0 || slot_bytes == 0 || explicit || asked <= limit {
         return RingFit {
             slots: requested,
+            decision: decide(requested),
             warning: None,
         };
     }
-    // Published so `TransformerModel::new` allocates the SAME depth this
-    // reserve was sized for. Both sides read the one cell; without this the
-    // runtime would allocate 8 slots against a reserve that funded fewer.
-    spark_model::ssm_reserve::set_decode_ring_slots(fitted);
+    let fitted =
+        spark_model::ssm_reserve::fit_decode_ring_slots(requested, beside, slot_bytes, limit);
+    let fitted_total = beside.saturating_add(fitted.saturating_mul(slot_bytes));
+    if fitted_total > limit && matches!(yardstick, Yardstick::PreLoadFree(_)) {
+        // Even a ringless serve does not fit in FREE MEMORY: the ring is not
+        // the problem, so do not shrink it behind the operator's back — the
+        // caller refuses and quotes the formula for the depth actually asked
+        // for. Not symmetric with the post-load arm on purpose: free memory
+        // is measured and the refusal is sound, whereas the post-load
+        // headroom is an ESTIMATE and must never be the thing that refuses a
+        // boot. There, dropping to depth 0 hands the decision to the KV
+        // budget stage, which measures.
+        return RingFit {
+            slots: requested,
+            decision: decide(requested),
+            warning: None,
+        };
+    }
     RingFit {
         slots: fitted,
+        decision: decide(fitted),
         warning: Some(format!(
-            "{} (was {:.2} GB); reserve {:.2} of {:.2} GB. Sized from free memory, not from \
-             --max-batch-size {} (#915): rollback depth yields, concurrency does not. Pass \
-             --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).",
+            "{} (was {:.2} GB); {}. Sized from {}, not from --max-batch-size {} (#915): \
+             rollback depth yields, concurrency does not. Pass --ssm-decode-ring-slots N to \
+             pin a depth (and be refused rather than shrunk).",
             formula(fitted, args.max_batch_size, per_seq_blob),
             (requested * slot_bytes) as f64 / GIB,
-            fitted_total as f64 / GIB,
-            free_mem as f64 / GIB,
+            if fitted_total > limit {
+                format!(
+                    "even 0 slots leaves {:.2} GB under the {:.2} GB it needs beside the KV \
+                     floor — the KV budget stage will decide",
+                    fitted_total as f64 / GIB,
+                    limit as f64 / GIB,
+                )
+            } else {
+                format!(
+                    "{} {:.2} of {:.2} GB",
+                    yardstick.total_label(),
+                    fitted_total as f64 / GIB,
+                    limit as f64 / GIB,
+                )
+            },
+            yardstick.name(),
             args.max_batch_size,
         )),
+    }
+}
+
+/// The INFO line: which yardstick, every term behind it, and what the ladder
+/// concluded. #915's third bullet applied to the FIT rather than the reserve.
+fn describe(
+    args: &cli::ServeArgs,
+    yardstick: &Yardstick,
+    slots: usize,
+    slot_bytes: usize,
+    beside: usize,
+    limit: usize,
+) -> String {
+    let ring_bytes = slots.saturating_mul(slot_bytes);
+    match yardstick {
+        Yardstick::PostLoad(h) => format!(
+            "SSM decode-ring fit against the predicted post-load KV headroom: {}",
+            h.describe(args.gpu_memory_utilization, ring_bytes, slots),
+        ),
+        Yardstick::PreLoadFree(why) => format!(
+            "SSM decode-ring fit against pre-load free memory ({why}): ring({slots}) {:.2} + \
+             rest of reserve {:.2} = {:.2} of {:.2} GB free",
+            ring_bytes as f64 / GIB,
+            beside as f64 / GIB,
+            (beside + ring_bytes) as f64 / GIB,
+            limit as f64 / GIB,
+        ),
     }
 }
 

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The decode-rollback ring reserve term and its #915 auto-fit.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), following
+//! the `per_sequence_state.rs` precedent: the term, the formula it prints and
+//! the shrink decision live here; `preflight.rs` gains only the calls.
+//!
+//! # Why this term needed a fit and not just a number
+//!
+//! `ssm_snapshot_bytes` multiplies a CONSTANT ring depth (8) by
+//! `--max-batch-size`, a flag that says nothing about what the card can hold.
+//! Serving Qwen/Qwen3.8-27B-FP8 on one 80 GB H100 with the hopper recipe
+//! (`--max-batch-size 32`, 48 GDN layers, 151.5 MiB per-seq state blob) that
+//! is 8 x 32 x 151.5 MiB = 37.88 GiB of ring inside a 45,823 MiB inference
+//! reserve, against a 71.3 GiB budget already carrying 57.2 GiB of weights —
+//! and the serve REFUSED to boot (rental H100, 2026-09-05, evidence cell
+//! `qwen38.atlas.a.lat.c1`). The shipped workaround was `--max-batch-size 4`
+//! (cell `qwen38.atlas.c.lat.c1`, reserve 8.54 GiB, GO in 22 s): paying for
+//! rollback depth with four fifths of the serve's concurrency.
+//!
+//! Ring depth degrades GRACEFULLY (fewer retained boundaries = fewer
+//! reachable re-steer anchors; a sequence that finds none hard-stops through
+//! `RollbackFallback::NoSsmSnapshot`, which is an honest decline, never a
+//! partial SSM rewind). Batch does not: it is the serve's concurrency. So the
+//! term that yields is the ring, and it yields down
+//! `ssm_reserve::DECODE_RING_FIT_LADDER` until the whole reserve fits.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+const MIB: f64 = 1024.0 * 1024.0;
+const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// The ring depth preflight will reserve for, and the warning the operator
+/// must see when it is not the depth the flags asked for.
+pub(super) struct RingFit {
+    pub(super) slots: usize,
+    /// `Some` only when the auto-fit SHRANK the ring — logged at WARN by the
+    /// caller, because a serve that quietly kept less rollback depth than its
+    /// recipe records is a serve whose re-steer behaviour cannot be
+    /// reproduced from the recipe.
+    pub(super) warning: Option<String>,
+}
+
+/// The ring depth the flags and environment ask for, before any fit.
+///
+/// SSOT: `spark_model::ssm_reserve::decode_rollback_ring_slots` makes the
+/// SAME decision (same published cell, same env vars, same constant) the
+/// runtime allocation in `TransformerModel::new` makes — including the skip
+/// under `--speculative`/`--dflash` (the ring's save/rollback path only runs
+/// on plain decode; the spec path rolls back through the verify snapshot).
+/// Reserving the ring unconditionally while the runtime skipped it stranded
+/// ~38 GB at bs32 on the 27B and capped the native batch at ~20.
+/// `use_speculative` here MUST mirror what `build_model` passes:
+/// `args.speculative || args.dflash`.
+///
+/// Kill switch: `ATLAS_SSM_RESERVE_RING_FULL` present => restore the old
+/// unconditional reservation (accounting-only, safe over-reserve;
+/// presence-style — `=0` is NOT "off").
+pub(super) fn requested_slots(args: &cli::ServeArgs, config: &ModelConfig) -> usize {
+    if std::env::var("ATLAS_SSM_RESERVE_RING_FULL").is_ok() {
+        return if config.num_ssm_layers() > 0 {
+            atlas_kernels::DECODE_ROLLBACK_RING_SLOTS
+        } else {
+            0
+        };
+    }
+    spark_model::ssm_reserve::decode_rollback_ring_slots(
+        config.num_ssm_layers(),
+        args.speculative || args.dflash,
+    )
+    .slots
+}
+
+/// Bytes ONE unit of ring depth costs: `--max-batch-size` x the per-sequence
+/// SSM state blob. The same product `ssm_snapshot_bytes` multiplies the depth
+/// by, factored out so the fit and the reserve cannot use different arithmetic.
+pub(super) fn slot_bytes(args: &cli::ServeArgs, per_seq_blob: usize) -> usize {
+    args.max_batch_size * per_seq_blob
+}
+
+/// `snapshots x batch x per-seq state bytes`, spelled out (issue #915's third
+/// bullet: preflight must print the formula so an operator can see why the
+/// reserve asked for what it asked for). SSOT for the INFO line, the shrink
+/// WARN and the refusal text, so all three quote the same arithmetic.
+pub(super) fn formula(slots: usize, max_batch: usize, per_seq_blob: usize) -> String {
+    format!(
+        "ring: {slots} slots x {max_batch} seqs x {:.1} MB/seq = {:.2} GB",
+        per_seq_blob as f64 / MIB,
+        (slots * max_batch * per_seq_blob) as f64 / GIB,
+    )
+}
+
+/// Shrink the ring until the reserve fits, or leave it alone.
+///
+/// `reserve_without_ring` is the WHOLE reserve minus the ring term
+/// (`inference_reserve + buffer_arena_bytes`), so the caller adds exactly
+/// `slots * slot_bytes` back.
+///
+/// Leaves the depth untouched — returning no warning — when the reserve
+/// already fits, when there is no ring to shrink, or when the depth is
+/// EXPLICIT (`--ssm-decode-ring-slots N`, published before preflight runs):
+/// an operator who named a depth gets that depth or a refusal, never a
+/// silent third answer.
+pub(super) fn autofit(
+    args: &cli::ServeArgs,
+    requested: usize,
+    slot_bytes: usize,
+    per_seq_blob: usize,
+    reserve_without_ring: usize,
+    free_mem: usize,
+) -> RingFit {
+    let asked = reserve_without_ring.saturating_add(requested.saturating_mul(slot_bytes));
+    let explicit = spark_model::ssm_reserve::published_decode_ring_slots().is_some();
+    if asked <= free_mem || requested == 0 || slot_bytes == 0 || explicit {
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    let fitted = spark_model::ssm_reserve::fit_decode_ring_slots(
+        requested,
+        reserve_without_ring,
+        slot_bytes,
+        free_mem,
+    );
+    let fitted_total = reserve_without_ring.saturating_add(fitted.saturating_mul(slot_bytes));
+    if fitted_total > free_mem {
+        // Even a ringless serve does not fit: the ring is not the problem, so
+        // do not shrink it behind the operator's back — the caller refuses
+        // and quotes the formula for the depth that was actually asked for.
+        return RingFit {
+            slots: requested,
+            warning: None,
+        };
+    }
+    // Published so `TransformerModel::new` allocates the SAME depth this
+    // reserve was sized for. Both sides read the one cell; without this the
+    // runtime would allocate 8 slots against a reserve that funded fewer.
+    spark_model::ssm_reserve::set_decode_ring_slots(fitted);
+    RingFit {
+        slots: fitted,
+        warning: Some(format!(
+            "{} (was {:.2} GB); reserve {:.2} of {:.2} GB. Sized from free memory, not from \
+             --max-batch-size {} (#915): rollback depth yields, concurrency does not. Pass \
+             --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).",
+            formula(fitted, args.max_batch_size, per_seq_blob),
+            (requested * slot_bytes) as f64 / GIB,
+            fitted_total as f64 / GIB,
+            free_mem as f64 / GIB,
+            args.max_batch_size,
+        )),
+    }
+}
+
+#[cfg(test)]
+#[path = "decode_ring_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring.rs
@@ -202,9 +202,9 @@ pub(super) fn fit_ring(
             (requested * slot_bytes) as f64 / GIB,
             if fitted_total > limit {
                 format!(
-                    "even 0 slots leaves {:.2} GB under the {:.2} GB it needs beside the KV \
-                     floor — the KV budget stage will decide",
-                    fitted_total as f64 / GIB,
+                    "even 0 slots does not clear the {:.2} GB KV floor inside {:.2} GB of \
+                     predicted headroom — the KV budget stage will decide, on measured bytes",
+                    beside as f64 / GIB,
                     limit as f64 / GIB,
                 )
             } else {

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
@@ -12,6 +12,11 @@
 use super::*;
 use clap::Parser as _;
 
+/// These cases pin the PRE-LOAD arm — the behaviour every route without a
+/// predictable post-load residency still takes. The post-load arm (#915
+/// second pass) has its own file, `headroom_tests.rs`.
+const PRE_LOAD: Yardstick = Yardstick::PreLoadFree("no residency prediction in this test");
+
 /// 48 GDN layers x (h 48*128*128*4 + conv (16*128*2 + 48*128)*4*4) =
 /// 158,859,264 B = exactly 151.5 MiB.
 const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
@@ -52,7 +57,16 @@ fn the_915_boot_shrinks_to_the_largest_fitting_depth_instead_of_refusing() {
     assert_eq!(slot, 32 * PER_SEQ_BLOB);
     let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
 
-    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    let fit = fit_ring(
+        &args,
+        8,
+        slot,
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        free,
+        &PRE_LOAD,
+        false,
+    );
     assert_eq!(fit.slots, 1, "8 -> 4 -> 2 -> 1 is the first rung that fits");
     assert!(
         RESERVE_WITHOUT_RING + fit.slots * slot <= free,
@@ -66,6 +80,10 @@ fn the_915_boot_shrinks_to_the_largest_fitting_depth_instead_of_refusing() {
     );
     assert!(warning.contains("(was 37.88 GB)"), "{warning}");
     assert!(warning.contains("reserve 11.61 of 14.10 GB"), "{warning}");
+    assert!(
+        warning.contains("Sized from pre-load free memory"),
+        "the WARN must name the yardstick it used: {warning}"
+    );
     assert!(warning.contains("#915"), "{warning}");
     assert!(
         warning.contains("--ssm-decode-ring-slots"),
@@ -81,9 +99,24 @@ fn a_reserve_that_fits_is_not_touched() {
     let args = args();
     let slot = slot_bytes(&args, PER_SEQ_BLOB);
     let free = 64 * 1024 * 1024 * 1024;
-    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    let fit = fit_ring(
+        &args,
+        8,
+        slot,
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        free,
+        &PRE_LOAD,
+        false,
+    );
     assert_eq!(fit.slots, 8);
     assert!(fit.warning.is_none());
+    // Silent is not the same as absent: the decision is logged either way.
+    assert!(
+        fit.decision.contains("pre-load free memory"),
+        "{}",
+        fit.decision
+    );
 }
 
 /// Nothing to shrink is not a shrink: a ringless serve (`--speculative`,
@@ -93,18 +126,20 @@ fn a_reserve_that_fits_is_not_touched() {
 fn a_ringless_serve_is_left_to_the_refusal() {
     let args = args();
     let free = RESERVE_WITHOUT_RING / 2;
-    let fit = autofit(
+    let fit = fit_ring(
         &args,
         0,
         slot_bytes(&args, PER_SEQ_BLOB),
         PER_SEQ_BLOB,
         RESERVE_WITHOUT_RING,
         free,
+        &PRE_LOAD,
+        false,
     );
     assert_eq!(fit.slots, 0);
     assert!(fit.warning.is_none());
     // Same when the model has no SSM state at all: a zero-byte depth unit.
-    let fit = autofit(&args, 8, 0, 0, RESERVE_WITHOUT_RING, free);
+    let fit = fit_ring(&args, 8, 0, 0, RESERVE_WITHOUT_RING, free, &PRE_LOAD, false);
     assert_eq!(fit.slots, 8);
     assert!(fit.warning.is_none());
 }
@@ -117,13 +152,15 @@ fn a_ringless_serve_is_left_to_the_refusal() {
 fn an_unfittable_reserve_keeps_the_requested_depth_for_the_refusal() {
     let args = args();
     let slot = slot_bytes(&args, PER_SEQ_BLOB);
-    let fit = autofit(
+    let fit = fit_ring(
         &args,
         8,
         slot,
         PER_SEQ_BLOB,
         RESERVE_WITHOUT_RING,
         RESERVE_WITHOUT_RING - 1,
+        &PRE_LOAD,
+        false,
     );
     assert_eq!(fit.slots, 8, "the refusal must quote what was asked for");
     assert!(fit.warning.is_none());

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/decode_ring_tests.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Exact-integer pins for the preflight ring term and its #915 auto-fit. No
+//! GPU, no model, no checkpoint — which is the point: this decision is made
+//! before the weights exist.
+//!
+//! The numbers are the 2026-09-05 rental-H100 boot from issue #915
+//! (Qwen/Qwen3.8-27B-FP8, one 80 GB H100, hopper recipe, evidence cell
+//! `qwen38.atlas.a.lat.c1`): 48 GDN layers, 151.5 MiB of SSM state per
+//! sequence, `--max-batch-size 32`, inference reserve 45,823 MiB of which
+//! 37.88 GiB was ring, 57.2 GiB of weights inside a 71.3 GiB budget.
+use super::*;
+use clap::Parser as _;
+
+/// 48 GDN layers x (h 48*128*128*4 + conv (16*128*2 + 48*128)*4*4) =
+/// 158,859,264 B = exactly 151.5 MiB.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+/// The 45,823 MiB inference reserve minus its 38,784 MiB 8-slot ring.
+const RESERVE_WITHOUT_RING: usize = 7_039 * 1024 * 1024;
+
+fn args() -> cli::ServeArgs {
+    cli::ServeArgs::parse_from(["spark", "Qwen/Qwen3.8-27B-FP8", "--max-batch-size", "32"])
+}
+
+/// The formula issue #915's third bullet asks preflight to print: an operator
+/// staring at 45.8 GiB could not see it was 8 snapshots x batch 32.
+#[test]
+fn the_formula_spells_out_snapshots_times_batch_times_per_seq_state() {
+    assert_eq!(
+        formula(8, 32, PER_SEQ_BLOB),
+        "ring: 8 slots x 32 seqs x 151.5 MB/seq = 37.88 GB"
+    );
+    // The same arithmetic at the depth the fit chose — one function, so the
+    // INFO line, the shrink WARN and the refusal cannot quote three answers.
+    assert_eq!(
+        formula(1, 32, PER_SEQ_BLOB),
+        "ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"
+    );
+    assert_eq!(
+        formula(0, 32, PER_SEQ_BLOB),
+        "ring: 0 slots x 32 seqs x 151.5 MB/seq = 0.00 GB"
+    );
+}
+
+/// The #915 boot itself: 14.1 GiB free (71.3 GiB budget less 57.2 GiB of
+/// weights) against a reserve whose ring alone wants 37.88 GiB. It must
+/// shrink to depth 1 and boot, not refuse.
+#[test]
+fn the_915_boot_shrinks_to_the_largest_fitting_depth_instead_of_refusing() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    assert_eq!(slot, 32 * PER_SEQ_BLOB);
+    let free = (14.1 * 1024.0 * 1024.0 * 1024.0) as usize;
+
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 1, "8 -> 4 -> 2 -> 1 is the first rung that fits");
+    assert!(
+        RESERVE_WITHOUT_RING + fit.slots * slot <= free,
+        "the depth it kept must actually fit"
+    );
+
+    let warning = fit.warning.expect("a shrink must be logged, never silent");
+    assert!(
+        warning.contains("ring: 1 slots x 32 seqs x 151.5 MB/seq = 4.73 GB"),
+        "{warning}"
+    );
+    assert!(warning.contains("(was 37.88 GB)"), "{warning}");
+    assert!(warning.contains("reserve 11.61 of 14.10 GB"), "{warning}");
+    assert!(warning.contains("#915"), "{warning}");
+    assert!(
+        warning.contains("--ssm-decode-ring-slots"),
+        "the warning must name the flag that pins a depth: {warning}"
+    );
+}
+
+/// A reserve that already fits is left exactly as the flags asked for, and
+/// says nothing — the WARN is reserved for the case where the serve is
+/// running at a depth its recipe does not record.
+#[test]
+fn a_reserve_that_fits_is_not_touched() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let free = 64 * 1024 * 1024 * 1024;
+    let fit = autofit(&args, 8, slot, PER_SEQ_BLOB, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// Nothing to shrink is not a shrink: a ringless serve (`--speculative`,
+/// watchdogs off, `--ssm-decode-ring-slots 0`, or a pure-attention model)
+/// goes straight to the refusal with no warning of its own.
+#[test]
+fn a_ringless_serve_is_left_to_the_refusal() {
+    let args = args();
+    let free = RESERVE_WITHOUT_RING / 2;
+    let fit = autofit(
+        &args,
+        0,
+        slot_bytes(&args, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        free,
+    );
+    assert_eq!(fit.slots, 0);
+    assert!(fit.warning.is_none());
+    // Same when the model has no SSM state at all: a zero-byte depth unit.
+    let fit = autofit(&args, 8, 0, 0, RESERVE_WITHOUT_RING, free);
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// When even depth 0 is over budget the ring is not what is wrong. Shrinking
+/// it behind the operator's back would swap a clear refusal for a serve with
+/// no rollback depth that still cannot boot, so the depth is returned
+/// UNCHANGED and the caller refuses quoting the full formula.
+#[test]
+fn an_unfittable_reserve_keeps_the_requested_depth_for_the_refusal() {
+    let args = args();
+    let slot = slot_bytes(&args, PER_SEQ_BLOB);
+    let fit = autofit(
+        &args,
+        8,
+        slot,
+        PER_SEQ_BLOB,
+        RESERVE_WITHOUT_RING,
+        RESERVE_WITHOUT_RING - 1,
+    );
+    assert_eq!(fit.slots, 8, "the refusal must quote what was asked for");
+    assert!(fit.warning.is_none());
+}
+
+/// `--ssm-decode-ring-slots 0` is a real value the CLI accepts, and the
+/// requested-depth path must honour a published depth rather than the
+/// constant 8 — the allocation side reads the same cell.
+#[test]
+fn the_flag_parses_through_the_model_side_ssot() {
+    use spark_model::ssm_reserve::parse_decode_ring_slots;
+    assert_eq!(parse_decode_ring_slots("auto"), Ok(None));
+    assert_eq!(parse_decode_ring_slots("2"), Ok(Some(2)));
+    assert!(parse_decode_ring_slots("12").is_err());
+    // The clap default is the `auto` this module's fit depends on.
+    assert_eq!(args().ssm_decode_ring_slots, "auto");
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/headroom.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/headroom.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The yardstick the #915 SSM decode-ring auto-fit is measured against.
+//!
+//! # Why the first pass fitted against the wrong number
+//!
+//! The first pass (`2224f5f11`) sized the ring from PRE-LOAD free memory.
+//! Measured on 1xH100 2026-09-11 (`h100-round2-report.md`, stages 3 and 5,
+//! plus the `preflight_probe.sh` sweep), that yardstick is ~6x too large and
+//! the fitter therefore never fired at the batch sizes that matter:
+//!
+//! | `--max-batch-size` | ring chosen | fired? | serve |
+//! |---|---|---|---|
+//! | 4 | 8 | no | boots |
+//! | 16 | 8 (18.94 GB) | no | **refused** by the KV stage |
+//! | 32 | 8 (37.88 GB) | no | **refused** by the KV stage |
+//! | 64 | 8 -> 4 | yes | still refused |
+//!
+//! The fitter's own WARN said it: `reserve 54.13 of 78.57 GB` — 78.57 GB is
+//! free memory before a single weight byte is resident. The quantity that has
+//! to accommodate the reserve is the POST-load KV headroom, and it is a
+//! different stage (`spark_model::factory::build`) that enforces it, four
+//! minutes later, with no shrink path — only a refusal:
+//!
+//! ```text
+//! KV cache: 79.2 GB total x 90% util = 71.3 GB budget;
+//!           33.2 GB pre-KV + 45.8 GB reserve -> 0 GB for KV
+//! ```
+//!
+//! # The yardstick this module computes
+//!
+//! The SAME formula that stage uses, evaluated from what preflight can
+//! already see:
+//!
+//! ```text
+//! budget          = total_mem x --gpu-memory-utilization
+//! pre_kv_estimate = weights + derived + buffer_arena + fixed_reserve
+//! headroom        = budget - pre_kv_estimate
+//! ```
+//!
+//! and the ring is then the largest `DECODE_RING_FIT_LADDER` depth for which
+//! `ring_bytes + kv_floor <= headroom`. `fixed_reserve` is inside `pre_kv`
+//! rather than beside it because `headroom` is defined as exactly the two
+//! terms the fit trades off — ring against KV.
+//!
+//! Round-6 receipt (`h100-round6-report.md`, native-FP8 residency fix in):
+//! weights 28.75 GB, derived 4.24 GB, arena 3.57 GiB, `fixed` = reserve minus
+//! ring. At `--max-batch-size 16` that leaves ~29 GiB of headroom, the full
+//! 8-slot ring (18.94 GiB) fits beside the KV floor, and the serve boots with
+//! 13.6 GB of real KV. At 32 the 8-slot ring wants 37.88 GiB against ~27 GiB
+//! of headroom, so the fit picks 4 — the depth the operator had to pass by
+//! hand (`--ssm-decode-ring-slots 4`) to get that boot at all.
+//!
+//! # What it refuses to estimate
+//!
+//! Both new terms are ESTIMATES and neither is allowed to be a guess:
+//!
+//! * `weights` is the checkpoint's on-disk byte count. That equals resident
+//!   bytes only for checkpoints Atlas loads verbatim; a BF16 checkpoint
+//!   requantised to NVFP4 at load is a different number entirely.
+//! * `derived` is `predicted_residency::predicted_derived_bytes`, which
+//!   answers only for the native-FP8 dense route.
+//!
+//! So the post-load yardstick is used ONLY when the derived prediction is
+//! available — the same route on which the on-disk count is a sound upper
+//! bound on residency (the loader prunes, never grows: round 6's 28.75 GB
+//! checkpoint settles at ~24.7 GB resident, so this over-states pre-KV by
+//! ~4 GB and can only choose a SMALLER ring, never a larger one). Every other
+//! model falls back to the pre-load free-memory yardstick and the log says
+//! which one was used and why.
+
+use atlas_core::config::ModelConfig;
+use spark_runtime::kv_cache::{KvCacheConfig, KvCacheDtype};
+
+use crate::cli;
+
+const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// The default `kv_floor` context length, in tokens per sequence.
+///
+/// The fit must not hand the whole headroom to the ring and leave a KV cache
+/// too small to admit `--max-batch-size` sequences: rollback depth is a
+/// nice-to-have, a KV cache is the serve. 4096 is a deliberate FLOOR and not
+/// a target — round 6 booted at bs=16 with 13.6 GB of KV (~415k tokens), far
+/// above this — chosen so the reservation stays a guard rail rather than a
+/// second, hidden concurrency cap.
+///
+/// Lever: `ATLAS_KV_FLOOR_TOKENS=<n>` (0 disables the floor entirely).
+pub(super) const DEFAULT_KV_FLOOR_TOKENS: usize = 4096;
+
+/// `ATLAS_KV_FLOOR_TOKENS`, or [`DEFAULT_KV_FLOOR_TOKENS`].
+///
+/// An unparseable value takes the default rather than 0: silently removing
+/// the floor because of a typo is the failure this guard exists to prevent.
+pub(super) fn kv_floor_tokens() -> usize {
+    match std::env::var("ATLAS_KV_FLOOR_TOKENS") {
+        Ok(v) => v.trim().parse().unwrap_or_else(|_| {
+            tracing::warn!(
+                "ATLAS_KV_FLOOR_TOKENS='{v}' is not a token count — using the default {}",
+                DEFAULT_KV_FLOOR_TOKENS,
+            );
+            DEFAULT_KV_FLOOR_TOKENS
+        }),
+        Err(_) => DEFAULT_KV_FLOOR_TOKENS,
+    }
+}
+
+/// What `preflight_reserve` needs from its caller to build the post-load
+/// yardstick, and cannot derive from `args` + `config` alone.
+pub(crate) struct PostLoadInputs<'a> {
+    /// `gpu.total_memory()` — the same total the KV budget stage multiplies
+    /// by `--gpu-memory-utilization`.
+    pub(crate) total_mem: usize,
+    /// The resolved checkpoint directory, for the on-disk weight estimate.
+    pub(crate) model_dir: &'a std::path::Path,
+    /// The KV dtype the cache will actually be built with, resolved through
+    /// `serve_phases::kv_cache::resolve_kv_dtype_str` so preflight and the
+    /// cache cannot disagree about bytes per token.
+    pub(crate) kv_dtype: KvCacheDtype,
+    /// Both `qwen3_attention::W8A8_PREFILL_KERNELS` are loaded for this
+    /// target. Decides whether the loader builds the Q and O FP8 prefill
+    /// twins (~1.5 GB on the 27B).
+    pub(crate) w8a8_prefill_kernels: bool,
+}
+
+/// Every term of the fit decision, kept so the INFO line can print all of
+/// them rather than a single derived number nobody can check.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct Headroom {
+    /// `total_mem x --gpu-memory-utilization`.
+    pub(super) budget: usize,
+    /// Checkpoint bytes on disk.
+    pub(super) weights: usize,
+    /// Derived copies the loader will build on top of them.
+    pub(super) derived: usize,
+    /// `BufferSizes::from_config(..).total_bytes()`.
+    pub(super) arena: usize,
+    /// The reserve terms that do NOT scale with ring depth.
+    pub(super) fixed: usize,
+    /// KV bytes for `--max-batch-size` sequences at the floor context.
+    pub(super) kv_floor: usize,
+    /// `budget - (weights + derived + arena + fixed)`, saturating.
+    pub(super) headroom: usize,
+}
+
+/// What the ring is fitted against.
+pub(super) enum Yardstick {
+    /// Pre-load free memory — the first pass's behaviour, kept for every
+    /// route whose post-load residency cannot be predicted. The `&'static
+    /// str` is why, for the log.
+    PreLoadFree(&'static str),
+    /// The predicted post-load KV headroom.
+    PostLoad(Headroom),
+}
+
+impl Yardstick {
+    /// `(bytes that must fit BESIDE the ring, the limit both must fit in)` —
+    /// the two arguments `ssm_reserve::fit_decode_ring_slots` takes.
+    ///
+    /// The two modes differ only in what the ring is competing with: free
+    /// memory against the rest of the reserve, or predicted headroom against
+    /// the KV floor. One ladder, two bases.
+    pub(super) fn ladder_basis(
+        &self,
+        reserve_without_ring: usize,
+        free_mem: usize,
+    ) -> (usize, usize) {
+        match self {
+            Self::PreLoadFree(_) => (reserve_without_ring, free_mem),
+            Self::PostLoad(h) => (h.kv_floor, h.headroom),
+        }
+    }
+
+    /// What the shrink WARN calls the thing it sized from.
+    pub(super) fn name(&self) -> &'static str {
+        match self {
+            Self::PreLoadFree(_) => "pre-load free memory",
+            Self::PostLoad(_) => "the predicted post-load KV headroom",
+        }
+    }
+
+    /// What the shrink WARN calls the sum it checked against that yardstick:
+    /// the whole reserve in pre-load mode, the ring plus the KV floor in
+    /// post-load mode.
+    pub(super) fn total_label(&self) -> &'static str {
+        match self {
+            Self::PreLoadFree(_) => "reserve",
+            Self::PostLoad(_) => "ring + KV floor",
+        }
+    }
+}
+
+/// Build the post-load yardstick, or say why it is unavailable.
+///
+/// `fixed_reserve` and `arena` come from the caller because they are already
+/// computed there and are the reserve's own arithmetic; everything else is
+/// estimated here.
+pub(super) fn post_load_yardstick(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    inputs: &PostLoadInputs<'_>,
+    fixed_reserve: usize,
+    arena: usize,
+) -> Yardstick {
+    let route = spark_model::weight_loader::predicted_residency::Fp8RouteInputs::from_env(
+        config,
+        inputs.w8a8_prefill_kernels,
+    );
+    let estimate =
+        spark_model::weight_loader::predicted_residency::predicted_derived_bytes(config, &route);
+    let Some(derived) = estimate.bytes() else {
+        return Yardstick::PreLoadFree(
+            estimate
+                .reason()
+                .unwrap_or("the derived-residency prediction declined"),
+        );
+    };
+    let Some(weights) = checkpoint_bytes(inputs.model_dir) else {
+        return Yardstick::PreLoadFree("the checkpoint's on-disk size could not be read");
+    };
+    let budget = (inputs.total_mem as f64 * args.gpu_memory_utilization) as usize;
+    let weights = weights as usize;
+    let derived = derived as usize;
+    let pre_kv = weights
+        .saturating_add(derived)
+        .saturating_add(arena)
+        .saturating_add(fixed_reserve);
+    Yardstick::PostLoad(Headroom {
+        budget,
+        weights,
+        derived,
+        arena,
+        fixed: fixed_reserve,
+        kv_floor: kv_floor_bytes(args, config, inputs.kv_dtype),
+        headroom: budget.saturating_sub(pre_kv),
+    })
+}
+
+/// KV bytes for `--max-batch-size` sequences at the floor context length.
+///
+/// Bytes per token come from the KV cache's OWN helper
+/// (`KvCacheConfig::block_bytes_kv_all_layers`, which
+/// `PagedKvCache::compute_num_blocks` divides the budget by), so the floor
+/// and the real pool are priced by one function. MLA is mirrored from
+/// `factory/build.rs`'s step 5: an absorbed cache stores one head of
+/// `kv_lora_rank + qk_rope_head_dim`, not `num_key_value_heads x head_dim`.
+///
+/// `layer_dims` is left empty because `config.kv_layer_dims` is populated by
+/// the LOADER and does not exist yet; `dims_for_layer` then falls back to the
+/// global pair, which is exact for every homogeneous model — and this
+/// yardstick is only used on the native-FP8 dense route, which is one.
+pub(super) fn kv_floor_bytes(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    kv_dtype: KvCacheDtype,
+) -> usize {
+    let tokens = kv_floor_tokens().min(args.max_seq_len);
+    if tokens == 0 || args.max_batch_size == 0 {
+        return 0;
+    }
+    args.max_batch_size * tokens * kv_bytes_per_token(args, config, kv_dtype)
+}
+
+/// Bytes one cached token costs across every attention layer, K and V.
+pub(super) fn kv_bytes_per_token(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    kv_dtype: KvCacheDtype,
+) -> usize {
+    let (num_kv_heads, head_dim) = if config.kv_lora_rank > 0 {
+        (1, config.kv_lora_rank + config.qk_rope_head_dim)
+    } else {
+        (config.num_key_value_heads, config.head_dim)
+    };
+    let block_size = args.block_size.max(1);
+    let kv = KvCacheConfig {
+        block_size,
+        num_kv_heads,
+        head_dim,
+        num_layers: config.num_attention_layers(),
+        dtype: kv_dtype,
+        layer_dtypes: Vec::new(),
+        layer_dims: Vec::new(),
+        cache_blocks_per_seq: None,
+    };
+    kv.block_bytes_kv_all_layers() / block_size
+}
+
+/// The checkpoint's on-disk byte count, from the safetensors index when there
+/// is one and from the directory listing otherwise.
+///
+/// This is the pre-load stand-in for the `Weights: X GB` the post-load audit
+/// prints from `store.resident_bytes()`. It is an UPPER bound on residency
+/// for a checkpoint loaded verbatim: the loader prunes tensors it has folded
+/// into derived copies (round 6: 28.75 GB of checkpoint settles at ~24.7 GB
+/// resident once the fused `[QKV|Z]` sources are dropped), and it never
+/// invents weights. Over-stating pre-KV can only shrink the fitted ring,
+/// which is the safe direction.
+///
+/// `None` — no index, no shard files, unreadable directory — takes the caller
+/// back to the pre-load yardstick rather than fitting against a zero.
+pub(super) fn checkpoint_bytes(model_dir: &std::path::Path) -> Option<u64> {
+    if let Some(total) = indexed_shard_bytes(model_dir) {
+        return Some(total);
+    }
+    // No index: sum the weight files present. Safetensors first, GGUF only
+    // when there are none, so a directory carrying both is not double-counted.
+    for ext in ["safetensors", "gguf"] {
+        let total: u64 = std::fs::read_dir(model_dir)
+            .ok()?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| x == ext)
+            })
+            .filter_map(|e| e.metadata().ok().map(|m| m.len()))
+            .sum();
+        if total > 0 {
+            return Some(total);
+        }
+    }
+    None
+}
+
+/// Sum of the DISTINCT shard files a `*.safetensors.index.json` references.
+///
+/// Read from the index rather than from `metadata.total_size` (which many
+/// re-quants omit or compute differently) and de-duplicated, because the
+/// weight map names one shard per tensor and a 66-shard checkpoint would
+/// otherwise be counted 1,606 times. Resolution order mirrors
+/// `spark_runtime::fast_weights::header::resolve_shards`.
+fn indexed_shard_bytes(model_dir: &std::path::Path) -> Option<u64> {
+    let index = [
+        "model.safetensors.index.json",
+        "consolidated.safetensors.index.json",
+    ]
+    .into_iter()
+    .map(|n| model_dir.join(n))
+    .find(|p| p.exists())?;
+    let raw = std::fs::read_to_string(&index).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let map = v.get("weight_map")?.as_object()?;
+    let shards: std::collections::HashSet<&str> = map.values().filter_map(|s| s.as_str()).collect();
+    let total: u64 = shards
+        .iter()
+        .filter_map(|s| std::fs::metadata(model_dir.join(s)).ok().map(|m| m.len()))
+        .sum();
+    (total > 0).then_some(total)
+}
+
+impl Headroom {
+    /// Every term of the decision, in the order the arithmetic runs, so an
+    /// operator reading one INFO line can redo the subtraction.
+    pub(super) fn describe(&self, util: f64, ring_bytes: usize, slots: usize) -> String {
+        let gb = |b: usize| b as f64 / GIB;
+        format!(
+            "budget {:.2} GB ({:.0}% util) = weights {:.2} + derived {:.2} + arena {:.2} + \
+             fixed reserve {:.2} -> headroom {:.2} GB; ring({}) {:.2} + KV floor {:.2} = {:.2} GB",
+            gb(self.budget),
+            util * 100.0,
+            gb(self.weights),
+            gb(self.derived),
+            gb(self.arena),
+            gb(self.fixed),
+            gb(self.headroom),
+            slots,
+            gb(ring_bytes),
+            gb(self.kv_floor),
+            gb(ring_bytes + self.kv_floor),
+        )
+    }
+}
+
+#[cfg(test)]
+#[path = "headroom_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/headroom_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/headroom_tests.rs
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The #915 second pass, pinned at the numbers the H100 actually produced.
+//!
+//! Source: `h100-round6-report.md` (Qwen/Qwen3.8-27B-FP8 on one 80 GB H100,
+//! native-FP8 profile, the residency fix in) and the preflight sweep in
+//! `h100-round2-report.md`. Every constant below is a line from one of those
+//! logs, not a number chosen to make an assertion pass:
+//!
+//! | term | round-6 value | source line |
+//! |---|---|---|
+//! | total / util | 79.2 GB x 90% = 71.3 GB budget | `KV cache: …` |
+//! | weights | 28.75 GB | `Weights: 28.75 GB, …` |
+//! | derived | 4.24 GB | `native FP8 dense residency: …` |
+//! | buffer arena | 3,658 MB | `Preflight reserve: … buffer_arena=3658 MB` |
+//! | reserve @bs16 | 25,107 MB (ring 18.94 GB) | `Preflight reserve: inference=…` |
+//! | reserve @bs32 | 46,923 MB (ring 37.88 GB) | round-2 probe |
+//! | reserve @bs64 | 51,771 MB (ring 4 = 37.88 GB) | round-2 probe |
+//!
+//! The verdicts these produce are the ones the operator had to reach by hand:
+//! bs=16 boots at the full depth 8, bs=32 needs depth 4 (which round 6 had to
+//! pass as `--ssm-decode-ring-slots 4`), bs=64 needs depth 1.
+
+use super::super::decode_ring::{fit_ring, slot_bytes};
+use super::*;
+
+use atlas_core::config::{LayerType, QuantizationConfig};
+use clap::Parser as _;
+
+const GIB_F: f64 = 1024.0 * 1024.0 * 1024.0;
+const MIB: usize = 1024 * 1024;
+
+/// 48 GDN layers x (h + conv) = 151.5 MiB, the same constant
+/// `decode_ring_tests.rs` derives from the 27B's GDN dims.
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+
+fn gib(x: f64) -> usize {
+    (x * GIB_F) as usize
+}
+
+fn args(batch: usize) -> cli::ServeArgs {
+    cli::ServeArgs::parse_from([
+        "spark",
+        "Qwen/Qwen3.8-27B-FP8",
+        "--max-batch-size",
+        &batch.to_string(),
+        "--max-seq-len",
+        "24576",
+        "--kv-cache-dtype",
+        "fp8",
+    ])
+}
+
+/// The same config fixture `predicted_residency_tests.rs` uses, so the KV
+/// floor and the derived prediction are priced off one model.
+fn qwen38_27b() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.model_type = "qwen3_5".to_string();
+    c.num_experts = 0;
+    c.num_experts_per_tok = 0;
+    c.moe_intermediate_size = 0;
+    c.hidden_size = 5120;
+    c.intermediate_size = 17408;
+    c.num_hidden_layers = 64;
+    c.num_attention_heads = 24;
+    c.num_key_value_heads = 4;
+    c.head_dim = 256;
+    c.attn_gated = true;
+    c.linear_num_key_heads = 16;
+    c.linear_key_head_dim = 128;
+    c.linear_num_value_heads = 48;
+    c.linear_value_head_dim = 128;
+    c.full_attention_interval = 4;
+    c.layer_types = (0..64)
+        .map(|i| {
+            if (i + 1) % 4 == 0 {
+                LayerType::FullAttention
+            } else {
+                LayerType::LinearAttention
+            }
+        })
+        .collect();
+    c.quantization_config = Some(QuantizationConfig {
+        quant_method: "fp8".to_string(),
+        quant_algo: String::new(),
+        format: String::new(),
+        ignore_modules: Vec::new(),
+    });
+    c
+}
+
+/// Round 6's pre-KV terms, with `fixed` recovered from the logged reserve by
+/// subtracting the depth-8 ring — which is how the reserve is composed
+/// (`fixed_reserve + slots * slot_bytes`), so this is arithmetic on the log,
+/// not a fitted parameter.
+fn round6_headroom(batch: usize, reserve_mib: usize, util: f64) -> Headroom {
+    let ring8 = 8 * batch * PER_SEQ_BLOB;
+    let fixed = reserve_mib * MIB - ring8;
+    let budget = (gib(79.2) as f64 * util) as usize;
+    let weights = gib(28.75);
+    // The predictor's own answer for this config — see
+    // `predicted_residency_tests::the_27b_prediction_matches_the_round6_residency_summary`.
+    let derived = 4_242_882_560usize;
+    let arena = 3658 * MIB;
+    let a = args(batch);
+    Headroom {
+        budget,
+        weights,
+        derived,
+        arena,
+        fixed,
+        kv_floor: kv_floor_bytes(&a, &qwen38_27b(), KvCacheDtype::Fp8),
+        headroom: budget.saturating_sub(weights + derived + arena + fixed),
+    }
+}
+
+fn fitted(batch: usize, reserve_mib: usize, util: f64) -> usize {
+    let a = args(batch);
+    let y = Yardstick::PostLoad(round6_headroom(batch, reserve_mib, util));
+    fit_ring(
+        &a,
+        8,
+        slot_bytes(&a, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        // `reserve_without_ring` is ignored in post-load mode — the ring
+        // competes with the KV floor inside the headroom, not with the rest
+        // of the reserve inside free memory.
+        usize::MAX,
+        0,
+        &y,
+        false,
+    )
+    .slots
+}
+
+/// Bytes per cached token come from the KV cache's own helper, so the floor
+/// and the real pool cannot be priced differently. 16 attention layers x
+/// (K + V) x 4 kv heads x 128... x 1 byte of FP8 = 32 KiB/token on the 27B,
+/// which makes the floor an exact power of two per batch slot.
+#[test]
+fn the_kv_floor_is_the_cache_s_own_bytes_per_token() {
+    let c = qwen38_27b();
+    assert_eq!(c.num_attention_layers(), 16);
+    assert_eq!(
+        kv_bytes_per_token(&args(16), &c, KvCacheDtype::Fp8),
+        16 * 2 * 4 * 256,
+    );
+    assert_eq!(kv_floor_tokens(), DEFAULT_KV_FLOOR_TOKENS);
+    // 16 seqs x 4096 tokens x 32 KiB = exactly 2 GiB.
+    assert_eq!(kv_floor_bytes(&args(16), &c, KvCacheDtype::Fp8), 2 << 30);
+    assert_eq!(kv_floor_bytes(&args(32), &c, KvCacheDtype::Fp8), 4 << 30);
+    assert_eq!(kv_floor_bytes(&args(64), &c, KvCacheDtype::Fp8), 8 << 30);
+    // BF16 KV is twice the bytes, so twice the floor — the floor tracks the
+    // dtype the cache will really be built with, not a constant.
+    assert_eq!(
+        kv_floor_bytes(&args(16), &c, KvCacheDtype::Bf16),
+        2 * kv_floor_bytes(&args(16), &c, KvCacheDtype::Fp8),
+    );
+}
+
+/// A shorter `--max-seq-len` than the floor caps it: reserving room for 4096
+/// tokens a sequence can never reach would be a floor on a serve that cannot
+/// use it.
+#[test]
+fn the_floor_never_exceeds_max_seq_len() {
+    let a = cli::ServeArgs::parse_from([
+        "spark",
+        "Qwen/Qwen3.8-27B-FP8",
+        "--max-batch-size",
+        "16",
+        "--max-seq-len",
+        "1024",
+    ]);
+    assert_eq!(
+        kv_floor_bytes(&a, &qwen38_27b(), KvCacheDtype::Fp8),
+        16 * 1024 * 16 * 2 * 4 * 256,
+    );
+}
+
+/// Round 6, `--max-batch-size 16`: the full depth-8 ring (18.94 GB) fits
+/// beside the KV floor inside ~29 GB of headroom, so nothing is shrunk — and
+/// the serve did boot, with 13.6 GB of real KV.
+#[test]
+fn round6_batch16_keeps_the_full_ring() {
+    let h = round6_headroom(16, 25_107, 0.90);
+    assert!(
+        h.headroom > 8 * 16 * PER_SEQ_BLOB + h.kv_floor,
+        "headroom {:.2} GB must cover ring 18.94 + floor 2.00",
+        h.headroom as f64 / GIB_F,
+    );
+    assert_eq!(fitted(16, 25_107, 0.90), 8);
+}
+
+/// Round 6, `--max-batch-size 32`: the depth-8 ring wants 37.88 GB of a ~27
+/// GB headroom, so the ladder drops to 4 — 18.94 GB — which is EXACTLY the
+/// depth the operator had to pass by hand (`--ssm-decode-ring-slots 4`) to
+/// get that boot, and which performed identically to bs=16 at C=16.
+///
+/// This is the case the first pass got wrong: it compared the reserve against
+/// 78.6 GB of pre-load free memory, kept depth 8, and the serve was refused
+/// four minutes later by the KV budget stage.
+#[test]
+fn round6_batch32_fits_the_ring_the_operator_had_to_pin_by_hand() {
+    assert_eq!(fitted(32, 46_923, 0.90), 4);
+    let a = args(32);
+    let h = round6_headroom(32, 46_923, 0.90);
+    assert!(
+        4 * slot_bytes(&a, PER_SEQ_BLOB) + h.kv_floor <= h.headroom,
+        "the chosen depth must actually fit",
+    );
+    assert!(
+        8 * slot_bytes(&a, PER_SEQ_BLOB) + h.kv_floor > h.headroom,
+        "and depth 8 must not — otherwise this test proves nothing",
+    );
+}
+
+/// `--max-batch-size 64`: both the ring and the floor scale with the batch,
+/// so the ladder has to go further down than the batch-32 case.
+#[test]
+fn batch64_falls_to_a_single_anchor() {
+    assert_eq!(fitted(64, 51_771 + (4 * 64 * PER_SEQ_BLOB) / MIB, 0.90), 1);
+}
+
+/// A tighter `--gpu-memory-utilization` shrinks the budget and therefore the
+/// ring, which is the whole point of fitting against the budget rather than
+/// against free memory: at 0.84 the same bs=32 serve drops another rung.
+#[test]
+fn a_tighter_utilization_costs_rollback_depth_not_concurrency() {
+    assert_eq!(fitted(16, 25_107, 0.84), 8);
+    assert_eq!(fitted(32, 46_923, 0.84), 2);
+    assert!(
+        fitted(32, 46_923, 0.84) < fitted(32, 46_923, 0.90),
+        "a smaller budget must never buy MORE ring",
+    );
+}
+
+/// The shrink WARN names the yardstick, quotes the formula at both depths,
+/// and still points at the flag that pins one — #915's third bullet.
+#[test]
+fn the_shrink_warning_carries_the_formula_and_the_yardstick() {
+    let a = args(32);
+    let y = Yardstick::PostLoad(round6_headroom(32, 46_923, 0.90));
+    let fit = fit_ring(
+        &a,
+        8,
+        slot_bytes(&a, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        usize::MAX,
+        0,
+        &y,
+        false,
+    );
+    let w = fit.warning.expect("a shrink must be logged, never silent");
+    assert!(
+        w.contains("ring: 4 slots x 32 seqs x 151.5 MB/seq = 18.94 GB"),
+        "{w}"
+    );
+    assert!(w.contains("(was 37.88 GB)"), "{w}");
+    assert!(w.contains("ring + KV floor"), "{w}");
+    assert!(
+        w.contains("Sized from the predicted post-load KV headroom"),
+        "{w}"
+    );
+    assert!(w.contains("--ssm-decode-ring-slots"), "{w}");
+    // And the INFO line spells out every term of the subtraction.
+    for term in [
+        "budget",
+        "weights",
+        "derived",
+        "arena",
+        "fixed reserve",
+        "headroom",
+        "ring(4)",
+        "KV floor",
+    ] {
+        assert!(
+            fit.decision.contains(term),
+            "{term} missing: {}",
+            fit.decision
+        );
+    }
+}
+
+/// An explicit `--ssm-decode-ring-slots N` pins the depth on the post-load
+/// yardstick exactly as it does on the pre-load one: the operator gets that
+/// depth or a refusal, never a silent third answer.
+#[test]
+fn an_explicit_depth_is_not_fitted_against_the_headroom_either() {
+    let a = args(32);
+    let y = Yardstick::PostLoad(round6_headroom(32, 46_923, 0.90));
+    let fit = fit_ring(
+        &a,
+        8,
+        slot_bytes(&a, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        usize::MAX,
+        0,
+        &y,
+        true,
+    );
+    assert_eq!(fit.slots, 8);
+    assert!(fit.warning.is_none());
+}
+
+/// When even depth 0 cannot clear the KV floor the fit goes to 0 and says so,
+/// rather than refusing: the headroom is an ESTIMATE, and the stage that
+/// MEASURES (the KV budget) is the only one allowed to refuse a boot over it.
+#[test]
+fn an_unmeetable_floor_shrinks_to_zero_and_defers_to_the_kv_stage() {
+    let a = args(32);
+    let mut h = round6_headroom(32, 46_923, 0.90);
+    h.headroom = h.kv_floor / 2;
+    let fit = fit_ring(
+        &a,
+        8,
+        slot_bytes(&a, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        usize::MAX,
+        0,
+        &Yardstick::PostLoad(h),
+        false,
+    );
+    assert_eq!(fit.slots, 0);
+    let w = fit.warning.expect("this must not be silent");
+    assert!(w.contains("the KV budget stage will decide"), "{w}");
+}
+
+/// A model whose post-load residency cannot be predicted keeps the first
+/// pass's behaviour — and the log says which yardstick was used and why, so
+/// "the fitter approved this" is never confused with "the fitter could not
+/// look".
+#[test]
+fn an_unpredictable_route_falls_back_to_pre_load_free_memory_and_says_so() {
+    let a = args(32);
+    let mut plain = qwen38_27b();
+    plain.quantization_config = None;
+    let y = post_load_yardstick(
+        &a,
+        &plain,
+        &PostLoadInputs {
+            total_mem: gib(79.2),
+            model_dir: std::path::Path::new("/nonexistent-checkpoint"),
+            kv_dtype: KvCacheDtype::Fp8,
+            w8a8_prefill_kernels: true,
+        },
+        gib(8.0),
+        gib(3.5),
+    );
+    // The exact reason depends on which gate declines FIRST, and one of them
+    // (`ATLAS_DENSE_FP8`) is process environment this test must not pin — the
+    // reason STRINGS are pinned in
+    // `spark_model::weight_loader::predicted_residency`'s own tests. What
+    // matters here is that an unpredictable route never reaches the post-load
+    // arm, and that it always carries a reason for the log.
+    match y {
+        Yardstick::PreLoadFree(why) => assert!(!why.is_empty(), "the fallback must say why"),
+        Yardstick::PostLoad(_) => panic!("must not predict a route it cannot see"),
+    }
+}
+
+/// A checkpoint directory that cannot be sized is also a fallback, not a
+/// zero: fitting against `budget - 0 - derived - …` would hand the ring the
+/// whole card.
+#[test]
+fn a_missing_checkpoint_is_a_fallback_not_a_zero_weight_estimate() {
+    assert_eq!(
+        checkpoint_bytes(std::path::Path::new("/nonexistent-ckpt")),
+        None
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("a-00001-of-00002.safetensors"),
+        vec![7u8; 2048],
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("a-00002-of-00002.safetensors"),
+        vec![7u8; 1024],
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("README.md"), b"not a weight").unwrap();
+    assert_eq!(checkpoint_bytes(dir.path()), Some(3072));
+}
+
+/// The index is read for its DISTINCT shards: a 1,606-tensor weight map over
+/// 66 shards must not count the shards 1,606 times.
+#[test]
+fn an_index_counts_each_shard_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("s1.safetensors"), vec![0u8; 1000]).unwrap();
+    std::fs::write(dir.path().join("s2.safetensors"), vec![0u8; 500]).unwrap();
+    std::fs::write(
+        dir.path().join("model.safetensors.index.json"),
+        br#"{"metadata":{"total_size":9999},"weight_map":{
+            "a":"s1.safetensors","b":"s1.safetensors","c":"s2.safetensors"}}"#,
+    )
+    .unwrap();
+    assert_eq!(checkpoint_bytes(dir.path()), Some(1500));
+}
+
+/// The ONLY test in this binary that touches the publication cell, so it
+/// cannot seal the depth for anyone else: `autofit` must publish what it
+/// fitted, or `TransformerModel::new` allocates 8 slots against a reserve
+/// that funded 4.
+#[test]
+fn the_fitted_depth_is_published_for_the_allocation_side() {
+    let a = args(32);
+    let y = Yardstick::PostLoad(round6_headroom(32, 46_923, 0.90));
+    assert_eq!(
+        spark_model::ssm_reserve::published_decode_ring_slots(),
+        None
+    );
+    let fit = super::super::decode_ring::autofit(
+        &a,
+        8,
+        slot_bytes(&a, PER_SEQ_BLOB),
+        PER_SEQ_BLOB,
+        usize::MAX,
+        0,
+        &y,
+    );
+    assert_eq!(fit.slots, 4);
+    assert_eq!(
+        spark_model::ssm_reserve::published_decode_ring_slots(),
+        Some(4),
+        "the reserve and the allocation must read one cell",
+    );
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/post_load_audit.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/post_load_audit.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The POST-load memory audit: does what actually loaded leave room for the
+//! reserve preflight promised?
+//!
+//! A sibling of `preflight.rs` (at the 500-line cap), same precedent as
+//! `decode_ring.rs`, `headroom.rs` and `refusal.rs`. Unchanged by the #915
+//! second pass — it is the measurement the new pre-load ESTIMATE in
+//! `headroom.rs` is trying to anticipate, which is exactly why it stays a
+//! separate, measured check rather than being folded into the estimate.
+
+use anyhow::Result;
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn post_load_memory_audit(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    weight_bytes: usize,
+    free_mem: usize,
+    inference_reserve: usize,
+    total_reserve: usize,
+    gdn_two_phase_bytes: usize,
+    max_batch_tokens_pre: usize,
+) -> Result<()> {
+    let estimated_free = free_mem.saturating_sub(weight_bytes);
+    let actual_free = gpu.free_memory().unwrap_or(estimated_free);
+    let available_free = if actual_free > 0 {
+        actual_free
+    } else {
+        estimated_free
+    };
+    if available_free < total_reserve {
+        let avail_gb = available_free as f64 / (1024.0 * 1024.0 * 1024.0);
+        let need_gb = total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
+        let hint = if args.max_batch_size > 1 {
+            format!(
+                " Reduce --max-batch-size (currently {}) or --max-seq-len (currently {}).",
+                args.max_batch_size, args.max_seq_len
+            )
+        } else {
+            format!(
+                " Reduce --max-seq-len (currently {}) or use a smaller model.",
+                args.max_seq_len
+            )
+        };
+        anyhow::bail!(
+            "Insufficient GPU memory for inference buffers. \
+             After loading {:.2} GB of weights, only {:.2} GB remains \
+             but {:.2} GB is needed for SSM state pool ({} slots × {} layers) + scratch buffers.{}",
+            weight_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+            avail_gb,
+            need_gb,
+            args.max_batch_size,
+            config.num_ssm_layers(),
+            hint,
+        );
+    }
+    if gdn_two_phase_bytes > 0 {
+        tracing::info!(
+            "GDN chunked prefill reserve: {} MB (chunk_size={}, max_seq_len={})",
+            gdn_two_phase_bytes / (1024 * 1024),
+            max_batch_tokens_pre,
+            args.max_seq_len,
+        );
+    }
+    tracing::info!(
+        "Weights: {:.2} GB, estimated free: {:.1} GB, actual free: {:.1} GB (reserve: {} MB)",
+        weight_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        estimated_free as f64 / (1024.0 * 1024.0 * 1024.0),
+        actual_free as f64 / (1024.0 * 1024.0 * 1024.0),
+        inference_reserve / (1024 * 1024),
+    );
+    Ok(())
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The pre-load reserve REFUSAL: what it suggests, and why it asked for what
+//! it asked for.
+//!
+//! A sibling of `preflight.rs` (which sits at the 500-line cap), same
+//! precedent as `per_sequence_state.rs` and `decode_ring.rs`.
+//!
+//! Refusal is now the LAST resort, not the first answer: the decode-rollback
+//! ring shrinks to fit before this runs (#915), so reaching here means the
+//! configuration does not fit even with no rollback depth at all. That makes
+//! the text load-bearing — it is the only thing an operator has to act on —
+//! which is why it carries the ring formula as well as a suggested batch.
+
+use atlas_core::config::ModelConfig;
+
+use crate::cli;
+
+use super::decode_ring;
+
+/// The terms the refusal text needs that are not derivable from `args` /
+/// `config`. Grouped so the call site stays one statement.
+pub(super) struct Refusal {
+    /// `inference_reserve + buffer_arena_bytes`.
+    pub(super) total_reserve: usize,
+    pub(super) free_mem: usize,
+    /// The terms that do NOT scale with `--max-seq-len`: SSM pools, h stage,
+    /// both snapshot regions, CUDA headroom. What is left of `free_mem` after
+    /// them is what the suggested sequence length is derived from.
+    pub(super) seq_len_independent: usize,
+    /// Ring depth the flags asked for, and the depth actually reserved for
+    /// (they differ only when an explicit depth was pinned — the auto-fit
+    /// path never reaches this refusal).
+    pub(super) ring_requested: usize,
+    pub(super) ring_slots: usize,
+    pub(super) per_seq_blob: usize,
+}
+
+/// Build the refusal error. Pure formatting over already-computed bytes.
+pub(super) fn reserve_refusal(
+    args: &cli::ServeArgs,
+    config: &ModelConfig,
+    r: Refusal,
+) -> anyhow::Error {
+    let need_gb = r.total_reserve as f64 / (1024.0 * 1024.0 * 1024.0);
+    let free_gb = r.free_mem as f64 / (1024.0 * 1024.0 * 1024.0);
+    let budget_for_seq_term = r.free_mem.saturating_sub(r.seq_len_independent) / 2;
+    let per_tok_bytes = {
+        let key_dim = config.linear_num_key_heads * config.linear_key_head_dim;
+        let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+        let nv = config.linear_num_value_heads;
+        let conv_dim = key_dim * 2 + value_dim;
+        if conv_dim > 0 && config.num_ssm_layers() > 0 {
+            (conv_dim * 2) + (nv * 2 * 4) + (value_dim * 2) + (value_dim * 2)
+        } else {
+            0
+        }
+    };
+    let suggested = budget_for_seq_term
+        .checked_div(per_tok_bytes)
+        .map(|q| q.max(2048))
+        .unwrap_or(0);
+    let hint = if suggested > 0 && suggested < args.max_seq_len {
+        format!(
+            " Try --max-seq-len {} (or lower --max-batch-size / --num-drafts).",
+            suggested
+        )
+    } else if args.max_batch_size > 1 {
+        " Reduce --max-batch-size.".to_string()
+    } else {
+        " Use a smaller model or a GPU with more memory.".to_string()
+    };
+    anyhow::anyhow!(
+        "Preflight failed: inference buffers alone need {:.2} GB but only {:.2} GB is free on the GPU \
+         (before weights load). SSM pool + GDN chunked prefill scales with --max-seq-len={} × --max-batch-size={}.{}{}",
+        need_gb,
+        free_gb,
+        args.max_seq_len,
+        args.max_batch_size,
+        hint,
+        ring_note(args, &r),
+    )
+}
+
+/// Issue #915's third bullet: an operator staring at a 45.8 GiB refusal could
+/// not see that 37.9 GiB of it was 8 rollback snapshots x batch 32. Print the
+/// arithmetic, and say why shrinking the ring did not rescue the boot.
+fn ring_note(args: &cli::ServeArgs, r: &Refusal) -> String {
+    if r.ring_requested == 0 {
+        return String::new();
+    }
+    format!(
+        " {} — {}.",
+        decode_ring::formula(r.ring_slots, args.max_batch_size, r.per_seq_blob),
+        if spark_model::ssm_reserve::published_decode_ring_slots().is_some() {
+            "an explicit --ssm-decode-ring-slots pins the depth, so it was not shrunk"
+        } else {
+            "even 0 ring slots does not fit, so shrinking it cannot rescue this boot"
+        },
+    )
+}

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/refusal.rs
@@ -34,6 +34,13 @@ pub(super) struct Refusal {
     pub(super) ring_requested: usize,
     pub(super) ring_slots: usize,
     pub(super) per_seq_blob: usize,
+    /// An explicit `--ssm-decode-ring-slots N` was published before preflight
+    /// ran. Passed IN rather than read from
+    /// `ssm_reserve::published_decode_ring_slots` here, so the refusal text
+    /// is a pure function of its inputs — the publication cell is a process
+    /// `OnceLock` that one caller (or one test) would otherwise seal for
+    /// everyone.
+    pub(super) ring_pinned: bool,
 }
 
 /// Build the refusal error. Pure formatting over already-computed bytes.
@@ -92,10 +99,14 @@ fn ring_note(args: &cli::ServeArgs, r: &Refusal) -> String {
     format!(
         " {} — {}.",
         decode_ring::formula(r.ring_slots, args.max_batch_size, r.per_seq_blob),
-        if spark_model::ssm_reserve::published_decode_ring_slots().is_some() {
+        if r.ring_pinned {
             "an explicit --ssm-decode-ring-slots pins the depth, so it was not shrunk"
         } else {
             "even 0 ring slots does not fit, so shrinking it cannot rescue this boot"
         },
     )
 }
+
+#[cfg(test)]
+#[path = "refusal_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/main_modules/serve_phases/preflight/refusal_tests.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/preflight/refusal_tests.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The refusal is the LAST resort and the only thing an operator has to act
+//! on, so its text is pinned (#915's third bullet).
+//!
+//! Numbers are the 2026-09-05 rental-H100 boot: 48 GDN layers, 151.5 MiB of
+//! SSM state per sequence, `--max-batch-size 32`, a ring that alone wants
+//! 37.88 GB. No global state is read — `ring_pinned` is an input — so these
+//! cases cannot be reordered into each other.
+
+use super::*;
+use clap::Parser as _;
+
+const PER_SEQ_BLOB: usize = 48 * ((48 * 128 * 128 * 4) + ((16 * 128 * 2 + 48 * 128) * 4 * 4));
+const GIB: usize = 1024 * 1024 * 1024;
+
+fn args() -> cli::ServeArgs {
+    cli::ServeArgs::parse_from([
+        "spark",
+        "Qwen/Qwen3.8-27B-FP8",
+        "--max-batch-size",
+        "32",
+        "--max-seq-len",
+        "24576",
+    ])
+}
+
+fn config() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.hidden_size = 5120;
+    c.linear_num_key_heads = 16;
+    c.linear_key_head_dim = 128;
+    c.linear_num_value_heads = 48;
+    c.linear_value_head_dim = 128;
+    c
+}
+
+fn refusal(ring_slots: usize, ring_pinned: bool) -> String {
+    reserve_refusal(
+        &args(),
+        &config(),
+        Refusal {
+            total_reserve: 46 * GIB,
+            free_mem: 14 * GIB,
+            seq_len_independent: 8 * GIB,
+            ring_requested: 8,
+            ring_slots,
+            per_seq_blob: PER_SEQ_BLOB,
+            ring_pinned,
+        },
+    )
+    .to_string()
+}
+
+/// An operator staring at a 46 GB refusal could not see that 37.9 GB of it
+/// was 8 rollback snapshots x batch 32. The formula must be in the text, and
+/// it must be the SAME formula the INFO line and the shrink WARN print.
+#[test]
+fn the_refusal_carries_the_ring_formula() {
+    let text = refusal(8, false);
+    assert!(
+        text.contains("ring: 8 slots x 32 seqs x 151.5 MB/seq = 37.88 GB"),
+        "{text}"
+    );
+    assert_eq!(
+        decode_ring::formula(8, 32, PER_SEQ_BLOB),
+        "ring: 8 slots x 32 seqs x 151.5 MB/seq = 37.88 GB",
+        "one formula, three readers",
+    );
+    // And the terms an operator acts on.
+    for term in ["46.00 GB", "14.00 GB", "--max-seq-len", "--max-batch-size"] {
+        assert!(text.contains(term), "{term} missing: {text}");
+    }
+}
+
+/// Reaching the refusal means one of exactly two things, and the text has to
+/// say which: the fit was disabled by an explicit depth, or shrinking would
+/// not have helped anyway.
+#[test]
+fn the_refusal_says_why_shrinking_did_not_rescue_the_boot() {
+    assert!(
+        refusal(8, false).contains("even 0 ring slots does not fit"),
+        "{}",
+        refusal(8, false),
+    );
+    assert!(
+        refusal(8, true).contains("an explicit --ssm-decode-ring-slots pins the depth"),
+        "{}",
+        refusal(8, true),
+    );
+}
+
+/// A ringless serve (`--speculative`, watchdogs off, a pure-attention model)
+/// gets no ring note at all rather than a `0 slots x … = 0.00 GB` line that
+/// invites an operator to tune a term that does not exist.
+#[test]
+fn a_ringless_serve_gets_no_ring_note() {
+    let text = reserve_refusal(
+        &args(),
+        &config(),
+        Refusal {
+            total_reserve: 46 * GIB,
+            free_mem: 14 * GIB,
+            seq_len_independent: 8 * GIB,
+            ring_requested: 0,
+            ring_slots: 0,
+            per_seq_blob: PER_SEQ_BLOB,
+            ring_pinned: false,
+        },
+    )
+    .to_string();
+    assert!(!text.contains("ring:"), "{text}");
+}

--- a/crates/spark-server/src/scheduler/rollback.rs
+++ b/crates/spark-server/src/scheduler/rollback.rs
@@ -224,9 +224,15 @@ pub fn rollback_to_boundary(
     };
 
     // A hybrid model needs the SSM state rewound too — restrict boundary
-    // selection to one with a live snapshot. `has_ssm_layers()` false
-    // (pure attention) keeps the original any-boundary search.
-    let hybrid = model.has_ssm_layers() && a.ssm_rollback_ring.is_enabled();
+    // selection to one with a live snapshot. A DISABLED ring is a DECLINE,
+    // not the pure-attention any-boundary path: depth 0 (spec on, watchdogs
+    // off, or the #915 auto-fit floor) means no snapshot exists, and rewinding
+    // tokens while the recurrent state stays conditioned on the discarded tail
+    // is silent corruption. This is the fail-open the ring's SSOT documents.
+    let hybrid = model.has_ssm_layers();
+    if hybrid && !a.ssm_rollback_ring.is_enabled() {
+        return RollbackOutcome::Fallback(RollbackFallback::NoSsmSnapshot);
+    }
     let (boundary_idx, ssm_slot) = if hybrid {
         match find_last_boundary_with_snapshot(
             &a.output_tokens,

--- a/crates/spark-server/src/scheduler/ssm_decode_ring.rs
+++ b/crates/spark-server/src/scheduler/ssm_decode_ring.rs
@@ -21,9 +21,11 @@
 //! cost bounded: at most `capacity` D2D copies are live per sequence,
 //! and the ring evicts oldest-first so a long generation never grows
 //! the set. `capacity` is the model's
-//! `decode_rollback_ring_slots()` — sized `ROLLBACK_RESTEER_CAP + 1`
-//! so every permitted rollback has a distinct snapshot plus the current
-//! boundary.
+//! `decode_rollback_ring_slots()` — 8 by default, so every permitted
+//! rollback has a distinct snapshot plus the current boundary, but as
+//! low as 0 when `--ssm-decode-ring-slots` or preflight's free-memory
+//! fit (#915) says so. A smaller ring retains fewer boundaries and so
+//! reaches fewer re-steer anchors; 0 declines every rollback.
 //!
 //! Memory cost: each slot stores `h_state + conv_state` for **all** SSM
 //! layers. Per marconi.md that is ~77 MB/slot for a 122B/36-layer model;


### PR DESCRIPTION
## Summary

The #915 auto-fit's first pass (#985) shrinks the SSM decode-rollback ring, but it sizes it against **pre-load free memory** — 78.6 GB on an 80 GB H100, before a single weight byte is resident. The quantity that actually has to accommodate the reserve is the **post-load KV headroom**, and a different stage enforces it four minutes later with no shrink path, only a refusal. So the fitter stayed silent at every batch size that mattered and the serve died anyway.

This fits against the same formula that stage enforces:

```text
budget          = total_mem x --gpu-memory-utilization
pre_kv_estimate = weights + derived + buffer_arena + fixed_reserve
headroom        = budget - pre_kv_estimate
```

and takes the largest ladder depth for which `ring_bytes + kv_floor <= headroom`.

On 1xH100 with `--max-batch-size 32` and **no `--ssm-decode-ring-slots` token in the argv at all**, the serve now boots unaided in 256 s at the depth an operator previously had to pass by hand. The same recipe one binary earlier was refused.

**Fixes #915** — see "Against #915's three asks" below; #985 closed two of them, this closes the third.

## What changed

Two commits, both `spark-server`-led:

- **`preflight/headroom.rs` (new, 378 lines)** is the yardstick. It computes the budget/pre-KV/headroom subtraction above from what preflight can already see, and `describe()` prints every term in the order the arithmetic runs, so an operator reading one INFO line can redo it.
- **Two terms were not knowable pre-load and now are.** `weights` is the checkpoint's on-disk byte count, read from the safetensors index — an upper bound on residency, because the loader prunes and never grows (round 6's 28.75 GB checkpoint settles at ~24.7 GB), so it can only ever choose a *smaller* ring. `derived` is `weight_loader::predicted_residency::predicted_derived_bytes`, which evaluates the native-FP8 dense loader's own residency plan (`fp8_residency::DenseFp8Plan`, #991) from `config.json` alone.
- **Neither estimate is allowed to be a guess.** The post-load yardstick is used **only** where the derived prediction is available, which is the same route on which the on-disk count is sound. `predicted_derived_bytes` declines explicitly — not the Qwen3.5-dense loader, `ATLAS_DENSE_FP8` unset, `--tp-size > 1`, `config.json` not declaring block-scaled FP8, `ATLAS_DENSE_FP8_KEEP_NVFP4` set, or any NVFP4 fallback lever armed — and every declining route keeps the pre-load behaviour.
- **The fit decision is logged at INFO on every boot**, with all its terms, in both branches — so "the fitter approved this" can be told from "the fitter never looked". The pre-load branch names *why* it fell back.
- **`--ssm-decode-ring-slots N` is unchanged**: it still pins the depth and is refused rather than shrunk.
- **The refusal's text is now tested, and stops reading a global.** `ring_note` read `published_decode_ring_slots()` directly — a process `OnceLock`, so one caller sealing it decided the wording for every later refusal in the same process, and made the text untestable in a shared test binary. The flag is an input on `Refusal` now, passed by the one call site that knows it. Refusal is the last resort after #985 and is the only thing an operator has to act on, so it earns a test.
- **Supporting factorings**: `weight_map::config_declared_variant` (step 1 of `detect_nvfp4_variant`, so a caller holding only `config.json` asks the same question); `qwen3_attention::W8A8_PREFILL_KERNELS` names the two kernels once for `init.rs`, `has_w8a8_prefill_kernels` and the prediction; the post-load memory audit moves to `preflight/post_load_audit.rs`, which keeps `preflight.rs` under the 500-line cap.

## Why the first pass could not work — the sweep it was measured against

From #985's own probe, on the same card:

| `--max-batch-size` | ring chosen | fired? | serve |
|---|---|---|---|
| 4 | 8 | no | boots |
| 16 | 8 (18.94 GB) | no | **refused** by the KV stage |
| 32 | 8 (37.88 GB) | no | **refused** by the KV stage |
| 64 | 8 -> 4 | yes | still refused |

The fitter's own WARN said it: `reserve 54.13 of 78.57 GB`. The KV stage measures something else entirely, and that is the number the ring has to live inside.

## Evidence

**Diagnostic single-H100 evidence, not certified campaign numbers.** 1xH100 80 GB (`atlas-testing-jawn`), `Qwen/Qwen3.8-27B-FP8`, native FP8, `--lm-head-dtype bf16`, `--gpu-memory-utilization 0.90`, `--max-seq-len 24576`, FP8 KV, 2026-09-11 (round 8, stage 2; round-6 comparands from the same box and recipe at `--max-batch-size 16`). Build at the integration tip carrying these two commits, `cargo build --locked --release`, exit 0.

### The boot, with no ring flag in the argv

`--max-batch-size 32`, and the `--ssm-decode-ring-slots auto` token was **deleted from the serve script, not re-spelled** — so what boots below is the compiled default. Confirmed in the recorded argv: there is no `--ssm-decode-ring-slots` token in it.

```text
INFO preflight: SSM decode-ring fit against the predicted post-load KV headroom:
  budget 71.26 GB (90% util) = weights 28.75 + derived 3.95 + arena 3.58 +
  fixed reserve 7.95 -> headroom 27.04 GB; ring(4) 18.94 + KV floor 4.00 = 22.94 GB

WARN preflight: SSM decode-rollback ring auto-fit — ring: 4 slots x 32 seqs x
  151.5 MB/seq = 18.94 GB (was 37.88 GB); ring + KV floor 22.94 of 27.04 GB.
  Sized from the predicted post-load KV headroom, not from --max-batch-size 32
  (#915): rollback depth yields, concurrency does not. Pass
  --ssm-decode-ring-slots N to pin a depth (and be refused rather than shrunk).

INFO preflight: Preflight reserve: inference=27531 MB, buffer_arena=3664 MB
  (pre-load free: 78.6 GB); ring: 4 slots x 32 seqs x 151.5 MB/seq = 18.94 GB

INFO factory::build: KV cache: 79.2 GB total x 90% util = 71.3 GB budget;
  33.2 GB pre-KV + 26.9 GB reserve -> 11.2 GB for KV -> 18317 blocks x
  16 tok/block = 293072 max KV tokens
```

**READY at +256 s, first try, no manual pin, no retry.** A full-log grep for `fallback|refus|No memory left|pre-load reserve|shrunk|backed off` returns only the auto-fit WARN itself and an unrelated `Remote image fetching disabled` notice — the post-load fit is the only path taken.

### It derives exactly what round 6 had to pin by hand

| line | r6 (bs32, ring `auto`, first pass) | r6 (bs32, **hand-pinned 4**) | **r8 (bs32, no flag)** |
|---|---|---|---|
| ring | 8 x 32 = 37.88 GB | 4 x 32 = 18.94 GB | **4 x 32 = 18.94 GB** |
| `Preflight inference` | 46,923 MB | 27,531 MB | **27,531 MB** |
| KV | — | 11.2 GB | **11.2 GB** |
| blocks / max KV tokens | — | 18,317 / 293,072 | **18,317 / 293,072** |
| boot | **REFUSED** (`33.2 + 45.8 = 79.0 GB` committed against a 71.3 GB budget) | OK, after a manual retry | **OK, first try, no flag** |

Every figure in the last column matches the hand-pinned column to the byte. The change turns a boot refusal plus an operator retry into an automatic, logged, one-line decision — and the WARN says why it is allowed to shrink and how to opt out.

### Prediction accuracy — the load-bearing estimate, checked against the loader's own log

The fit line's `derived 3.95` and the loader's `native FP8 dense residency: ... derived 4.24 GB` (round 6, `--max-batch-size 16`, same box and recipe) are **the same 4,242,882,560 bytes**: `predicted_residency` is exact on this route, and the two lines differ only in units — `headroom.rs` divides by 2^30 while `fp8_residency.rs` divides by 1e9, and both print the literal `GB`. 4,242,882,560 / 2^30 = 3.951; / 1e9 = 4.243.

`the_27b_prediction_matches_the_round6_residency_summary` pins the total at that exact integer and asserts the relative error against the logged 4.24 GB is **under the 5% bound** — it lands at 0.07%. The two component assertions (16 attention layers x (K twin + V twin) = 167,813,120 B; 48 GDN layers x 84,897,280 = 4,075,069,440 B) are recomputed independently in the test, so a change to `ssm_concat_bytes` cannot silently redefine what is being checked.

### Throughput — a scheduler control, and it behaves like one

Ladder at `1024x256`, C=16 only:

| cell | r8 bs32 auto | r8 bs16 control (same binary) |
|---|---|---|
| C=16 aggregate | **227.72 tok/s** | 227.68 tok/s |
| C=16 TPOT p50 | **55.66 ms** | 55.65 ms |

A 0.02% difference against a 0.11-0.24% rep spread — i.e. **no throughput claim is being made here**. Raising the cap to 32 does nothing at C=16 because C=16 cannot fill more than 16 rows. What it still costs is KV: 13.6 -> 11.2 GB, 355,280 -> 293,072 tokens, because the reserve scales with the cap whether or not the rows are used. **bs32 remains strictly worse than bs16 on this box unless offered concurrency actually exceeds 16.** What this PR changes is that the answer is now "and it costs you 2.4 GB of KV" instead of "and it will not boot".

Gates on that boot: smoke PASS (`391`, TTFT 72.54 ms), coherency `COH_EXIT=0` **4/4**, 16-way concurrent arithmetic probe **16/16**, and GPU memory moved 73,851 -> 73,879 MiB across ready + gates + ladder — flat, no leak.

### One reporting gap, named rather than left to be found

`kernel flags: ... ssm_decode_ring_slots=auto` prints the flag **as parsed, not as fitted**. It is emitted 449 ms *before* the preflight fit, so it structurally cannot carry the chosen depth; there is exactly one `ssm_decode_ring_slots` occurrence in the whole log and it says `auto`. The ring really is 4 slots — the fit line, the WARN and the `Preflight reserve` line all agree, and the resulting KV is bit-identical to the hand-pinned boot. This is a reporting gap, not a behaviour gap, but anyone grepping `kernel flags` to learn the effective ring depth on an `auto` boot will read the wrong number. Fixing it means re-emitting or deferring that line, which is a `serve_flags` change with nothing to do with the fit, so it is not in this PR.

## Against #915's three asks

| #915 asks | state |
|---|---|
| Size the ring from the post-weights free memory, and shrink instead of refusing to boot | **done here**, verified on hardware: bs32 with no flag boots at ring 4 and 11.2 GB of KV |
| Make ring depth a first-class flag with a documented memory formula | **done in #985**, verified on hardware |
| Preflight prints the formula so the operator sees why N GiB was asked for | **done in #985**; this PR adds the fit's own INFO line with every term of the subtraction |

**What remains outside the fix, stated plainly.** The post-load yardstick answers only for the native-FP8 dense route at `--tp-size 1`. Every other model keeps the pre-load free-memory yardstick — and logs, at INFO, that it did and why. That is deliberate: the alternative is predicting residency for loaders that requantise at load, where the on-disk byte count is not an upper bound on anything, and a wrong prediction there would refuse a serve that would have booted. Extending the prediction to another loader is a per-loader change with its own hardware bill. The route in #915's title and evidence is covered, which is why this is `Fixes`.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda --lib ssm_reserve` — **25 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda --lib residency` — **29 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl preflight` — **42 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl ssm_decode_ring` — **14 passed, 0 failed**
- [x] `cargo clippy -p spark-model -p spark-server -p spark-runtime --tests --features cuda,nccl` — clean, no warnings emitted
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] Tested against real hardware — 1xH100 80 GB, 2026-09-11: the no-flag bs32 boot and its gates above
- [ ] PTX gate — not applicable, **no `.cu` or `.cuh` file is touched** (confirmed against the full 38-file diff)

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates every committed `.benchmarks/` record on landing. A GB10 re-measure is owed before merge.

## Notes for reviewers

**Stacked on #985 and #991.** #985's two commits are the first two here and #991's six the next six; this PR's own content is the **last two**. Review those:

```
git diff pr/915-ssm-ring-autofit..
```

The base is `main` rather than either stack branch, so this PR does not become unreviewable if #985 or #991 is rebased — and so the diff shown by GitHub carries all eight commits. Merge #985, then #991, then this.

The dependency on #991 is real and not bookkeeping: `predicted_derived_bytes` evaluates `fp8_residency::DenseFp8Plan`, which #991 introduces, and it is the whole reason `derived` can be a computed term rather than a fudge factor. Cherry-picking #985's and #991's commits onto this branch applied with **no conflicts**; nothing was adapted. This PR's own two were cherry-picked with `-x` provenance lines and also applied clean.

The part to read closest is `headroom.rs`'s "What it refuses to estimate" section and the gate list in `predicted_derived_bytes`. The correctness of this change is entirely a question of whether those gates are tight enough — a prediction that is available when it should not be will under-size the ring on a route whose residency it cannot see, and nothing downstream would catch that. `DenseFp8Plan::resolve` being a pure function of `DenseFp8Inputs` is what lets the CPU tests pin every clause without touching the process environment.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
