### PR TITLE
spark-model: accumulate FP8 KV calibration over the requested token window before freezing (#919)

### DIFF
--- a/crates/spark-model/src/layers/fp8_calibration.rs
+++ b/crates/spark-model/src/layers/fp8_calibration.rs
@@ -2,19 +2,38 @@
 
 //! Online FP8 KV cache scale calibration.
 //!
-//! Tracks running max |K| and max |V| values during the first N tokens of
-//! inference to compute per-tensor scales: `scale = max / 448.0` (mapping the
-//! observed dynamic range to FP8 E4M3 [-448, 448]).
+//! Tracks running max |K| and max |V| during the first
+//! `--fp8-kv-calibration-tokens` tokens of inference to compute per-tensor
+//! scales: `scale = amax * headroom / 448.0` (mapping the observed dynamic
+//! range onto FP8 E4M3 `[-448, 448]`).
 //!
-//! The scale is frozen on the FIRST observation (which runs immediately before
-//! the first KV write) and is then constant for the entire lifetime of every
-//! cache entry. This is required for correctness: FP8 KV round-trips (write
-//! `fp8=bf16/scale`, read `bf16=fp8*scale`) only if the SAME scale quantizes
-//! and dequantizes an entry. Freezing after N warmup tokens (the old design)
-//! wrote early entries at a placeholder scale, then froze to a different value,
-//! silently invalidating all already-written / cached KV — a paged multi-query
-//! read spanning the freeze boundary then read history through the wrong scale
-//! and generation degenerated. See the freeze block in `observe`.
+//! # The invariant
+//!
+//! FP8 KV round-trips (write `fp8 = bf16/scale`, read `bf16 = fp8*scale`) only
+//! if the SAME scale quantizes and dequantizes an entry. Paged / multi-query
+//! attention reads a sequence's whole history in one pass with ONE
+//! `k_scale`/`v_scale`, so a scale that changes under live cache entries
+//! dequantizes them through the wrong basis (~6x error → generation garbage:
+//! loops, empty completions). That is why the 2026-07-25 hardening froze the
+//! scale on the FIRST observe.
+//!
+//! # Atlas #919
+//!
+//! Freezing on the first observe made `--fp8-kv-calibration-tokens 256` a lie.
+//! Every H100 serve log showed
+//! `FP8 KV cache with online calibration (checkpoint ships no k/v scales):
+//!  freezing per-tensor scales on the first observed tokens.`
+//! and the thing being observed was the readiness probe — so a 24k-context
+//! serve ran on scales derived from ~13 tokens.
+//!
+//! The window is now real: the amax accumulates ACROSS requests until
+//! `window_tokens` have been observed, and the batch that reaches the window
+//! freezes on the amax of everything seen, itself included. The invariant is
+//! preserved by REWRITING the entries written inside the window — the window's
+//! BF16 K/V and slot mappings are staged aside and replayed through the
+//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see
+//! [`staging`] for the full tradeoff). A readiness probe therefore counts
+//! toward the window and can never end it on its own.
 //!
 //! Thread safety: uses `parking_lot::Mutex` for interior mutability. The lock
 //! is uncontended (single inference thread) so lock overhead is negligible.
@@ -24,11 +43,19 @@ use parking_lot::Mutex;
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::kv_cache::KvCacheDtype;
 
-/// FP8 E4M3 max representable magnitude.
-const FP8_E4M3_MAX: f32 = 448.0;
+mod staging;
+mod state;
 
-/// Minimum scale to prevent division by zero or denormalized values.
-const MIN_SCALE: f32 = 1e-12;
+pub use staging::Fp8KvWriteTarget;
+use staging::{KvStaging, MAX_STAGED_TOKENS};
+use state::{CalibrationState, CalibrationStep, POST_FREEZE_OBSERVE_PERIOD};
+
+/// Scale used for the calibration window's own writes, before the freeze.
+///
+/// Covers ±896: models with large norm weights (Gemma-4 26B, Mistral) reach
+/// |K| ~600, which clips at scale 1.0. Those writes are requantized at the
+/// frozen scale when the window closes, so this only has to be SAFE, not tight.
+const PROVISIONAL_SCALE: f32 = 2.0;
 
 /// Whether this KV dtype's write path calls [`Fp8KvCalibration::observe`].
 ///
@@ -48,6 +75,10 @@ pub fn dtype_runs_online_fp8_kv_calibration(kv_dtype: KvCacheDtype) -> bool {
 /// `Some(false)` = still warming. Vacuously true when no layer calibrates.
 /// Must not use `find_map`: a BF16 boundary layer reporting `Some(false)`
 /// would shadow later FP8 layers that already froze.
+///
+/// #919 note: graphs now stay eager for the whole calibration window instead
+/// of one batch. That is the cost of calibrating on the requested token count;
+/// the window is a few hundred tokens, once per process.
 pub fn graphs_ready_after_fp8_kv_cal<I>(states: I) -> bool
 where
     I: IntoIterator<Item = Option<bool>>,
@@ -57,18 +88,10 @@ where
 
 /// Mutable calibration state protected by Mutex for Send + Sync.
 struct CalibrationInner {
-    /// Running max of |K| values observed so far.
-    k_running_max: f32,
-    /// Running max of |V| values observed so far.
-    v_running_max: f32,
-    /// Total tokens processed during calibration.
-    tokens_seen: usize,
-    /// Whether calibration is complete (scales frozen).
-    frozen: bool,
-    /// Calibrated k_scale (set once after warmup).
-    k_scale: f32,
-    /// Calibrated v_scale (set once after warmup).
-    v_scale: f32,
+    state: CalibrationState,
+    staging: KvStaging,
+    /// Set when a batch could not be staged, so the freeze log can say so.
+    unstaged_tokens: usize,
 }
 
 /// Online FP8 KV cache scale calibration tracker for one attention layer.
@@ -77,8 +100,10 @@ struct CalibrationInner {
 /// struct (required by `TransformerLayer` trait).
 pub struct Fp8KvCalibration {
     inner: Mutex<CalibrationInner>,
-    /// Headroom multiplier on the first-observe absmax (CLI `--fp8-kv-headroom`).
-    headroom: f32,
+    /// Attention-layer index, for the freeze log line.
+    attn_layer_idx: usize,
+    /// Tokens the window was asked for, before the `MAX_STAGED_TOKENS` clamp.
+    requested_tokens: usize,
     /// GPU buffer for absmax reduction output: `[1]` f32 for K, `[1]` f32 for V.
     /// Layout: `[k_absmax: f32, v_absmax: f32]` = 8 bytes.
     absmax_buf: DevicePtr,
@@ -95,21 +120,37 @@ unsafe impl Sync for Fp8KvCalibration {}
 impl Fp8KvCalibration {
     /// Create a new calibration tracker.
     ///
-    /// `_warmup_tokens`: retained for API/CLI compat but no longer gates the
-    ///   freeze — the scale is now frozen on the FIRST observe (before any KV is
-    ///   persisted), so a warmup window would only reintroduce the write/read
-    ///   scale mismatch. Any value > 0 simply enables online calibration.
-    /// `headroom`: multiplier on the first-observe absmax when freezing
+    /// `attn_layer_idx`: this layer's index, for the freeze log line.
+    /// `window_tokens`: `--fp8-kv-calibration-tokens`. The amax accumulates
+    ///   over this many observed tokens, across requests, before the scale
+    ///   freezes (#919). Clamped to `MAX_STAGED_TOKENS` so the BF16 staging
+    ///   cannot reserve gigabytes per layer; 1 reproduces the pre-#919
+    ///   freeze-on-first-observe behaviour, and 0 never gets here (the
+    ///   attention initializer does not build a calibrator at all).
+    /// `headroom`: multiplier on the accumulated amax when freezing
     ///   (`--fp8-kv-headroom`, CLI-validated ≥ 1.0; clamped here as defense in
     ///   depth because a sub-1.0 value guarantees clipping).
     /// `gpu`: GPU backend for allocating the absmax reduction buffer.
-    pub fn new(_warmup_tokens: usize, headroom: f32, gpu: &dyn GpuBackend) -> Result<Self> {
+    pub fn new(
+        attn_layer_idx: usize,
+        window_tokens: usize,
+        headroom: f32,
+        gpu: &dyn GpuBackend,
+    ) -> Result<Self> {
         let headroom = if headroom >= 1.0 {
             headroom
         } else {
             tracing::warn!("fp8-kv headroom {headroom} < 1.0 guarantees clipping; clamped to 1.0");
             1.0
         };
+        let effective = window_tokens.min(MAX_STAGED_TOKENS);
+        if effective != window_tokens && attn_layer_idx == 0 {
+            tracing::warn!(
+                "--fp8-kv-calibration-tokens {window_tokens} exceeds the {MAX_STAGED_TOKENS}-token \
+                 staging cap (the window's KV is held in BF16 so it can be requantized at the \
+                 freeze); calibrating on {effective} tokens instead."
+            );
+        }
         let absmax_kernel = gpu.kernel("reshape_and_cache", "bf16_absmax")?;
         // Allocate 8 bytes: [k_absmax: f32, v_absmax: f32]
         let absmax_buf = gpu.alloc(8)?;
@@ -119,18 +160,12 @@ impl Fp8KvCalibration {
 
         Ok(Self {
             inner: Mutex::new(CalibrationInner {
-                k_running_max: 0.0,
-                v_running_max: 0.0,
-                tokens_seen: 0,
-                frozen: false,
-                // Start with scale=2.0 (effective range ±896) during warmup.
-                // Models with large norm weights (Gemma-4 26B, Mistral) can produce
-                // K/V values up to ~600, which exceeds FP8 E4M3 range at scale=1.0 (±448).
-                // Scale=2.0 covers ±896 which is safe for all known models.
-                k_scale: 2.0,
-                v_scale: 2.0,
+                state: CalibrationState::new(effective, headroom, PROVISIONAL_SCALE),
+                staging: KvStaging::default(),
+                unstaged_tokens: 0,
             }),
-            headroom,
+            attn_layer_idx,
+            requested_tokens: window_tokens,
             absmax_buf,
             absmax_kernel,
         })
@@ -138,32 +173,33 @@ impl Fp8KvCalibration {
 
     /// Whether calibration is still in warmup phase (scales not yet frozen).
     pub fn is_calibrating(&self) -> bool {
-        let inner = self.inner.lock();
-        !inner.frozen
+        !self.inner.lock().state.frozen
     }
 
     /// Get current scales. Returns (k_scale, v_scale).
     ///
-    /// Before the first observe: the conservative construction default (2.0,
-    /// covering ±896) — never used for a persisted write, since observe() runs
-    /// before every write and freezes on its first call. After the first
-    /// observe: the frozen, data-derived scale (constant thereafter).
+    /// Inside the window: [`PROVISIONAL_SCALE`], which every read during the
+    /// window also uses — consistent, just coarse. After the freeze: the
+    /// data-derived scale the whole window was requantized to (constant
+    /// thereafter).
     pub fn scales(&self) -> (f32, f32) {
         let inner = self.inner.lock();
-        (inner.k_scale, inner.v_scale)
+        (inner.state.k_scale, inner.state.v_scale)
     }
 
-    /// Observe K/V projection outputs and update running max.
+    /// Observe K/V projection outputs and update the running max.
     ///
-    /// Launches absmax reduction kernels on the K and V buffers, then reads
-    /// the results back to CPU after a sync. Call this AFTER K/V projections
-    /// and BEFORE writing to the KV cache.
+    /// Launches absmax reductions on the K and V buffers, reads them back after
+    /// a sync, then either stages this batch (still inside the window) or
+    /// freezes and requantizes the staged window. Call this AFTER the K/V
+    /// projections and BEFORE writing to the KV cache — the caller's write then
+    /// uses [`Self::scales`], which is exactly what this call just decided.
     ///
-    /// `k_data`: device BF16 buffer of K projection output
-    /// `v_data`: device BF16 buffer of V projection output
-    /// `num_tokens`: number of tokens in the batch
-    /// `num_kv_heads`: number of KV heads
-    /// `head_dim`: dimension per head
+    /// `k_data`/`v_data`: device BF16 K/V projection outputs.
+    /// `num_tokens`/`num_kv_heads`/`head_dim`: this batch's shape.
+    /// `target`: where the caller is about to write, so the freeze can replay
+    ///   the window into the same pools.
+    #[allow(clippy::too_many_arguments)]
     pub fn observe(
         &self,
         gpu: &dyn GpuBackend,
@@ -173,264 +209,138 @@ impl Fp8KvCalibration {
         num_kv_heads: u32,
         head_dim: u32,
         stream: u64,
+        target: &Fp8KvWriteTarget,
     ) -> Result<()> {
-        // Observe during warmup (always) and periodically after (every 512 tokens)
-        // to catch distribution shifts in multi-turn conversations. Without periodic
-        // recalibration, FP8 KV scales become stale as context grows, causing recent
-        // K values to collapse into fewer E4M3 quantization buckets.
-        // Recalibrate every 128 tokens (was 512) to catch distribution shifts
-        // in multi-turn conversations where K/V statistics change frequently.
-        let should_observe = {
+        {
             let inner = self.inner.lock();
-            !inner.frozen || (inner.tokens_seen % 128 < num_tokens as usize)
-        };
-        if !should_observe {
-            return Ok(());
+            if !inner.state.should_observe(num_tokens as usize) {
+                return Ok(());
+            }
         }
 
+        let (k_max, v_max) = self.absmax(
+            gpu,
+            k_data,
+            v_data,
+            num_tokens,
+            num_kv_heads,
+            head_dim,
+            stream,
+        )?;
+
+        let mut inner = self.inner.lock();
+        match inner.state.record(k_max, v_max, num_tokens as usize) {
+            CalibrationStep::Stage => {
+                let capacity = inner.state.window_tokens;
+                let elems = (num_kv_heads * head_dim) as usize;
+                let staged = inner.staging.stage(
+                    gpu, k_data, v_data, num_tokens, elems, target, capacity, stream,
+                )?;
+                if !staged {
+                    inner.unstaged_tokens += num_tokens as usize;
+                }
+            }
+            CalibrationStep::Freeze {
+                k_scale,
+                v_scale,
+                tokens_seen,
+            } => {
+                let staged_tokens = inner.staging.used_tokens();
+                let inner = &mut *inner;
+                inner.staging.replay_and_release(
+                    gpu,
+                    target,
+                    num_kv_heads,
+                    head_dim,
+                    k_scale,
+                    v_scale,
+                    stream,
+                )?;
+                tracing::info!(
+                    "FP8 KV scales frozen after {} tokens (requested {}) on attn layer {}: \
+                     k_scale={:.6} (amax={:.3}), v_scale={:.6} (amax={:.3}), headroom={:.2}; \
+                     requantized {} staged tokens in {} batches, {} unstaged",
+                    tokens_seen,
+                    self.requested_tokens,
+                    self.attn_layer_idx,
+                    k_scale,
+                    inner.state.k_running_max,
+                    v_scale,
+                    inner.state.v_running_max,
+                    inner.state.headroom,
+                    staged_tokens,
+                    inner.state.staged_batches,
+                    inner.unstaged_tokens,
+                );
+            }
+            CalibrationStep::Frozen => {
+                if inner.state.tokens_seen % POST_FREEZE_OBSERVE_PERIOD < num_tokens as usize
+                    && ema_recal_enabled()
+                {
+                    // F5 (2026-05-26): post-freeze EMA recalibration is OPT-IN via
+                    // `ATLAS_FP8_KV_EMA_RECAL=1`, default OFF. Moving `k_scale` /
+                    // `v_scale` after the freeze makes every already-written cache
+                    // entry stale relative to the new scales — attention then reads
+                    // the whole history through a shifted quantization basis. The
+                    // forensic study of the canonical opencode probe shows
+                    // reasoning-channel collapse and drift-to-phantom-path patterns
+                    // whose timing matches deep-layer KV read through a rescaled
+                    // basis. #919's staging only covers the calibration window, so
+                    // this path is still unsafe by construction — it stays off.
+                    inner.state.ema_recalibrate(k_max, v_max);
+                    tracing::info!(
+                        "FP8 KV EMA-recalibrated after {} tokens on attn layer {}: \
+                         k_scale={:.6} (amax={:.2}), v_scale={:.6} (amax={:.2})",
+                        inner.state.tokens_seen,
+                        self.attn_layer_idx,
+                        inner.state.k_scale,
+                        inner.state.k_running_max,
+                        inner.state.v_scale,
+                        inner.state.v_running_max,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Absmax of the K and V projection outputs, read back to the host.
+    #[allow(clippy::too_many_arguments)]
+    fn absmax(
+        &self,
+        gpu: &dyn GpuBackend,
+        k_data: DevicePtr,
+        v_data: DevicePtr,
+        num_tokens: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        stream: u64,
+    ) -> Result<(f32, f32)> {
         let n_elems = num_tokens * num_kv_heads * head_dim;
-
-        // Reset absmax buffer to 0.0 before reduction (async to avoid sync/async conflict)
+        // Reset the absmax buffer to 0.0 before the reduction (async, to avoid
+        // a sync/async conflict on the stream).
         gpu.memset_async(self.absmax_buf, 0, 8, stream)?;
-
-        // Launch absmax for K
         let k_out = self.absmax_buf;
         super::ops::bf16_absmax(gpu, self.absmax_kernel, k_data, k_out, n_elems, stream)?;
-
-        // Launch absmax for V (write to offset 4 = second f32)
+        // V writes to offset 4 = the second f32.
         let v_out = self.absmax_buf.offset(4);
         super::ops::bf16_absmax(gpu, self.absmax_kernel, v_data, v_out, n_elems, stream)?;
 
-        // Sync and read back
         gpu.synchronize(stream)?;
-        let mut result_buf = [0u8; 8];
-        gpu.copy_d2h(self.absmax_buf, &mut result_buf)?;
-        let k_max =
-            f32::from_le_bytes([result_buf[0], result_buf[1], result_buf[2], result_buf[3]]);
-        let v_max =
-            f32::from_le_bytes([result_buf[4], result_buf[5], result_buf[6], result_buf[7]]);
-
-        // Update running max and check if warmup is complete
-        let mut inner = self.inner.lock();
-        inner.k_running_max = inner.k_running_max.max(k_max);
-        inner.v_running_max = inner.v_running_max.max(v_max);
-        inner.tokens_seen += num_tokens as usize;
-
-        if !inner.frozen {
-            // HARDENING (2026-07-25): freeze the scale on the FIRST observation,
-            // BEFORE any KV is persisted with it. The write path calls observe()
-            // immediately before quantizing+writing KV (write_kv_cache.rs:482-485),
-            // so the scale frozen HERE is exactly what THIS batch — and every
-            // later batch — writes with, and what every read dequantizes with.
-            //
-            // The previous design wrote the first `warmup_tokens` (256) at a
-            // placeholder scale (2.0), then froze to a data-derived value (~0.3)
-            // and never re-quantized the already-written entries. A paged /
-            // multi-query attention read (chunked prefill, or a prefix-cache
-            // resume where seq_len_start>0) covers the whole history in one pass,
-            // so once the sequence crossed the freeze boundary it dequantized the
-            // pre-freeze KV (and cached/shared prefixes) through the NEW scale —
-            // ~6x error → generation garbage (loops/empty). Freezing on the first
-            // observe guarantees ONE constant scale for every cache entry's whole
-            // lifetime — the exact invariant the EMA-recal guard below documents.
-            // `warmup_tokens` no longer gates the freeze (kept for API compat).
-            //
-            // Headroom: the first observe sees only the first prefill chunk, so
-            // size the scale to cover headroom× its observed max, covering later
-            // tokens whose magnitude grows (trades <1 bit of precision for no
-            // clipping). CLI `--fp8-kv-headroom`, threaded through ModelConfig —
-            // deliberately NOT an env var (no knobs outside the command line).
-            let headroom = self.headroom;
-            inner.k_scale = (inner.k_running_max * headroom / FP8_E4M3_MAX).max(MIN_SCALE);
-            inner.v_scale = (inner.v_running_max * headroom / FP8_E4M3_MAX).max(MIN_SCALE);
-            inner.frozen = true;
-            tracing::info!(
-                "FP8 KV scale frozen on first observe ({} tok, headroom={:.1}): k_scale={:.6} (max={:.2}), v_scale={:.6} (max={:.2}) — constant for all entries",
-                inner.tokens_seen,
-                headroom,
-                inner.k_scale,
-                inner.k_running_max,
-                inner.v_scale,
-                inner.v_running_max,
-            );
-        } else if inner.frozen
-            && inner.tokens_seen % 128 < num_tokens as usize
-            && std::env::var("ATLAS_FP8_KV_EMA_RECAL")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false)
-        {
-            // F5 (2026-05-26): Periodic EMA recalibration is now OPT-IN
-            // via `ATLAS_FP8_KV_EMA_RECAL=1`, default OFF. Rationale:
-            // changing `k_scale` / `v_scale` after `frozen=true` makes
-            // previously-written KV cache entries (quantized with the
-            // OLD scales) stale relative to the NEW scales — every
-            // attention read after a recalibration sees the historical
-            // cache through a shifted quantization basis. The comment
-            // "responds faster to multi-turn topic switches" was correct
-            // about the calibration signal but missed that retroactively
-            // rescaling the cache corrupts already-stored multi-turn
-            // context. The forensic study of the canonical opencode
-            // probe shows reasoning-channel collapse + drift-to-phantom-
-            // path patterns whose timing is consistent with deep-layer
-            // KV reading through a rescaled basis.
-            let new_k = (k_max / FP8_E4M3_MAX).max(MIN_SCALE);
-            let new_v = (v_max / FP8_E4M3_MAX).max(MIN_SCALE);
-            let k_shift = (new_k - inner.k_scale).abs() / inner.k_scale.max(MIN_SCALE);
-            let v_shift = (new_v - inner.v_scale).abs() / inner.v_scale.max(MIN_SCALE);
-            let alpha = if k_shift > 0.2 || v_shift > 0.2 {
-                0.3
-            } else {
-                0.1
-            };
-            inner.k_scale = (1.0 - alpha) * inner.k_scale + alpha * new_k;
-            inner.v_scale = (1.0 - alpha) * inner.v_scale + alpha * new_v;
-            // Reset running max for next observation window
-            inner.k_running_max = k_max;
-            inner.v_running_max = v_max;
-
-            tracing::info!(
-                "FP8 KV calibrated after {} tokens: k_scale={:.6} (max={:.2}), v_scale={:.6} (max={:.2})",
-                inner.tokens_seen,
-                inner.k_scale,
-                inner.k_running_max,
-                inner.v_scale,
-                inner.v_running_max,
-            );
-        }
-
-        Ok(())
+        let mut buf = [0u8; 8];
+        gpu.copy_d2h(self.absmax_buf, &mut buf)?;
+        Ok((
+            f32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]),
+            f32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]),
+        ))
     }
+}
+
+fn ema_recal_enabled() -> bool {
+    std::env::var("ATLAS_FP8_KV_EMA_RECAL")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
-mod tests {
-    use spark_runtime::gpu::GpuBackend;
-    use spark_runtime::gpu::mock::MockGpuBackend;
-
-    use super::Fp8KvCalibration;
-
-    fn compact_source(src: &str) -> String {
-        src.chars().filter(|c| !c.is_whitespace()).collect()
-    }
-
-    /// The write/read-scale invariant, as a fails-without-the-fix test: the
-    /// scale a batch is WRITTEN with must be the scale every later read
-    /// dequantizes with, so after the first observe the scale may never move.
-    ///
-    /// On the pre-fix design this fails: the first 10-token observe leaves the
-    /// placeholder scale (2.0) live, and the observe that crosses the
-    /// `warmup_tokens = 256` boundary re-derives it (with the mock's zeroed
-    /// absmax buffer, to `MIN_SCALE` = 1e-12) — every entry written before the
-    /// boundary is then dequantized ~6× off in production, and here the
-    /// snapshot comparison trips.
-    #[test]
-    fn scale_freezes_on_first_observe_and_stays_fixed_by_default() {
-        let gpu = MockGpuBackend::new();
-        let cal = Fp8KvCalibration::new(256, 2.0, &gpu).expect("mock construct");
-        let k = gpu.alloc(4096).expect("k buf");
-        let v = gpu.alloc(4096).expect("v buf");
-        let stream = gpu.default_stream();
-
-        // First observe: a 10-token first prefill chunk. The fix freezes HERE,
-        // before any KV has been persisted.
-        cal.observe(&gpu, k, v, 10, 8, 128, stream)
-            .expect("observe");
-        assert!(
-            !cal.is_calibrating(),
-            "scale must freeze on the first observe"
-        );
-        let frozen = cal.scales();
-
-        // Cross the old warmup boundary (256 tokens) in later observes.
-        for _ in 0..30 {
-            cal.observe(&gpu, k, v, 10, 8, 128, stream)
-                .expect("observe");
-        }
-        assert_eq!(
-            cal.scales(),
-            frozen,
-            "the frozen scale moved after later observes — pre-freeze KV would \
-             now dequantize through a different scale than it was written with"
-        );
-    }
-
-    #[test]
-    fn only_plain_fp8_kv_runs_online_calibration() {
-        use spark_runtime::kv_cache::KvCacheDtype as D;
-        assert!(super::dtype_runs_online_fp8_kv_calibration(D::Fp8));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Bf16));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Nvfp4));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Turbo8));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Fp8KTurbo4V));
-    }
-
-    #[test]
-    fn graphs_ready_vacuous_when_no_calibrator() {
-        assert!(super::graphs_ready_after_fp8_kv_cal([None, None]));
-    }
-
-    #[test]
-    fn graphs_ready_blocked_while_any_calibrator_is_warm() {
-        assert!(!super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(false),
-            Some(true)
-        ]));
-    }
-
-    #[test]
-    fn graphs_ready_when_every_calibrator_frozen() {
-        assert!(super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(true),
-            Some(true)
-        ]));
-    }
-
-    #[test]
-    fn graphs_stay_blocked_when_a_warm_layer_follows_a_frozen_layer() {
-        assert!(!super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(true),
-            Some(false),
-            None
-        ]));
-    }
-
-    #[test]
-    fn attention_init_gates_calibrator_on_tokens_and_plain_fp8() {
-        let src = compact_source(include_str!("qwen3_attention/init.rs"));
-        assert!(
-            src.contains(
-                "fp8_calibration:iffp8_calibration_tokens>0&&crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype){Some(Fp8KvCalibration::new("
-            ),
-            "the attention initializer must require enabled tokens and an observing KV dtype"
-        );
-    }
-
-    #[test]
-    fn decode_uses_shared_calibration_readiness() {
-        let src = compact_source(include_str!("../model/trait_impl/decode_a.rs"));
-        assert!(
-            src.contains(
-                "fnfp8_calibration_frozen(&self)->bool{crate::layers::fp8_calibration::graphs_ready_after_fp8_kv_cal(self.layers.iter().map(|l|l.fp8_calibration_frozen()),)}"
-            ),
-            "decode readiness must aggregate every layer through the shared policy"
-        );
-    }
-
-    #[test]
-    fn fused_verify_unsuppress_matches_decode_frozen_flag() {
-        let src = compact_source(include_str!("../model/trait_impl/verify_fused.rs"));
-        assert!(
-            src.contains(
-                "&&self.fp8_calibration_frozen(){self.suppress_graphs.store(false,std::sync::atomic::Ordering::Relaxed);"
-            ),
-            "fused verify must unsuppress graphs from the frozen-state predicate"
-        );
-        assert!(
-            !src.contains("calibration_tokens+10"),
-            "old token-count gate kept fused verify eager for ~266 tokens"
-        );
-    }
-}
+mod tests;

--- a/crates/spark-model/src/layers/fp8_calibration.rs
+++ b/crates/spark-model/src/layers/fp8_calibration.rs
@@ -31,9 +31,10 @@
 //! freezes on the amax of everything seen, itself included. The invariant is
 //! preserved by REWRITING the entries written inside the window — the window's
 //! BF16 K/V and slot mappings are staged aside and replayed through the
-//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see
-//! [`staging`] for the full tradeoff). A readiness probe therefore counts
-//! toward the window and can never end it on its own.
+//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see the
+//! private `staging` submodule of this module for the full tradeoff). A
+//! readiness probe therefore counts toward the window and can never end it on
+//! its own.
 //!
 //! Thread safety: uses `parking_lot::Mutex` for interior mutability. The lock
 //! is uncontended (single inference thread) so lock overhead is negligible.
@@ -178,10 +179,10 @@ impl Fp8KvCalibration {
 
     /// Get current scales. Returns (k_scale, v_scale).
     ///
-    /// Inside the window: [`PROVISIONAL_SCALE`], which every read during the
-    /// window also uses — consistent, just coarse. After the freeze: the
-    /// data-derived scale the whole window was requantized to (constant
-    /// thereafter).
+    /// Inside the window: `PROVISIONAL_SCALE` (private to this module), which
+    /// every read during the window also uses — consistent, just coarse. After
+    /// the freeze: the data-derived scale the whole window was requantized to
+    /// (constant thereafter).
     pub fn scales(&self) -> (f32, f32) {
         let inner = self.inner.lock();
         (inner.state.k_scale, inner.state.v_scale)

--- a/crates/spark-model/src/layers/fp8_calibration/staging.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/staging.rs
@@ -87,7 +87,7 @@ struct StagedBatch {
 }
 
 /// Device-side copies of the calibration window's BF16 K/V and slot mappings.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(super) struct KvStaging {
     k: DevicePtr,
     v: DevicePtr,
@@ -96,6 +96,20 @@ pub(super) struct KvStaging {
     elems_per_token: usize,
     used_tokens: usize,
     batches: Vec<StagedBatch>,
+}
+
+impl Default for KvStaging {
+    fn default() -> Self {
+        Self {
+            k: DevicePtr(0),
+            v: DevicePtr(0),
+            slots: DevicePtr(0),
+            capacity_tokens: 0,
+            elems_per_token: 0,
+            used_tokens: 0,
+            batches: Vec::new(),
+        }
+    }
 }
 
 impl KvStaging {

--- a/crates/spark-model/src/layers/fp8_calibration/staging.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/staging.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! BF16 staging for the FP8 KV calibration window (Atlas #919).
+//!
+//! ## Why this exists
+//!
+//! The FP8 KV round-trip is only correct if the scale that quantized a cache
+//! entry is the scale that dequantizes it: paged attention reads a sequence's
+//! whole history in one pass with ONE `k_scale`/`v_scale`. That is why the
+//! 2026-07-25 hardening froze the scale on the FIRST observe — but it is also
+//! why #919 happened, because "the first observe" is the readiness probe and a
+//! 24k serve ended up calibrated on 13 tokens.
+//!
+//! ## The fix, and its tradeoff
+//!
+//! Accumulate the amax over the requested window and, when the freeze finally
+//! fires, make the already-written entries agree with the new scale by
+//! REWRITING them. Of the three options considered (#919):
+//!
+//! * (a) hold pre-freeze tokens in BF16 — impossible without a second pool:
+//!   the FP8 pools are sized for 1 byte/element and attention must be able to
+//!   read those tokens back DURING the window.
+//! * (b) rescale the stored FP8 codes in place — needs a new dequant/requant
+//!   kernel in all five arch trees (`kernels/{hopper,b200,gb10,strix,strix-hip}`)
+//!   and loses precision twice.
+//! * (c) **chosen**: keep the original BF16 K/V of the window's batches, plus
+//!   their slot mappings, and replay them through the EXISTING
+//!   `reshape_and_cache_fp8` kernel at the frozen scale. No new kernel, and the
+//!   rewritten entries are quantized once, from the original BF16, at the final
+//!   scale — strictly better than a code-domain rescale.
+//!
+//! Replay is chronological, so "last writer wins" per slot is identical to the
+//! original write order even if a block was freed and re-allocated inside the
+//! window. The crossing batch is written by the caller AFTER the replay, at the
+//! frozen scale, so it needs no staging.
+//!
+//! Cost: `window_tokens * num_kv_heads * head_dim * 2 B * 2` device bytes per
+//! attention layer, freed at the freeze. 256 tokens x 4 KV heads x 128 dims is
+//! 512 KiB/layer. `MAX_STAGED_TOKENS` caps a pathological `--fp8-kv-calibration-
+//! tokens`.
+//!
+//! Known gap, documented rather than fixed: KV spilled to host
+//! (`--high-speed-swap`) inside the window is not replayed. The window is a few
+//! hundred tokens, long before spill pressure.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+use crate::layers::ops;
+
+/// Hard cap on staged calibration tokens, so an absurd
+/// `--fp8-kv-calibration-tokens` cannot reserve gigabytes of device memory per
+/// layer. The effective window is clamped to this in `Fp8KvCalibration::new`.
+pub(super) const MAX_STAGED_TOKENS: usize = 4096;
+
+/// Bytes per BF16 element.
+const BF16: usize = 2;
+/// Bytes per `slot_mapping` entry (int64, see `reshape_and_cache_fp8.cu`).
+const SLOT: usize = 8;
+
+/// Everything the replay needs to re-run `reshape_and_cache_fp8` for one layer.
+#[derive(Debug, Clone, Copy)]
+pub struct Fp8KvWriteTarget {
+    /// `reshape_and_cache_fp8` kernel handle (the layer's `reshape_cache_k`).
+    pub kernel: KernelHandle,
+    /// Base pointer of this layer's K pool.
+    pub k_pool: DevicePtr,
+    /// Base pointer of this layer's V pool.
+    pub v_pool: DevicePtr,
+    /// Tokens per KV block.
+    pub block_size: u32,
+    /// Pool stride in ELEMENTS (`block_size * num_kv_heads * head_dim`).
+    pub cache_stride: u64,
+    /// Source K row stride in elements, as passed to the live write.
+    pub key_stride: u32,
+    /// Source V row stride in elements, as passed to the live write.
+    pub value_stride: u32,
+    /// This batch's `slot_mapping` (int64 per token), staged alongside the
+    /// BF16 K/V so the replay lands on exactly the entries the window wrote.
+    pub slot: DevicePtr,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StagedBatch {
+    offset_tokens: usize,
+    num_tokens: u32,
+}
+
+/// Device-side copies of the calibration window's BF16 K/V and slot mappings.
+#[derive(Debug, Default)]
+pub(super) struct KvStaging {
+    k: DevicePtr,
+    v: DevicePtr,
+    slots: DevicePtr,
+    capacity_tokens: usize,
+    elems_per_token: usize,
+    used_tokens: usize,
+    batches: Vec<StagedBatch>,
+}
+
+impl KvStaging {
+    /// Tokens staged so far.
+    pub(super) fn used_tokens(&self) -> usize {
+        self.used_tokens
+    }
+
+    /// Copy one pre-freeze batch aside. Silently declines (returns `false`) if
+    /// the window no longer fits — the caller then writes the batch at the
+    /// provisional scale and the freeze simply leaves it alone, which is the
+    /// pre-#919 behaviour for that batch rather than a correctness cliff.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn stage(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        k: DevicePtr,
+        v: DevicePtr,
+        num_tokens: u32,
+        elems_per_token: usize,
+        target: &Fp8KvWriteTarget,
+        capacity_tokens: usize,
+        stream: u64,
+    ) -> Result<bool> {
+        if self.capacity_tokens == 0 {
+            self.k = gpu.alloc(capacity_tokens * elems_per_token * BF16)?;
+            self.v = gpu.alloc(capacity_tokens * elems_per_token * BF16)?;
+            self.slots = gpu.alloc(capacity_tokens * SLOT)?;
+            self.capacity_tokens = capacity_tokens;
+            self.elems_per_token = elems_per_token;
+        }
+        let n = num_tokens as usize;
+        if elems_per_token != self.elems_per_token || self.used_tokens + n > self.capacity_tokens {
+            return Ok(false);
+        }
+
+        let row = elems_per_token * BF16;
+        let dst_off = self.used_tokens * row;
+        copy_rows(
+            gpu,
+            k,
+            target.key_stride,
+            self.k.offset(dst_off),
+            row,
+            n,
+            stream,
+        )?;
+        copy_rows(
+            gpu,
+            v,
+            target.value_stride,
+            self.v.offset(dst_off),
+            row,
+            n,
+            stream,
+        )?;
+        gpu.copy_d2d_async(
+            target.slot,
+            self.slots.offset(self.used_tokens * SLOT),
+            n * SLOT,
+            stream,
+        )?;
+
+        self.batches.push(StagedBatch {
+            offset_tokens: self.used_tokens,
+            num_tokens,
+        });
+        self.used_tokens += n;
+        Ok(true)
+    }
+
+    /// Requantize every staged batch at the frozen scale, in write order, then
+    /// release the staging buffers. Returns the number of tokens rewritten.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn replay_and_release(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        target: &Fp8KvWriteTarget,
+        num_kv_heads: u32,
+        head_dim: u32,
+        k_scale: f32,
+        v_scale: f32,
+        stream: u64,
+    ) -> Result<usize> {
+        let rewritten = self.used_tokens;
+        let row = self.elems_per_token * BF16;
+        for batch in std::mem::take(&mut self.batches) {
+            let off = batch.offset_tokens;
+            ops::reshape_and_cache_fp8(
+                gpu,
+                target.kernel,
+                self.k.offset(off * row),
+                self.v.offset(off * row),
+                target.k_pool,
+                target.v_pool,
+                self.slots.offset(off * SLOT),
+                batch.num_tokens,
+                num_kv_heads,
+                head_dim,
+                target.block_size,
+                k_scale,
+                v_scale,
+                // The staging buffers are packed, whatever the live source
+                // strides were.
+                self.elems_per_token as u32,
+                self.elems_per_token as u32,
+                target.cache_stride,
+                stream,
+            )?;
+        }
+        self.release(gpu)?;
+        Ok(rewritten)
+    }
+
+    /// Free the staging buffers. Idempotent.
+    pub(super) fn release(&mut self, gpu: &dyn GpuBackend) -> Result<()> {
+        if self.capacity_tokens == 0 {
+            return Ok(());
+        }
+        gpu.free(self.k)?;
+        gpu.free(self.v)?;
+        gpu.free(self.slots)?;
+        *self = Self::default();
+        Ok(())
+    }
+}
+
+/// Copy `rows` rows of `row_bytes` from a source with `src_stride` ELEMENTS
+/// between rows into a packed destination.
+fn copy_rows(
+    gpu: &dyn GpuBackend,
+    src: DevicePtr,
+    src_stride: u32,
+    dst: DevicePtr,
+    row_bytes: usize,
+    rows: usize,
+    stream: u64,
+) -> Result<()> {
+    let src_pitch = src_stride as usize * BF16;
+    if src_pitch == row_bytes {
+        return gpu.copy_d2d_async(src, dst, row_bytes * rows, stream);
+    }
+    gpu.copy_d2d_2d_async(src, src_pitch, dst, row_bytes, row_bytes, rows, stream)
+}

--- a/crates/spark-model/src/layers/fp8_calibration/state.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/state.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pure, GPU-free state machine behind [`super::Fp8KvCalibration`].
+//!
+//! SSOT for "when does the FP8 KV scale freeze, and on what data". Split out
+//! of `fp8_calibration.rs` so the decision can be unit-tested without a GPU:
+//! the glue module owns the absmax kernel launch and the BF16 staging, this
+//! module owns nothing but arithmetic.
+//!
+//! Atlas #919: the serve log line
+//! `FP8 KV cache with online calibration (checkpoint ships no k/v scales):
+//!  freezing per-tensor scales on the first observed tokens.`
+//! meant exactly that — the freeze fired on the FIRST `observe`, so a 24k
+//! serve got its per-tensor scales from whatever the readiness probe sent
+//! (13 tokens). `--fp8-kv-calibration-tokens N` now means what it reads like:
+//! accumulate the running amax over the first N observed tokens, ACROSS
+//! requests, and freeze on the observe that reaches N.
+
+/// FP8 E4M3 max representable magnitude.
+pub(super) const FP8_E4M3_MAX: f32 = 448.0;
+
+/// Minimum scale to prevent division by zero or denormalized values.
+pub(super) const MIN_SCALE: f32 = 1e-12;
+
+/// Post-freeze re-observation period, in tokens. Only used by the opt-in EMA
+/// recalibration path (`ATLAS_FP8_KV_EMA_RECAL=1`).
+pub(super) const POST_FREEZE_OBSERVE_PERIOD: usize = 128;
+
+/// What the caller must do with the batch it is about to write.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum CalibrationStep {
+    /// Still inside the calibration window. Write this batch with the current
+    /// (provisional) scales AND stage its BF16 K/V + slot mapping, so the
+    /// freeze can rewrite those cache entries at the final scale.
+    Stage,
+    /// This batch reached the window. `k_scale`/`v_scale` are final and were
+    /// computed over every token observed so far, this batch included. The
+    /// caller replays the staged batches at these scales, then writes this
+    /// batch at them too.
+    Freeze {
+        k_scale: f32,
+        v_scale: f32,
+        tokens_seen: usize,
+    },
+    /// Already frozen — nothing to stage, nothing to replay.
+    Frozen,
+}
+
+/// Mutable calibration state. One per attention layer.
+#[derive(Debug)]
+pub(super) struct CalibrationState {
+    /// Running max of |K| over every token observed so far.
+    pub(super) k_running_max: f32,
+    /// Running max of |V| over every token observed so far.
+    pub(super) v_running_max: f32,
+    /// Total tokens observed (calibration window + post-freeze probes).
+    pub(super) tokens_seen: usize,
+    /// Whether calibration is complete (scales frozen).
+    pub(super) frozen: bool,
+    /// Live k_scale: provisional before the freeze, final after it.
+    pub(super) k_scale: f32,
+    /// Live v_scale: provisional before the freeze, final after it.
+    pub(super) v_scale: f32,
+    /// Tokens that must be observed before the freeze (`>= 1`).
+    pub(super) window_tokens: usize,
+    /// Headroom multiplier on the accumulated amax (`--fp8-kv-headroom`).
+    pub(super) headroom: f32,
+    /// Tokens actually staged for requantization (`<= window_tokens`).
+    pub(super) staged_tokens: usize,
+    /// Staged batch count, for the freeze log line.
+    pub(super) staged_batches: usize,
+}
+
+impl CalibrationState {
+    /// `window_tokens` is clamped to `>= 1`: `--fp8-kv-calibration-tokens 0`
+    /// never constructs a calibrator at all (checkpoint/static scales win), and
+    /// a 1-token window reproduces the pre-#919 freeze-on-first-observe
+    /// behaviour exactly — nothing is ever staged, so nothing is ever rewritten.
+    pub(super) fn new(window_tokens: usize, headroom: f32, provisional_scale: f32) -> Self {
+        Self {
+            k_running_max: 0.0,
+            v_running_max: 0.0,
+            tokens_seen: 0,
+            frozen: false,
+            k_scale: provisional_scale,
+            v_scale: provisional_scale,
+            window_tokens: window_tokens.max(1),
+            headroom,
+            staged_tokens: 0,
+            staged_batches: 0,
+        }
+    }
+
+    /// Whether this batch needs an absmax reduction at all.
+    ///
+    /// Every pre-freeze batch is observed (that is the whole point of the
+    /// window). After the freeze only the periodic probe runs, and only to feed
+    /// the opt-in EMA path.
+    pub(super) fn should_observe(&self, num_tokens: usize) -> bool {
+        !self.frozen || self.tokens_seen % POST_FREEZE_OBSERVE_PERIOD < num_tokens
+    }
+
+    /// Fold one observation into the window and decide what happens to the
+    /// batch it came from.
+    ///
+    /// The freeze uses the amax over EVERY token in the window, this batch
+    /// included, so a single 300-token first request freezes on all 300 rather
+    /// than on a prefix of them — and a 13-token readiness probe followed by a
+    /// 243-token request freezes on the max of both.
+    pub(super) fn record(&mut self, k_max: f32, v_max: f32, num_tokens: usize) -> CalibrationStep {
+        self.k_running_max = self.k_running_max.max(k_max);
+        self.v_running_max = self.v_running_max.max(v_max);
+        self.tokens_seen += num_tokens;
+
+        if self.frozen {
+            return CalibrationStep::Frozen;
+        }
+        if self.tokens_seen < self.window_tokens {
+            self.staged_tokens += num_tokens;
+            self.staged_batches += 1;
+            return CalibrationStep::Stage;
+        }
+
+        // `headroom >= 1.0` (CLI-validated, clamped again in the glue), so the
+        // frozen scale can never quantize the window's own amax into clipping:
+        // `k_scale * 448 == k_running_max * headroom >= k_running_max`.
+        self.k_scale = (self.k_running_max * self.headroom / FP8_E4M3_MAX).max(MIN_SCALE);
+        self.v_scale = (self.v_running_max * self.headroom / FP8_E4M3_MAX).max(MIN_SCALE);
+        self.frozen = true;
+        CalibrationStep::Freeze {
+            k_scale: self.k_scale,
+            v_scale: self.v_scale,
+            tokens_seen: self.tokens_seen,
+        }
+    }
+
+    /// Opt-in post-freeze EMA nudge (`ATLAS_FP8_KV_EMA_RECAL=1`).
+    ///
+    /// Default OFF and deliberately so: moving a frozen scale re-bases every
+    /// already-written cache entry. Kept because the flag is documented.
+    pub(super) fn ema_recalibrate(&mut self, k_max: f32, v_max: f32) {
+        let new_k = (k_max / FP8_E4M3_MAX).max(MIN_SCALE);
+        let new_v = (v_max / FP8_E4M3_MAX).max(MIN_SCALE);
+        let k_shift = (new_k - self.k_scale).abs() / self.k_scale.max(MIN_SCALE);
+        let v_shift = (new_v - self.v_scale).abs() / self.v_scale.max(MIN_SCALE);
+        let alpha = if k_shift > 0.2 || v_shift > 0.2 {
+            0.3
+        } else {
+            0.1
+        };
+        self.k_scale = (1.0 - alpha) * self.k_scale + alpha * new_k;
+        self.v_scale = (1.0 - alpha) * self.v_scale + alpha * new_v;
+        self.k_running_max = k_max;
+        self.v_running_max = v_max;
+    }
+}
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod state_tests;

--- a/crates/spark-model/src/layers/fp8_calibration/state_tests.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/state_tests.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Atlas #919 regression tests for the FP8 KV calibration state machine.
+//!
+//! Red before the fix: pre-#919 `record` froze unconditionally on its first
+//! call, so every `freeze_at_*` case below returned `Freeze` after 13 tokens
+//! with the amax of those 13 tokens only.
+
+use super::{CalibrationState, CalibrationStep, FP8_E4M3_MAX};
+
+/// `--fp8-kv-calibration-tokens 256` with the H100 readiness probe in front of
+/// the real request: the 13-token probe must COUNT but must not freeze, and the
+/// frozen scale must see the larger amax that only the second request exposed.
+#[test]
+fn readiness_probe_counts_toward_the_window_but_does_not_freeze_it() {
+    let mut st = CalibrationState::new(256, 1.0, 2.0);
+
+    // The readiness probe: 13 tokens, small activations.
+    assert_eq!(st.record(1.0, 0.5, 13), CalibrationStep::Stage);
+    assert!(
+        !st.frozen,
+        "a 13-token probe must not end a 256-token window"
+    );
+    assert_eq!(st.tokens_seen, 13);
+    assert_eq!(
+        st.k_scale, 2.0,
+        "provisional scale stays live while staging"
+    );
+
+    // The real request completes the window and carries the true dynamic range.
+    let step = st.record(8.0, 4.0, 243);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 8.0 / FP8_E4M3_MAX,
+            v_scale: 4.0 / FP8_E4M3_MAX,
+            tokens_seen: 256,
+        },
+        "the freeze must use the amax over all 256 observed tokens"
+    );
+    assert_eq!(st.staged_tokens, 13, "only the probe needed staging");
+    assert_eq!(st.staged_batches, 1);
+}
+
+/// A single request longer than the window freezes at the window, on the amax
+/// of the whole batch that crossed it — not on a 256-token prefix of it, and
+/// not on the first 13 tokens.
+#[test]
+fn a_single_oversized_first_request_freezes_on_all_of_it() {
+    let mut st = CalibrationState::new(256, 1.0, 2.0);
+    let step = st.record(6.0, 3.0, 300);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 6.0 / FP8_E4M3_MAX,
+            v_scale: 3.0 / FP8_E4M3_MAX,
+            tokens_seen: 300,
+        }
+    );
+    assert_eq!(
+        st.staged_tokens, 0,
+        "the batch that crosses the window is written at the frozen scale, \
+         so it never needs staging or a rewrite"
+    );
+}
+
+/// Many small requests still reach the window; the freeze fires on the observe
+/// that crosses it, and every earlier batch is staged for requantization.
+#[test]
+fn many_small_requests_accumulate_across_the_window() {
+    let mut st = CalibrationState::new(64, 1.0, 2.0);
+    for i in 0..7 {
+        assert_eq!(
+            st.record(1.0 + i as f32, 1.0, 9),
+            CalibrationStep::Stage,
+            "batch {i} is inside the window"
+        );
+    }
+    assert_eq!(st.tokens_seen, 63);
+    let step = st.record(2.0, 9.0, 1);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 7.0 / FP8_E4M3_MAX,
+            v_scale: 9.0 / FP8_E4M3_MAX,
+            tokens_seen: 64,
+        },
+        "K keeps the largest earlier max, V picks up the crossing batch's"
+    );
+    assert_eq!(st.staged_tokens, 63);
+    assert_eq!(st.staged_batches, 7);
+}
+
+/// A 1-token window is the pre-#919 behaviour, kept as the explicit
+/// "freeze immediately" mode: freeze on the first observe, stage nothing.
+#[test]
+fn a_one_token_window_freezes_immediately_like_before() {
+    let mut st = CalibrationState::new(1, 1.0, 2.0);
+    assert!(matches!(
+        st.record(3.0, 2.0, 13),
+        CalibrationStep::Freeze { .. }
+    ));
+    assert_eq!(st.staged_tokens, 0);
+    assert_eq!(st.staged_batches, 0);
+}
+
+/// `window_tokens` is clamped to 1, so a 0 that slipped past the CLI cannot
+/// produce a never-freezing calibrator (which would pin CUDA graphs eager for
+/// the life of the process — see `graphs_ready_after_fp8_kv_cal`).
+#[test]
+fn a_zero_window_is_clamped_and_still_freezes() {
+    let mut st = CalibrationState::new(0, 1.0, 2.0);
+    assert_eq!(st.window_tokens, 1);
+    assert!(matches!(
+        st.record(3.0, 2.0, 1),
+        CalibrationStep::Freeze { .. }
+    ));
+}
+
+/// The frozen scale must never be able to clip the very data it was calibrated
+/// on: `scale * 448 >= amax` for every observation in the window.
+#[test]
+fn the_frozen_scale_never_shrinks_below_the_pre_freeze_amax() {
+    for headroom in [1.0_f32, 1.25, 2.0] {
+        let mut st = CalibrationState::new(32, headroom, 2.0);
+        let ks = [0.5_f32, 11.0, 3.0, 7.5];
+        let vs = [9.0_f32, 1.0, 2.0, 0.25];
+        for i in 0..3 {
+            assert_eq!(st.record(ks[i], vs[i], 8), CalibrationStep::Stage);
+        }
+        let CalibrationStep::Freeze {
+            k_scale, v_scale, ..
+        } = st.record(ks[3], vs[3], 8)
+        else {
+            panic!("must freeze at the window");
+        };
+        let k_amax = ks.iter().copied().fold(0.0_f32, f32::max);
+        let v_amax = vs.iter().copied().fold(0.0_f32, f32::max);
+        assert!(
+            k_scale * FP8_E4M3_MAX >= k_amax,
+            "headroom {headroom}: k_scale {k_scale} clips the window's own amax {k_amax}"
+        );
+        assert!(
+            v_scale * FP8_E4M3_MAX >= v_amax,
+            "headroom {headroom}: v_scale {v_scale} clips the window's own amax {v_amax}"
+        );
+    }
+}
+
+/// Once frozen the scale is constant: that is the write/read invariant the
+/// whole staging + replay design exists to protect.
+#[test]
+fn later_observes_never_move_a_frozen_scale() {
+    let mut st = CalibrationState::new(16, 1.0, 2.0);
+    let CalibrationStep::Freeze {
+        k_scale, v_scale, ..
+    } = st.record(4.0, 2.0, 16)
+    else {
+        panic!("must freeze at the window");
+    };
+    for _ in 0..40 {
+        assert_eq!(st.record(400.0, 400.0, 16), CalibrationStep::Frozen);
+    }
+    assert_eq!((st.k_scale, st.v_scale), (k_scale, v_scale));
+}
+
+/// Every pre-freeze batch must be observed — a batch that skipped the absmax
+/// would also skip staging, leaving cache entries nothing can rewrite.
+#[test]
+fn every_pre_freeze_batch_is_observed() {
+    let mut st = CalibrationState::new(1024, 1.0, 2.0);
+    for _ in 0..50 {
+        assert!(st.should_observe(3));
+        st.record(1.0, 1.0, 3);
+    }
+    assert!(!st.frozen);
+}

--- a/crates/spark-model/src/layers/fp8_calibration/tests.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/tests.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! GPU-glue tests for [`super::Fp8KvCalibration`]. The freeze DECISION is
+//! tested without a GPU in `state_tests.rs`; these cover the wiring around it.
+
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+use super::{Fp8KvCalibration, Fp8KvWriteTarget};
+
+fn compact_source(src: &str) -> String {
+    src.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// Kernel-arg count of `reshape_and_cache_fp8`.
+const RESHAPE_FP8_ARGS: usize = 13;
+
+fn reshape_fp8_launches(gpu: &MockGpuBackend) -> usize {
+    gpu.launches_snapshot()
+        .iter()
+        .filter(|l| l.args.len() == RESHAPE_FP8_ARGS)
+        .count()
+}
+
+const NKV: u32 = 4;
+const HD: u32 = 32;
+
+fn target(gpu: &MockGpuBackend, slot: DevicePtr) -> Fp8KvWriteTarget {
+    Fp8KvWriteTarget {
+        kernel: gpu
+            .kernel("reshape_and_cache", "reshape_and_cache_fp8")
+            .unwrap(),
+        k_pool: gpu.alloc(1 << 16).unwrap(),
+        v_pool: gpu.alloc(1 << 16).unwrap(),
+        block_size: 16,
+        cache_stride: (16 * NKV * HD) as u64,
+        key_stride: NKV * HD,
+        value_stride: NKV * HD,
+        slot,
+    }
+}
+
+/// Atlas #919, the reported shape: a 13-token readiness probe must NOT end a
+/// 256-token calibration window. Red before the fix — the calibrator froze on
+/// the first observe, so `is_calibrating()` was already false here.
+#[test]
+fn a_readiness_probe_does_not_end_a_256_token_window() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(0, 256, 2.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(256 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    cal.observe(&gpu, k, v, 13, NKV, HD, stream, &tgt)
+        .expect("probe observe");
+    assert!(
+        cal.is_calibrating(),
+        "a 13-token probe froze a 256-token window (#919)"
+    );
+    assert_eq!(
+        cal.scales(),
+        (super::PROVISIONAL_SCALE, super::PROVISIONAL_SCALE),
+        "the window's own writes use the provisional scale"
+    );
+
+    cal.observe(&gpu, k, v, 243, NKV, HD, stream, &tgt)
+        .expect("second observe");
+    assert!(!cal.is_calibrating(), "the window must close at 256 tokens");
+}
+
+/// The freeze requantizes the staged window through `reshape_and_cache_fp8`
+/// before the caller writes the crossing batch, and frees its staging buffers.
+#[test]
+fn the_freeze_replays_the_staged_window_and_releases_its_buffers() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(3, 64, 1.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(64 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    for _ in 0..3 {
+        cal.observe(&gpu, k, v, 16, NKV, HD, stream, &tgt)
+            .expect("staged observe");
+    }
+    let before = gpu.alloc_count();
+    // The mock hands out one KernelHandle for every lookup, so the requantizing
+    // writes are told apart from the absmax reductions by arity:
+    // `reshape_and_cache_fp8` takes 13 kernel args, `bf16_absmax` takes 3.
+    let replays_before = reshape_fp8_launches(&gpu);
+
+    cal.observe(&gpu, k, v, 16, NKV, HD, stream, &tgt)
+        .expect("crossing observe");
+
+    let replays = reshape_fp8_launches(&gpu) - replays_before;
+    assert_eq!(
+        replays, 3,
+        "one requantizing write per staged batch, in write order"
+    );
+    assert!(
+        gpu.alloc_count() < before,
+        "staging buffers must be freed at the freeze"
+    );
+}
+
+/// A window of 1 is the explicit "freeze immediately" mode: nothing is staged,
+/// so the freeze replays nothing.
+#[test]
+fn a_one_token_window_stages_nothing() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(0, 1, 2.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(64 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    let before = gpu.alloc_count();
+    cal.observe(&gpu, k, v, 13, NKV, HD, stream, &tgt)
+        .expect("observe");
+    assert!(!cal.is_calibrating());
+    assert_eq!(
+        gpu.alloc_count(),
+        before,
+        "freeze-on-first-observe must not allocate staging"
+    );
+}
+
+#[test]
+fn only_plain_fp8_kv_runs_online_calibration() {
+    use spark_runtime::kv_cache::KvCacheDtype as D;
+    assert!(super::dtype_runs_online_fp8_kv_calibration(D::Fp8));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Bf16));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Nvfp4));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Turbo8));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Fp8KTurbo4V));
+}
+
+#[test]
+fn graphs_ready_vacuous_when_no_calibrator() {
+    assert!(super::graphs_ready_after_fp8_kv_cal([None, None]));
+}
+
+#[test]
+fn graphs_ready_blocked_while_any_calibrator_is_warm() {
+    assert!(!super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(false),
+        Some(true)
+    ]));
+}
+
+#[test]
+fn graphs_ready_when_every_calibrator_frozen() {
+    assert!(super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(true),
+        Some(true)
+    ]));
+}
+
+#[test]
+fn graphs_stay_blocked_when_a_warm_layer_follows_a_frozen_layer() {
+    assert!(!super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(true),
+        Some(false),
+        None
+    ]));
+}
+
+#[test]
+fn attention_init_gates_calibrator_on_tokens_and_plain_fp8() {
+    let src = compact_source(include_str!("../qwen3_attention/init.rs"));
+    assert!(
+        src.contains(
+            "fp8_calibration:iffp8_calibration_tokens>0&&crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype){Some(Fp8KvCalibration::new("
+        ),
+        "the attention initializer must require enabled tokens and an observing KV dtype"
+    );
+}
+
+#[test]
+fn decode_uses_shared_calibration_readiness() {
+    let src = compact_source(include_str!("../../model/trait_impl/decode_a.rs"));
+    assert!(
+        src.contains(
+            "fnfp8_calibration_frozen(&self)->bool{crate::layers::fp8_calibration::graphs_ready_after_fp8_kv_cal(self.layers.iter().map(|l|l.fp8_calibration_frozen()),)}"
+        ),
+        "decode readiness must aggregate every layer through the shared policy"
+    );
+}
+
+#[test]
+fn fused_verify_unsuppress_matches_decode_frozen_flag() {
+    let src = compact_source(include_str!("../../model/trait_impl/verify_fused.rs"));
+    assert!(
+        src.contains(
+            "&&self.fp8_calibration_frozen(){self.suppress_graphs.store(false,std::sync::atomic::Ordering::Relaxed);"
+        ),
+        "fused verify must unsuppress graphs from the frozen-state predicate"
+    );
+    assert!(
+        !src.contains("calibration_tokens+10"),
+        "old token-count gate kept fused verify eager for ~266 tokens"
+    );
+}

--- a/crates/spark-model/src/layers/qwen3_attention/decode/write_kv_cache.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/decode/write_kv_cache.rs
@@ -467,8 +467,34 @@ impl Qwen3AttentionLayer {
             ),
             _ => {
                 // FP8 KV cache
+                // #919: `observe` accumulates the amax over the requested
+                // `--fp8-kv-calibration-tokens` window ACROSS requests and,
+                // when the window closes, requantizes the entries the window
+                // wrote — so it needs to know where this write is going. It
+                // runs BEFORE the write below, so `effective_fp8_scales()`
+                // returns exactly the scale this batch is about to be written
+                // with (and every later read dequantizes with).
                 if !graph_capture && let Some(ref cal) = self.fp8_calibration {
-                    cal.observe(gpu, k, v, num_tokens, num_kv_heads, head_dim, stream)?;
+                    let target = crate::layers::fp8_calibration::Fp8KvWriteTarget {
+                        kernel: self.reshape_cache_k,
+                        k_pool: kv_cache.k_pool_ptr(self.attn_layer_idx),
+                        v_pool: kv_cache.v_pool_ptr(self.attn_layer_idx),
+                        block_size,
+                        cache_stride: kv_cache.cache_stride() as u64,
+                        key_stride,
+                        value_stride,
+                        slot,
+                    };
+                    cal.observe(
+                        gpu,
+                        k,
+                        v,
+                        num_tokens,
+                        num_kv_heads,
+                        head_dim,
+                        stream,
+                        &target,
+                    )?;
                 }
                 let (k_scale, v_scale) = self.effective_fp8_scales();
                 ops::reshape_and_cache_fp8(

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -663,6 +663,7 @@ impl Qwen3AttentionLayer {
                 && crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype)
             {
                 Some(Fp8KvCalibration::new(
+                    attn_layer_idx,
                     fp8_calibration_tokens,
                     config.fp8_kv_headroom,
                     gpu,

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -369,6 +369,7 @@ impl TransformerModel {
             mtp_store_gen: store_gen,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            reused_prefix_tokens: 0,
             cached_prefix_blocks: 0,
             prefix_ref_tokens: Vec::new(),
             prefix_lookup_applied: false,

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -36,6 +36,7 @@ mod prefill_a;
 mod prefill_b;
 mod prefill_c;
 mod prefill_d;
+mod prefix_reuse;
 mod sequence;
 mod speculative;
 pub(in crate::model) mod ssm_fault_in;

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -233,6 +233,14 @@ impl TransformerModel {
             }
         };
 
+        // #919: `cached_tokens` counts reused KV, not matched-then-discarded KV.
+        // The SSM-without-snapshot arm above has already zeroed `kv_write_start`.
+        seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+            prefix_match.matched_tokens,
+            kv_write_start,
+            marconi_skip,
+        );
+
         // Determine tokens to actually process
         let (proc_tokens, proc_count, seq_len_start) = if marconi_skip && kv_write_start >= n {
             // Exact match: entire prompt cached with SSM snapshot.

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -369,6 +369,14 @@ impl TransformerModel {
                 0
             };
             seq.marconi_skip_to = skip_tokens;
+            // #919: report what was REUSED, not what the lookup matched. The
+            // SSM-without-snapshot and exact-leaf-bypass arms above leave
+            // `matched > 0` with `skip_tokens == 0` — a full prefill.
+            seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+                matched,
+                skip_tokens,
+                skip,
+            );
             seq.prefix_lookup_skip = skip;
             seq.prefix_lookup_applied = true;
             Ok((skip_tokens, skip))

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -243,6 +243,12 @@ impl TransformerModel {
             (0, false)
         };
         seq.marconi_skip_to = kv_write_start;
+        // #919: `cached_tokens` counts reused KV, not matched-then-discarded KV.
+        seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+            matched,
+            kv_write_start,
+            marconi_skip,
+        );
 
         // Allocate all KV blocks upfront for the full sequence.
         let blocks_needed = (total_len - 1) / bs + 1;

--- a/crates/spark-model/src/model/trait_impl/prefix_reuse.rs
+++ b/crates/spark-model/src/model/trait_impl/prefix_reuse.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT for what `usage.prompt_tokens_details.cached_tokens` reports.
+//!
+//! Atlas #919 (part 2): a chat completion reported `cached_tokens: 48` while
+//! the server log for the same request showed a full prefill and no reuse.
+//! The field was stamped from `PrefixMatch::matched_tokens` — the LOOKUP
+//! result — at `prefix_lookup.rs` / `prefill_a.rs` / `prefill_c.rs`, before the
+//! code decided whether to actually use the match. Three paths find a match,
+//! inc_ref its blocks onto the block table, and then recompute all of its KV
+//! anyway:
+//!
+//! * a hybrid-SSM model with no usable SSM snapshot
+//!   (`"…but no SSM snapshot — recomputing all KV"`),
+//! * the exact-leaf snapshot shortcut bypass (default ON,
+//!   `ATLAS_MARCONI_EXACT=1` re-enables the shortcut),
+//! * a Marconi restore declined below `marconi_min_tokens()` or by the session
+//!   gate.
+//!
+//! 48 is 3 x the default `--block-size 16`, exactly the shape a block-aligned
+//! lookup produces. So the log was right and the usage field was wrong.
+//!
+//! `matched_tokens` itself keeps its meaning — `cached_prefix_tokens` is
+//! load-bearing for block-ref accounting (`sequence.rs` release, `cache_sequence`
+//! double-bump avoidance, `forward_layers.rs` KV write floor). The reported
+//! count is a SECOND, narrower number: the tokens whose KV this request really
+//! read out of the cache instead of recomputing.
+
+/// Prompt tokens actually served from the prefix cache.
+///
+/// `matched`: `PrefixMatch::matched_tokens` from the lookup.
+/// `kv_write_start`: the position the prefill actually starts writing KV at —
+///   0 whenever the match was found but discarded.
+/// `skip`: whether the prefill took the skip path at all.
+///
+/// Never exceeds `matched`: the SSM paths can set `kv_write_start` from a
+/// snapshot depth, and a snapshot deeper than the matched prefix still only
+/// reuses the matched prefix.
+pub(crate) fn reused_prefix_tokens(matched: usize, kv_write_start: usize, skip: bool) -> usize {
+    if !skip && kv_write_start == 0 {
+        return 0;
+    }
+    kv_write_start.min(matched)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reused_prefix_tokens;
+
+    /// The reported #919 case: a 48-token block-aligned match that the SSM arm
+    /// throws away (`kv_write_start = 0`) must report 0, not 48.
+    #[test]
+    fn a_discarded_match_reports_zero_not_the_lookup_length() {
+        assert_eq!(reused_prefix_tokens(48, 0, false), 0);
+    }
+
+    /// The exact-leaf bypass finds a FULL-prompt hit and then recomputes
+    /// everything — the worst version of the bug, `cached_tokens == prompt_tokens`
+    /// on a 100% full prefill.
+    #[test]
+    fn the_exact_leaf_bypass_reports_zero() {
+        assert_eq!(reused_prefix_tokens(4593, 0, false), 0);
+    }
+
+    /// A genuine non-SSM skip reports the whole reused prefix.
+    #[test]
+    fn a_real_skip_reports_the_reused_prefix() {
+        assert_eq!(reused_prefix_tokens(48, 48, true), 48);
+    }
+
+    /// An intermediate SSM snapshot reuses only up to the snapshot depth, even
+    /// though the lookup matched further.
+    #[test]
+    fn an_intermediate_snapshot_reports_only_what_it_skipped() {
+        assert_eq!(reused_prefix_tokens(512, 256, true), 256);
+    }
+
+    /// A snapshot deeper than the matched prefix cannot inflate the count.
+    #[test]
+    fn the_report_never_exceeds_the_matched_prefix() {
+        assert_eq!(reused_prefix_tokens(256, 512, true), 256);
+    }
+
+    /// No match at all.
+    #[test]
+    fn no_match_reports_zero() {
+        assert_eq!(reused_prefix_tokens(0, 0, false), 0);
+    }
+}

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -137,11 +137,22 @@ pub struct SequenceState {
     /// Persistent paged metadata for chunked prefill, allocated lazily on the
     /// first chunk that needs paged attention.
     pub chunked_prefill_meta: Option<ChunkedPrefillPageMetadata>,
-    /// Number of prompt tokens served by the prefix cache (block-aligned).
-    /// Set by the model layer on the chunk-0 prefix-cache lookup; read by
-    /// the scheduler to populate `usage.prompt_tokens_details.cached_tokens`.
-    /// 0 when prefix caching is disabled or the prompt had no cache match.
+    /// Number of prompt tokens MATCHED by the chunk-0 prefix-cache lookup
+    /// (block-aligned). Load-bearing for block-ref accounting: `free_sequence`
+    /// release, `cache_sequence` double-bump avoidance, and the chunked-prefill
+    /// KV write floor all key off it. NOT what gets reported to clients —
+    /// a match can be found and then discarded (see `reused_prefix_tokens`).
     pub cached_prefix_tokens: usize,
+    /// Number of prompt tokens whose KV this request actually READ from the
+    /// prefix cache instead of recomputing. Stamped after the skip decision;
+    /// read by the scheduler to populate
+    /// `usage.prompt_tokens_details.cached_tokens`.
+    ///
+    /// Atlas #919: this used to be `cached_prefix_tokens`, which reports the
+    /// lookup result — so a request that matched 48 tokens and then recomputed
+    /// all of them (no SSM snapshot / exact-leaf bypass / declined Marconi
+    /// restore) advertised `cached_tokens: 48` next to a full-prefill log line.
+    pub reused_prefix_tokens: usize,
     /// Number of `block_table` entries that came FROM the prefix cache on this
     /// sequence's lookup (`matched_blocks.len()`). The cache already holds its
     /// own "+1" KV ref on each of those blocks, and eviction returns exactly ONE
@@ -298,6 +309,7 @@ impl SequenceState {
             adapter_id: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            reused_prefix_tokens: 0,
             cached_prefix_blocks: 0,
             prefix_ref_tokens: Vec::new(),
             prefix_lookup_applied: false,

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -906,10 +906,15 @@ pub struct ServeArgs {
     pub profile: bool,
 
     /// Number of warmup tokens for online FP8 KV cache scale calibration.
-    /// During the first N tokens, tracks max |K| and max |V| values across
-    /// all attention layers. After N tokens, computes per-tensor scales as
-    /// max/448 (mapping the observed range to FP8 E4M3 [-448, 448]).
-    /// 0 = disabled (use static scales from checkpoint, or uncalibrated 1.0).
+    /// Tracks max |K| and max |V| over the first N observed tokens — ACROSS
+    /// requests, so a readiness probe counts toward the window but can never
+    /// close it on its own (#919) — then computes per-tensor scales as
+    /// amax*headroom/448 (mapping the observed range to FP8 E4M3 [-448, 448]).
+    /// The window's own KV is held in BF16 and requantized at the freeze, so
+    /// the write scale always equals the read scale; N is clamped to 4096 to
+    /// bound that staging. 1 = freeze on the first observe (the pre-#919
+    /// behaviour). 0 = disabled (use static scales from checkpoint, or
+    /// uncalibrated 1.0).
     /// Only applies when --kv-cache-dtype is fp8.
     /// Precedence (highest wins): this flag → MODEL.toml
     /// `[behavior].fp8_kv_calibration_tokens` → 0. An explicit value always
@@ -918,12 +923,11 @@ pub struct ServeArgs {
     #[arg(long)]
     pub fp8_kv_calibration_tokens: Option<usize>,
 
-    /// Headroom multiplier applied to the first-observe absmax when the online
-    /// FP8 KV scale freezes (calibration freezes on the FIRST observe so the
-    /// write scale always equals the read scale). The first observe sees only
-    /// the first prefill chunk, so the frozen scale covers headroom× its
-    /// observed max — later tokens whose magnitude grows don't clip, at a cost
-    /// of <1 bit of precision. Must be ≥ 1.0 (below 1.0 guarantees clipping;
+    /// Headroom multiplier applied to the accumulated absmax when the online
+    /// FP8 KV scale freezes. The calibration window only sees the first
+    /// `--fp8-kv-calibration-tokens` tokens, so the frozen scale covers
+    /// headroom× their max — later tokens whose magnitude grows don't clip, at
+    /// a cost of <1 bit of precision. Must be ≥ 1.0 (below 1.0 guarantees clipping;
     /// rejected at startup). Replaces `ATLAS_FP8_KV_HEADROOM`.
     #[arg(long, default_value_t = 2.0)]
     pub fp8_kv_headroom: f32,

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -234,7 +234,7 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
     if args.fp8_kv_headroom < 1.0 {
         v.push(Violation::new(
             format!("--fp8-kv-headroom {} is below 1.0.", args.fp8_kv_headroom),
-            "the frozen FP8 KV scale covers headroom× the first-observe absmax; \
+            "the frozen FP8 KV scale covers headroom× the calibration-window absmax; \
              a multiplier under 1.0 clips the very values it was measured from.",
             "use a value ≥ 1.0 (default 2.0).",
         ));

--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -250,9 +250,17 @@ pub(crate) fn resolve_kv_cache_config(
                     fp8_kv_scale_count,
                 );
             } else {
+                // #919: this used to read "freezing per-tensor scales on the
+                // first observed tokens", and meant it — the freeze fired on
+                // the first observe, i.e. on the readiness probe. The window is
+                // now accumulated across requests; each attention layer logs
+                // "FP8 KV scales frozen after N tokens (requested M)" when it
+                // closes, which is the line to grep for in a serve log.
                 tracing::info!(
                     "FP8 KV cache with online calibration (checkpoint ships no k/v scales): \
-                     freezing per-tensor scales on the first observed tokens.{}",
+                     accumulating per-tensor K/V amax over the first {} observed tokens \
+                     (across requests, readiness probe included) before freezing the scales.{}",
+                    config.fp8_kv_calibration_tokens,
                     if args.fp8_kv_calibration_tokens.is_none() {
                         " (auto-enabled from MODEL.toml)"
                     } else {

--- a/crates/spark-server/src/scheduler/cached_tokens_tests.rs
+++ b/crates/spark-server/src/scheduler/cached_tokens_tests.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Atlas #919 part 2: `usage.prompt_tokens_details.cached_tokens` accounting.
+//! Logical child of `phase_promote_prefills` via `#[path]`.
+/// Atlas #919: `usage.prompt_tokens_details.cached_tokens` must report the
+/// prompt tokens whose KV was REUSED, not the prefix-cache lookup length. The
+/// lookup length lives on `cached_prefix_tokens` and is load-bearing for block
+/// refcounting, so the report sites must read `reused_prefix_tokens` instead.
+///
+/// Red before the fix: every one of these files bound `cached_prompt_tok` from
+/// `seq.cached_prefix_tokens`, which is non-zero even when the prefill
+/// recomputed every token (no SSM snapshot / exact-leaf bypass).
+#[test]
+fn cached_tokens_is_reported_from_reused_prefix_tokens() {
+    for (name, src) in [
+        (
+            "phase_promote_prefills.rs",
+            include_str!("phase_promote_prefills.rs"),
+        ),
+        ("prefill_a_step.rs", include_str!("prefill_a_step.rs")),
+        ("prefill_b_step.rs", include_str!("prefill_b_step.rs")),
+    ] {
+        let compact: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            !compact.contains("cached_prompt_tok=p.seq.cached_prefix_tokens")
+                && !compact.contains("cached_prompt_tok=seq.cached_prefix_tokens"),
+            "{name} still reports the prefix-cache LOOKUP length as cached_tokens (#919)"
+        );
+        assert!(
+            compact.contains("cached_prompt_tok=p.seq.reused_prefix_tokens")
+                || compact.contains("cached_prompt_tok=seq.reused_prefix_tokens"),
+            "{name} must report the tokens actually reused from the prefix cache"
+        );
+    }
+}

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -93,7 +93,7 @@ pub(super) fn promote_completed_prefills(
         let use_legacy_tool_call =
             p.require_tool_call && p.grammar_state.is_none() && tool_call_start_token.is_some();
         let now = Instant::now();
-        let cached_prompt_tok = p.seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = p.seq.reused_prefix_tokens as u32;
         let immediate_finish =
             !spontaneous_think && (p.eos_tokens.contains(&first) || p.max_tokens <= 1);
 
@@ -249,3 +249,7 @@ fn build_active_seq_from_prefill(
         adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
     }
 }
+
+#[cfg(test)]
+#[path = "cached_tokens_tests.rs"]
+mod cached_tokens_tests;

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -189,7 +189,7 @@ pub fn start_chunked_prefill(
             req_require_tool_call && grammar_state.is_none() && tool_call_start_token.is_some();
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         let mut a = ActiveSeq {
             seq,
             session_hash: req_session_hash,
@@ -527,7 +527,7 @@ pub fn start_chunked_prefill(
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
 
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         if !spontaneous_think && (eos_tokens.contains(&first) || max_tokens <= 1) {
             let mut a = ActiveSeq {
                 seq,

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -160,7 +160,7 @@ pub fn prefill_request(
             req_require_tool_call && grammar_state.is_none() && tool_call_start_token.is_some();
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         let mut a = ActiveSeq {
             seq,
             session_hash: req_session_hash,
@@ -358,7 +358,7 @@ pub fn prefill_request(
     let tool_request = grammar_state.is_some() || use_legacy_tool_call;
 
     let now = Instant::now();
-    let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+    let cached_prompt_tok = seq.reused_prefix_tokens as u32;
 
     if !spontaneous_think && (eos_tokens.contains(&first) || max_tokens <= 1) {
         let mut a = ActiveSeq {


### PR DESCRIPTION
## Summary

Two accounting bugs, one per half of #919, both found by reading H100 serve logs next to the usage JSON the same server emitted.

**`--fp8-kv-calibration-tokens 256` calibrated on 13 tokens.** The online FP8 KV calibrator froze the per-tensor K/V scales on the FIRST `observe`, so the flag's token count was decoration: every serve logged `freezing per-tensor scales on the first observed tokens` and meant it — the first observe is the readiness probe, and a 24k-context serve got the numerical basis for its entire KV cache from a handful of tokens of the server's own warmup text. The amax now accumulates **across requests** until the requested count is reached, and the entries the window already wrote are made to agree with the final scale rather than left behind it.

**`usage.prompt_tokens_details.cached_tokens` reported prefix-cache hits that never happened.** The field was stamped from the lookup result, which three paths find and then discard — hence `cached_tokens: 48` next to a full-prefill log line. It now reports the tokens whose KV was actually read out of the cache.

Fixes #919.

## What was wrong

### 1. The freeze fired before the window could accumulate

`--fp8-kv-calibration-tokens N` reads like "accumulate until N tokens". It was implemented as "freeze on the first observe, whatever that is".

The freeze-on-first-observe rule was not an accident, and this PR does not remove it. Paged attention reads a sequence's whole history in one pass with ONE `k_scale`/`v_scale`, so a scale that moves under live cache entries dequantizes them through the wrong basis — the 2026-07-25 hardening froze on the first observe precisely to guarantee that the scale which quantized an entry is the scale which dequantizes it. The problem is that "the first observe" is whatever request arrives first, and on every real deployment that is the readiness probe.

Measured on 1×H100, `Qwen/Qwen3.8-27B-FP8`, native FP8, `--kv-cache-dtype fp8 --fp8-kv-calibration-tokens 256 --kv-high-precision-layers auto`: the startup line said `freezing per-tensor scales on the first observed tokens`, and the scales froze on the ~13–31-token readiness/smoke request. 256 was never reached because nothing ever waited for it.

### 2. `cached_tokens` was the lookup length, not the reuse length

`SequenceState::cached_prefix_tokens` is `PrefixMatch::matched_tokens` — the lookup result — and the three report sites (`phase_promote_prefills.rs`, `prefill_a_step.rs`, `prefill_b_step.rs`) stamped `usage.prompt_tokens_details.cached_tokens` straight from it, *before* the code decided whether to use the match. Three paths find a match, `inc_ref` its blocks onto the block table, and then recompute all of its KV anyway:

* a hybrid-SSM model with no usable SSM snapshot (`"…but no SSM snapshot — recomputing all KV"`),
* the exact-leaf snapshot shortcut bypass (default ON),
* a Marconi restore declined below `marconi_min_tokens()` or by the session gate.

The reported `48` is 3 × the default `--block-size 16`, exactly the shape a block-aligned lookup produces. The log was right; the usage field was wrong. This is worse than a cosmetic mismatch for OpenAI-compat clients and for anything that reads the field as a cache-hit signal — `atlas-plugin`'s own concurrency benchmark does exactly that.

## What the fix does

### The window accumulates; the window's own writes are requantized

`layers/fp8_calibration/state.rs` is the new SSOT for "when does the scale freeze, and on what data", and it is deliberately GPU-free so the decision is unit-testable without a device. `record()` folds each observation into a running amax, and returns one of three things: `Stage` (still inside the window), `Freeze { k_scale, v_scale, tokens_seen }` (this batch reached it), or `Frozen`. The freeze uses the amax over **every token in the window, the crossing batch included** — so a 13-token probe followed by a 243-token request freezes on the max of both.

Keeping the write-scale-equals-read-scale invariant is the whole difficulty, because entries written *during* the window were quantized at a provisional scale. Three options were considered:

* **(a) hold the window's tokens in BF16** — impossible without a second pool: the FP8 pools are sized at 1 byte/element and attention must be able to read those tokens back *during* the window.
* **(b) rescale the stored FP8 codes in place** — needs a new dequant/requant kernel in all five arch trees (`kernels/{hopper,b200,gb10,strix,strix-hip}`) and loses precision twice.
* **(c) chosen** — `layers/fp8_calibration/staging.rs` keeps the original BF16 K/V of the window's batches plus their `slot_mapping`s, and at the freeze replays them through the **existing** `reshape_and_cache_fp8` kernel at the frozen scale, in write order, before the crossing batch is written. No new kernel, and the rewritten entries are quantized **once, from the original BF16**, rather than rescaled in the FP8 code domain.

Replay is chronological, so "last writer wins" per slot is identical to the original write order even if a block was freed and re-allocated inside the window. Cost is `window_tokens × num_kv_heads × head_dim × 2 B × 2` device bytes per attention layer, freed at the freeze — 512 KiB/layer at 256 tokens × 4 KV heads × 128 dims — and `MAX_STAGED_TOKENS = 4096` clamps a pathological flag value (with a warning, once, from layer 0).

`write_kv_cache.rs` now hands `observe()` an `Fp8KvWriteTarget` describing where the batch is about to go, and still calls it strictly *before* the write, so `effective_fp8_scales()` returns exactly the scale this batch is written with.

Each attention layer logs its own freeze, which is the second half of what #919 asked for:

```
FP8 KV scales frozen after 1198 tokens (requested 256) on attn layer 2:
k_scale=0.064453 (amax=14.438), v_scale=0.038225 (amax=8.562), headroom=2.00;
requantized 30 staged tokens in 4 batches, 0 unstaged
```

The startup line stops lying too: `accumulating per-tensor K/V amax over the first {N} observed tokens (across requests, readiness probe included) before freezing the scales`.

**🪤 The window is a floor, not a target, and this is the honest caveat.** The freeze is evaluated per observation batch, so the first observation that *crosses* the requested count freezes on everything it saw. On the H100 run below, a 1,193-token prefill arrives as one observation and the window closes at **1,198 tokens against a requested 256** — a 4.7× overshoot. That is benign (more calibration data, and the 30 staged tokens are correctly replayed) but a deployment that wants a tight 256-token basis does not get one. Reads *inside* the window use a conservative provisional scale (`PROVISIONAL_SCALE = 2.0`, i.e. headroom up to |x| = 896) rather than a data-derived one; that is coarse, but it is consistent, because every read during the window uses the same value. And `--fp8-kv-calibration-tokens 1` reproduces the old freeze-on-first-observe behaviour exactly — nothing is staged, so nothing is rewritten.

### `cached_tokens` is stamped after the reuse decision

`model/trait_impl/prefix_reuse.rs` is the new SSOT: `reused_prefix_tokens(matched, kv_write_start, skip)` returns `0` when the match was found and thrown away, and `kv_write_start.min(matched)` otherwise — never more than the matched prefix, because an SSM snapshot deeper than the match still only reuses the match. The three lookup sites (`prefill_a.rs`, `prefill_b/prefix_lookup.rs`, `prefill_c.rs`) stamp `SequenceState::reused_prefix_tokens` **after** the skip decision, and the three report sites read that instead.

`cached_prefix_tokens` keeps its meaning and its value untouched: `free_sequence` release, `cache_sequence` double-bump avoidance and the chunked-prefill KV write floor all key off the lookup length, and breaking that would be a refcount bug. The reported count is a second, narrower number.

## Oracle and evidence

### FP8 KV calibration — 1×H100, diagnostic, not a GB10 record

1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8`, native FP8, serve flags `--kv-cache-dtype fp8 --fp8-kv-calibration-tokens 256 --kv-high-precision-layers auto --max-seq-len 24576 --max-batch-size 16`, 2026-09-11. **This is a single-H100 diagnostic run on rented hardware, not a GB10 perf-gate record** — see the perf-gate section.

**Before:** every serve logged `freezing per-tensor scales on the first observed tokens` and froze on the ~13–31-token readiness/smoke request.

**After**, and the freeze is checked at three checkpoints rather than one:

| checkpoint | tokens the server has seen | `FP8 KV scales frozen` lines |
|---|---|---|
| at READY (`/v1/models` answering, readiness probe done) | readiness probe only | **0** |
| after a 27-in/4-out smoke request | ~31 | **0** |
| after the first 1,193-token request | 1,198 | **12** |

**Exactly 12 lines fire, one per FP8 attention layer** — `attn layer 2` through `attn layer 13`. That is the boot's own `Selective boundary KV cache: 4/16 attention layers at bf16, rest at fp8`: the four boundary layers have no FP8 scales to calibrate, and they log nothing. Every line reports `0 unstaged`, i.e. the replay is complete and no token was written under the provisional basis and left there.

The per-layer spread is why per-tensor-per-layer calibration is worth doing at all:

| | min | max | ratio |
|---|---|---|---|
| `k_scale` | 0.064453 (layer 2, amax 14.438) | 0.102679 (layer 7, amax 23.000) | 1.59× |
| `v_scale` | 0.028460 (layer 3, amax 6.375) | 0.273438 (layer 12, amax 61.250) | **9.61×** |

V amax spans 6.4 → 61.3 across twelve layers. A single global KV scale has to cover both ends.

**Coherency gate 4/4** on the same serve (`determinism_ok`, `toolcall_ok`, `think_leak_ok`, `known_answer_ok`), 16/16 on the concurrent known-answer probe.

**The anticipated cost measures null.** Calibration keeps decode eager until every layer has frozen, so the first request could in principle pay a graphs-eager penalty. It does not: **C=1 TPOT 17.87 ms on the very first request** (the one the window closes inside) **vs 17.88 ms warm** — because on this shape the freeze lands inside the prefill, before decode starts.

**And the ladder does not move.** Twelve cells against the immediately preceding tip, all inside rep-to-rep spread:

| | previous tip | this change | delta |
|---|---|---|---|
| tok/s agg C=1 | 51.96 | **51.91** | −0.10% |
| TTFT p50 C=1 | 369.3 ms | **371.2 ms** | +0.5% |
| TPOT C=1 | 17.87 ms | **17.88 ms** | +0.06% |
| tok/s agg C=16 | 366.19 | **366.37** | +0.05% |

That is the null result this PR wants: the calibration window changes *when* the scales freeze and *what* they are computed from, and costs nothing in steady state.

### `cached_tokens` — CPU tests, no hardware needed

`model/trait_impl/prefix_reuse.rs` carries **6** unit tests over the decision function, each named for the case it pins:

* `a_discarded_match_reports_zero_not_the_lookup_length` — the literal #919 case, `reused_prefix_tokens(48, 0, false) == 0`.
* `the_exact_leaf_bypass_reports_zero` — the worst version, a full-prompt 4,593-token match recomputed end to end must report 0, not 4,593.
* `a_real_skip_reports_the_reused_prefix`, `an_intermediate_snapshot_reports_only_what_it_skipped`, `the_report_never_exceeds_the_matched_prefix`, `no_match_reports_zero` — the genuine-reuse and clamping directions, so the fix cannot be "return 0 always".

`scheduler/cached_tokens_tests.rs` pins the three report sites themselves: it reads `phase_promote_prefills.rs`, `prefill_a_step.rs` and `prefill_b_step.rs` as source and asserts none of them still binds `cached_prompt_tok` from `cached_prefix_tokens` and that each binds it from `reused_prefix_tokens`. It is a source-level assertion rather than a behavioural one because the report sites have no seam to inject a sequence through; it is **red before the fix**, which is the property that matters.

`atlas-plugin`'s `a_requested_warm_path_requires_observed_cached_tokens` is unchanged by this PR and needs no change — but it is now **testing something real**. It asserts that a requested warm path with a zero `cached_prompt_tokens` on any request is `cache_uncontrolled` and not `comparable`. Against the old server that check could be satisfied by a discarded lookup, so a benchmark could report a controlled warm cache it did not have.

### Calibration state and staging

`layers/fp8_calibration/state_tests.rs` — 8 tests on the pure state machine, including `readiness_probe_counts_toward_the_window_but_does_not_freeze_it`, `a_single_oversized_first_request_freezes_on_all_of_it` (the overshoot above, pinned as intended behaviour rather than left implicit), `many_small_requests_accumulate_across_the_window`, `a_one_token_window_freezes_immediately_like_before` (the pre-#919 escape hatch), `the_frozen_scale_never_shrinks_below_the_pre_freeze_amax` and `later_observes_never_move_a_frozen_scale`.

`layers/fp8_calibration/tests.rs` — 11 tests on the glue, including `the_freeze_replays_the_staged_window_and_releases_its_buffers`, `a_one_token_window_stages_nothing`, `only_plain_fp8_kv_runs_online_calibration`, and the four `graphs_ready_*` cases that pin CUDA-graph readiness against a mix of frozen and warm layers.

## Test plan

All on Spark 1 (GB10), CPU-only, isolated worktree, shared `CARGO_TARGET_DIR`, `ATLAS_SKIP_BUILD=1`, `CUDARC_CUDA_VERSION=13000`, against this branch fetched from the fork at `90e248cca`.

- [x] `cargo test -p spark-model --features cuda fp8_calibration` — **19 passed, 0 failed** (896 filtered out)
- [x] `cargo test -p spark-model --features cuda calib` — **19 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda kv` — **28 + 1 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda prefix_reuse` — **6 passed, 0 failed** (the six `prefix_reuse.rs` cases above)
- [x] `cargo test -p spark-runtime --lib --features cuda kv` — **56 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl kv` — **25 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl calib` — **2 passed, 0 failed**
- [x] `cargo test -p spark-server --bins --features cuda,nccl cached_tokens` — **1 passed, 0 failed** (the three-report-site source assertion)
- [x] `cargo test -p atlas-plugin concurrency` — **37 + 1 passed, 0 failed**
- [x] `cargo clippy -p spark-model -p spark-server -p spark-runtime -p atlas-plugin --tests --features cuda,nccl` — clean, no warnings emitted
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo doc --workspace --no-deps` — clean. `spark-model` carries `#![deny(warnings)]`, so `rustdoc::private_intra_doc_links` is a hard error there; see the third commit
- [x] `python3 scripts/check_kernel_shadows.py` — `kernel shadow structure: OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`

- [x] Tested against real hardware — the 1×H100 receipt above (2026-09-11). No GB10 serve was run for this PR.

**No `.cu` and no `kernels/` file is touched** — confirmed by `git diff --name-only`. The diff is 21 files, all under `crates/`.

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates the committed `.benchmarks/` records the moment it lands, and a GB10 re-measure is owed before merge. That is the required check talking.

The evidence above is a **1×H100 diagnostic**, deliberately labelled as such: it is where the bug was observed and where the fix was verified, and it is the right box for that, but it is not a GB10 record and is not offered as one. The ladder table is included to show the change is performance-neutral on the box it was measured on, not to claim a GB10 number.

## Notes for reviewers

The two halves share an issue and nothing else. They are in one PR because they are one issue and each is small; they can be read independently — part 1 is `layers/fp8_calibration*` plus `write_kv_cache.rs` and the two CLI doc/hint sites, part 2 is `prefix_reuse.rs` plus the three stamp sites and the three report sites.

`fp8_calibration.rs` was a single file and is now a module with `state.rs` (pure decision), `staging.rs` (BF16 staging and replay) and the original glue, which is why the diff shows 526 lines moving in the parent file. The split is what makes the freeze decision testable without a GPU; the 19 tests under the `fp8_calibration` filter all run on CPU.

**Post-freeze EMA recalibration stays OFF and stays unsafe.** `ATLAS_FP8_KV_EMA_RECAL=1` still exists and is still default-off. The staging introduced here covers the calibration window only, so moving a scale *after* the freeze still re-bases every already-written entry; the source says so at the call site.

**One documented gap:** KV spilled to host (`--high-speed-swap`) inside the calibration window is not replayed. The window is a few hundred tokens and closes long before spill pressure, so this is recorded in `staging.rs` rather than fixed.

The first two commits are cherry-picked with `-x` from `fix/919-fp8-kv-calibration-window`, which was cut from an integration branch. **Both applied to `main` clean, with no conflicts and no adaptation.** Four of the touched files have unrelated changes on the integration branch (`qwen3_attention/init.rs`, `cli/validate.rs`, `scheduler/prefill_{a,b}_step.rs`); none of them collide with this PR's hunks, and the `init.rs` hunk — adding `attn_layer_idx` to the `Fp8KvCalibration::new` call so each layer can name itself in its freeze line — does **not** depend on integration-only structure: `attn_layer_idx` is already a parameter of `new_with_gating` on `main`.

The **third commit is new here** and is a docs-only fix the source branch never needed: `cargo doc --workspace --no-deps` is a required check, `spark-model/src/lib.rs` carries `#![deny(warnings)]`, and the calibration module's own docs linked two private items (the `staging` submodule, and `PROVISIONAL_SCALE` from the public `scales()`). Both are now named in plain backticks with a note on where they live — the same treatment `qwen35_dense.rs` already gives `gdn_fp8_arm_selected`. Nothing outside doc comments moves.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
