### PR TITLE
spark-model: route the SSM out_proj and chunk-0 Q/K/V prefill projections through the W8A8 cuBLASLt arm (#928)

### DIFF
--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -303,3 +303,9 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "native_fp8_decode_proj_w8a8_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+# The PREFILL sibling: the SSM out_proj and cache-skip Q/K/V shapes that round 9
+# left on W8A16 (#917/#928). Selector clauses are CPU-tested next to each site.
+name = "native_fp8_prefill_proj_w8a8_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/native_fp8_prefill_proj_w8a8_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_prefill_proj_w8a8_microtest.rs
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! The PREFILL projections that round 9 left on W8A16, at Qwen3.8-27B shapes:
+//! the shipped `w8a16_gemm_pipelined` / `w8a16_gemm_t_m128` kernels against the
+//! W8A8 block-scaled cuBLASLt arm this change adds (#917/#928).
+//!
+//! WHY. nsys on 1xH100, 2026-09-11 round 9, `Qwen/Qwen3.8-27B-FP8`, recipe
+//! `ATLAS_CUBLAS_GEMM=ffn,ssm,attn` (`nsys-r9-prefill`). A 1193-token prefill
+//! is **368.263 ms** of GPU-busy union. `w8a16_gemm_pipelined` is **100.582 ms
+//! = 27.31%** over **112 launches** and `w8a16_gemm_t_m128` a further
+//! **12.012 ms** over 32. The kernels' launchers make the grid a shape decoder
+//! (`(ceil(N/32), ceil(M/128))` and `(ceil(N/128), ceil(M/128))`), and the
+//! 1193-token prompt is served as two chunks, 1168 + 25:
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 48 | 160x10 | N=5120 K=6144 M=1168 | SSM `out_proj`, chunk 0 | 54 119.7 |
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | attn `q_proj`, chunk 0 | 32 466.8 |
+//! | 48 | 160x1 | N=5120 K=6144 M=25 | SSM `out_proj`, chunk 1 | 13 995.4 |
+//! | 32 | 8x10 | N=1024 K=5120 M=1168 | attn `k_proj`+`v_proj`, chunk 0 | 12 012.2 |
+//!
+//! Those are the four shapes below. (The dense FFN is NOT among them: the same
+//! trace has gate/up/down on `nvjet…` cuBLASLt lines at every M.)
+//!
+//! It answers three questions per projection and guesses none:
+//!
+//!   1. NUMBERS. W8A8 quantizes the ACTIVATION to E4M3 per 128-wide K group,
+//!      which the W8A16 kernels do not, so the two are NOT bit-identical and no
+//!      bit gate would be honest. The gate is cosine >= 0.999 and relative RMS
+//!      <= 3e-2 against the W8A16 reference, plus: nothing outside the route's
+//!      extent (sentinel), nothing non-finite.
+//!
+//!      ⚠ THE FLOOR, so a marginal `rel_rms` is read correctly: E4M3 carries
+//!      3 stored mantissa bits, so round-to-nearest costs ~2.5% RMS relative
+//!      error per element and that error does NOT average down over a dot
+//!      product of independent terms. The EXPECTED `rel_rms` is ~2-2.6e-2 —
+//!      3e-2 is one notch of headroom over the floor, not a loose tolerance,
+//!      and cosine is the robust metric. Same floor the FFN and decode-proj
+//!      microtests state. `ATLAS_W8A8_REL_RMS_GATE` overrides it.
+//!
+//!   2. THE PHANTOM ROWS. cuBLASLt is handed `ceil16(M)` and WRITES rows
+//!      `M..ceil16(M)`. At M=1193 that is 1200, i.e. 7 rows past the real
+//!      output — the extent every capacity clause in
+//!      `qwen3_ssm/prefill_out_w8a8.rs` and
+//!      `qwen3_attention/prefill_qkv_w8a8.rs` is written against. This pins
+//!      that they land THERE and nowhere else: finite, inside the padded
+//!      extent, sentinel intact beyond it.
+//!
+//!   3. TIME. Per projection, sync'd over `REPS`: µs per launch and the
+//!      TFLOP/s it implies, for both routes.
+//!
+//! Run (H100): `cargo run --release -p spark-model --features cuda,gpu-examples
+//! --example native_fp8_prefill_proj_w8a8_microtest`. The example calls
+//! cuBLASLt directly, so `ATLAS_CUBLAS_GEMM` is not required here — the serve
+//! spelling is printed at the end for copy-paste.
+
+use anyhow::{Result, ensure};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_model::weight_map::{Fp8Weight, WeightQuantFormat};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use std::time::Instant;
+
+const H: usize = 5120; // hidden
+const VALUE_DIM: usize = 6144; // GDN out_proj contract width
+const Q_PROJ_DIM: usize = 12288; // gated [Q|gate]
+const KV_DIM: usize = 1024;
+/// Chunk 0 of the round-9 trace prompt is 1168; 1193 is the whole prompt and is
+/// deliberately NOT a multiple of 16, so the phantom rows are exercised.
+const ROWS: [usize; 2] = [64, 1193];
+const REPS: usize = 10;
+const GUARD: usize = 64;
+const SENTINEL: u8 = 0x5a;
+const COSINE_GATE: f64 = 0.999;
+const REL_RMS_GATE: f64 = 3e-2;
+
+/// Which W8A16 kernel a projection falls back to in the serve — the reference
+/// this compares and times against.
+#[derive(Clone, Copy, PartialEq)]
+enum Ref {
+    /// `w8a16_gemm_pipelined` over the row-major `[N, K]` weight.
+    Pipelined,
+    /// `w8a16_gemm_n128_m128` over the transposed `[K, N]` twin.
+    TransposedM128,
+}
+
+struct Proj {
+    name: &'static str,
+    n: usize,
+    k: usize,
+    reference: Ref,
+    weight: DevicePtr,
+    scale: DevicePtr,
+    weight_t: DevicePtr,
+    scale_t: DevicePtr,
+    act: DevicePtr,
+}
+
+impl Proj {
+    fn flops(&self, m: usize) -> f64 {
+        2.0 * m as f64 * self.n as f64 * self.k as f64
+    }
+    fn fp8w(&self) -> Fp8Weight {
+        Fp8Weight {
+            weight: self.weight,
+            row_scale: self.scale,
+            n: self.n as u32,
+            k: self.k as u32,
+            scale_format: WeightQuantFormat::Fp8BlockScaled,
+        }
+    }
+}
+
+struct Kernels {
+    pipelined: KernelHandle,
+    t_m128: KernelHandle,
+    quant: KernelHandle,
+    kmajor: KernelHandle,
+}
+
+struct Scratch {
+    act_fp8: DevicePtr,
+    act_scale: DevicePtr,
+    act_scale_kmajor: DevicePtr,
+}
+
+fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+
+fn values(bytes: &[u8]) -> Vec<f64> {
+    bytes
+        .chunks_exact(2)
+        .map(|x| bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32() as f64)
+        .collect()
+}
+
+fn metrics(observed: &[u8], baseline: &[u8], live: usize) -> (f64, f64) {
+    let a = values(&observed[GUARD..GUARD + live]);
+    let b = values(&baseline[GUARD..GUARD + live]);
+    let (mut dot, mut na, mut nb, mut se, mut ss) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+        se += (x - y) * (x - y);
+        ss += y * y;
+    }
+    let cosine = if na > 0.0 && nb > 0.0 {
+        dot / (na.sqrt() * nb.sqrt())
+    } else {
+        0.0
+    };
+    let rel_rms = if ss > 0.0 { (se / ss).sqrt() } else { 0.0 };
+    (cosine, rel_rms)
+}
+
+/// `live` bytes are what the routes are COMPARED on (rows 0..M); `written`
+/// bytes are everything the W8A8 route may TOUCH (rows 0..ceil16(M)). Beyond
+/// `written` the sentinel must survive.
+fn check(
+    observed: &[u8],
+    baseline: &[u8],
+    sentinel: &[u8],
+    live: usize,
+    written: usize,
+    gate: f64,
+) -> Result<()> {
+    ensure!(
+        observed.len() == sentinel.len() && baseline.len() == sentinel.len(),
+        "output extent mismatch"
+    );
+    for i in 0..sentinel.len() {
+        if !(GUARD..GUARD + written).contains(&i) {
+            ensure!(
+                observed[i] == sentinel[i],
+                "route wrote outside its extent at byte {i}"
+            );
+        }
+    }
+    ensure!(
+        values(&observed[GUARD..GUARD + written])
+            .iter()
+            .all(|x| x.is_finite()),
+        "nonfinite projection output (phantom rows included)"
+    );
+    let (cosine, rel_rms) = metrics(observed, baseline, live);
+    ensure!(cosine >= COSINE_GATE, "cosine {cosine:.6} < {COSINE_GATE}");
+    ensure!(rel_rms <= gate, "rel_rms {rel_rms:.4e} > {gate:.1e}");
+    Ok(())
+}
+
+/// The shipped W8A16 arm for this projection — BF16 activations straight in.
+fn run_w8a16(gpu: &dyn GpuBackend, k: &Kernels, p: &Proj, out: DevicePtr, m: usize) -> Result<()> {
+    match p.reference {
+        Ref::Pipelined => ops::w8a16_gemm_pipelined(
+            gpu,
+            k.pipelined,
+            p.act,
+            p.weight,
+            p.scale,
+            out,
+            m as u32,
+            p.n as u32,
+            p.k as u32,
+            0,
+        ),
+        Ref::TransposedM128 => ops::w8a16_gemm_n128_m128(
+            gpu, k.t_m128, p.act, p.weight_t, p.scale_t, out, m as u32, p.n as u32, p.k as u32, 0,
+        ),
+    }
+}
+
+/// The arm under test, exactly as the two new prefill sites compose it:
+/// `per_token_group_quant_fp8` once, then `cublas_fp8_proj_prequant`.
+fn run_w8a8(
+    gpu: &dyn GpuBackend,
+    k: &Kernels,
+    s: &Scratch,
+    p: &Proj,
+    out: DevicePtr,
+    m: usize,
+) -> Result<()> {
+    ops::per_token_group_quant_fp8(
+        gpu,
+        k.quant,
+        p.act,
+        s.act_fp8,
+        s.act_scale,
+        m as u32,
+        p.k as u32,
+        0,
+    )?;
+    ops::cublas_fp8_proj_prequant(
+        gpu,
+        k.kmajor,
+        s.act_fp8,
+        s.act_scale,
+        s.act_scale_kmajor,
+        &p.fp8w(),
+        out,
+        m as u32,
+        p.n as u32,
+        p.k as u32,
+        0,
+    )
+}
+
+/// `[N, K]` FP8 -> `[K, N]`, and `[N/128, K/128]` FP32 -> `[K/128, N/128]`.
+/// The serve builds these once at load (`prefill_weights.rs`); here they exist
+/// so the `k_proj`/`v_proj` timing is against the kernel the serve really runs.
+fn transpose(weight: &[u8], scale: &[u8], n: usize, k: usize) -> (Vec<u8>, Vec<u8>) {
+    let mut wt = vec![0u8; n * k];
+    for row in 0..n {
+        for col in 0..k {
+            wt[col * n + row] = weight[row * k + col];
+        }
+    }
+    let (sn, sk) = (n / 128, k / 128);
+    let mut st = vec![0u8; sn * sk * 4];
+    for row in 0..sn {
+        for col in 0..sk {
+            let src = (row * sk + col) * 4;
+            let dst = (col * sn + row) * 4;
+            st[dst..dst + 4].copy_from_slice(&scale[src..src + 4]);
+        }
+    }
+    (wt, st)
+}
+
+struct Rng(u64);
+impl Rng {
+    fn bits(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 32) as u32
+    }
+    /// FP8 E4M3 bytes, sign kept, exponents clipped off the NaN encodings.
+    fn fp8(&mut self, n: usize, depth: usize) -> Vec<u8> {
+        (0..n * depth)
+            .map(|_| {
+                let x = self.bits();
+                ((x % 127) as u8) | (((x >> 7) & 1) as u8 * 128)
+            })
+            .collect()
+    }
+    /// One FP32 scale per 128x128 weight block.
+    fn scales(&mut self, n: usize, depth: usize) -> Vec<u8> {
+        (0..(n / 128) * (depth / 128))
+            .flat_map(|_| (((self.bits() % 16 + 1) as f32) / 1024.0).to_le_bytes())
+            .collect()
+    }
+    fn acts(&mut self, elems: usize) -> Vec<u8> {
+        (0..elems)
+            .flat_map(|_| {
+                bf16::from_f32(((self.bits() % 2049) as f32 - 1024.0) / 1024.0)
+                    .to_bits()
+                    .to_le_bytes()
+            })
+            .collect()
+    }
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let k = Kernels {
+        pipelined: gpu.kernel("w8a16_gemm_pipelined", "w8a16_gemm_pipelined")?,
+        t_m128: gpu.kernel("w8a16_gemm_t_m128", "w8a16_gemm_t_m128")?,
+        quant: gpu.kernel("per_token_group_quant_fp8", "per_token_group_quant_fp8")?,
+        kmajor: gpu.kernel("fp8_scale_transpose", "fp8_act_scale_to_kmajor")?,
+    };
+    let gate: f64 = std::env::var("ATLAS_W8A8_REL_RMS_GATE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(REL_RMS_GATE);
+    let max_m = ops::cublas_fp8_m_pad(*ROWS.iter().max().unwrap() as u32) as usize;
+    println!(
+        "gates: cosine >= {COSINE_GATE}, rel_rms <= {gate:.1e} \
+         (E4M3 activation-quant floor is ~2-2.6e-2; see the module header)\n\
+         rows {ROWS:?}, cuBLASLt M pad reaches {max_m}"
+    );
+
+    let mut rng = Rng(0x0928_2026_5A5A_0001);
+    let act_h = upload(&gpu, &rng.acts(max_m * H))?;
+    let act_v = upload(&gpu, &rng.acts(max_m * VALUE_DIM))?;
+
+    let mut mk = |name, n: usize, kk: usize, reference, act| -> Result<Proj> {
+        let w = rng.fp8(n, kk);
+        let s = rng.scales(n, kk);
+        let (wt, st) = if reference == Ref::TransposedM128 {
+            transpose(&w, &s, n, kk)
+        } else {
+            (vec![0u8; 1], vec![0u8; 4])
+        };
+        Ok(Proj {
+            name,
+            n,
+            k: kk,
+            reference,
+            weight: upload(&gpu, &w)?,
+            scale: upload(&gpu, &s)?,
+            weight_t: upload(&gpu, &wt)?,
+            scale_t: upload(&gpu, &st)?,
+            act,
+        })
+    };
+    let projections = [
+        mk("ssm out_proj", H, VALUE_DIM, Ref::Pipelined, act_v)?,
+        mk("attn q_proj", Q_PROJ_DIM, H, Ref::Pipelined, act_h)?,
+        mk("attn k_proj", KV_DIM, H, Ref::TransposedM128, act_h)?,
+        mk("attn v_proj", KV_DIM, H, Ref::TransposedM128, act_h)?,
+    ];
+
+    let kg = H.max(VALUE_DIM) / 128;
+    let scratch = Scratch {
+        act_fp8: gpu.alloc(max_m * H.max(VALUE_DIM))?,
+        act_scale: gpu.alloc(max_m * kg * 4)?,
+        act_scale_kmajor: gpu.alloc(max_m * kg * 4)?,
+    };
+
+    let mut failures = 0usize;
+    let mut controls_done = false;
+    for m in ROWS {
+        let m_pad = ops::cublas_fp8_m_pad(m as u32) as usize;
+        println!("\n=== M = {m} (cuBLASLt pad = {m_pad}) ===");
+        for p in &projections {
+            let written = m_pad * p.n * 2;
+            let live = m * p.n * 2;
+            let sentinel = vec![SENTINEL; written + 2 * GUARD];
+            let base = upload(&gpu, &sentinel)?;
+            let out = base.offset(GUARD);
+
+            let capture = |w8a8: bool| -> Result<Vec<u8>> {
+                gpu.copy_h2d(&sentinel, base)?;
+                if w8a8 {
+                    run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                } else {
+                    run_w8a16(&gpu, &k, p, out, m)?;
+                }
+                gpu.synchronize(0)?;
+                let mut host = vec![0_u8; sentinel.len()];
+                gpu.copy_d2h(base, &mut host)?;
+                Ok(host)
+            };
+            let reference = capture(false)?;
+            let observed = capture(true)?;
+
+            if !controls_done {
+                // A green run has to be able to go red: three corruptions of
+                // the OBSERVED buffer, all refused by the real oracle.
+                for control in ["guard", "nonfinite", "value"] {
+                    let mut bad = observed.clone();
+                    match control {
+                        "guard" => bad[0] ^= 1,
+                        "nonfinite" => {
+                            bad[GUARD..GUARD + 2].copy_from_slice(&0x7fc0_u16.to_le_bytes())
+                        }
+                        _ => {
+                            for x in bad[GUARD..GUARD + p.n * 2].chunks_exact_mut(2) {
+                                x.copy_from_slice(&bf16::from_f32(1.0e3).to_bits().to_le_bytes());
+                            }
+                        }
+                    }
+                    let err = check(&bad, &reference, &sentinel, live, written, gate)
+                        .expect_err("known-bad output was admitted by the real oracle");
+                    println!("KNOWN_BAD {control}: refused: {err}");
+                }
+                controls_done = true;
+            }
+
+            let (cosine, rel_rms) = metrics(&observed, &reference, live);
+            let phantom = if m_pad > m {
+                let vals = values(&observed[GUARD + live..GUARD + written]);
+                format!(
+                    " phantom_rows={m}..{m_pad} finite={} max_abs={:.3}",
+                    vals.iter().all(|x| x.is_finite()),
+                    vals.iter().fold(0.0_f64, |a, x| a.max(x.abs()))
+                )
+            } else {
+                String::new()
+            };
+            println!(
+                "  {:<14} N={:<5} K={:<5} ref={:<10} cosine={cosine:.6} rel_rms={rel_rms:.4e}{phantom}",
+                p.name,
+                p.n,
+                p.k,
+                match p.reference {
+                    Ref::Pipelined => "pipelined",
+                    Ref::TransposedM128 => "t_m128",
+                },
+            );
+            if let Err(e) = check(&observed, &reference, &sentinel, live, written, gate) {
+                println!("  FAIL {} M={m}: {e}", p.name);
+                failures += 1;
+            }
+
+            println!("  --- timing, {REPS} reps ---");
+            for (label, w8a8) in [("W8A16 (shipped)", false), ("W8A8-cuBLASLt", true)] {
+                if w8a8 {
+                    run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                } else {
+                    run_w8a16(&gpu, &k, p, out, m)?;
+                }
+                gpu.synchronize(0)?;
+                let t0 = Instant::now();
+                for _ in 0..REPS {
+                    if w8a8 {
+                        run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                    } else {
+                        run_w8a16(&gpu, &k, p, out, m)?;
+                    }
+                }
+                gpu.synchronize(0)?;
+                let us = t0.elapsed().as_secs_f64() * 1e6 / REPS as f64;
+                println!(
+                    "  {:<14} {:<16} {us:>9.1} us  {:>7.1} TFLOP/s",
+                    p.name,
+                    label,
+                    p.flops(m) / (us / 1e6) / 1e12
+                );
+            }
+        }
+    }
+
+    ensure!(failures == 0, "{failures} case(s) failed");
+    println!(
+        "\nALL PASS: Qwen3.8-27B prefill projections at M in {ROWS:?} — W8A8 cuBLASLt within \
+         cosine {COSINE_GATE} / rel_rms {gate:.1e} of the W8A16 reference, phantom rows finite \
+         and confined to ceil16(M).\n\
+         Serve spelling: ATLAS_CUBLAS_GEMM=ffn,ssm,attn \
+         (ATLAS_SSM_OUT_W8A16_ONLY / ATLAS_ATTN_QKV_W8A16_ONLY revert per site)."
+    );
+    Ok(())
+}

--- a/crates/spark-model/src/layers/qwen3_attention/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/mod.rs
@@ -33,6 +33,7 @@ pub mod innerq_driver;
 mod prefill;
 // The cuBLASLt W8A8 prefill arm that replaced `ATLAS_CUBLAS_GEMM=attn`'s
 // off-ledger BF16 weight dequant (#917 round 3 / #927).
+mod prefill_qkv_w8a8;
 mod prefill_w8a8;
 mod prefill_weights;
 mod trait_impl;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -52,6 +52,18 @@ impl Qwen3AttentionLayer {
             };
         }
 
+        // ONE decision for all three projections, then ONE activation
+        // quantization they share — see `prefill_qkv_w8a8.rs` for why it is
+        // all-or-none (k's phantom rows land in v's region and are covered by
+        // v's own write, which only holds if both take the same arm in this
+        // order) and for the nsys receipt that made it worth doing (#917/#928:
+        // q_proj 16 x 2029.2 µs + k/v 32 x 375.4 µs = 44.5 ms of a 368.3 ms
+        // 1193-token prefill, all of it W8A16).
+        let w8a8 = self.cache_skip_qkv_w8a8_selected(ctx, n, q_proj_dim as u32, nkv * hd, h);
+        self.log_cache_skip_qkv_route(ctx, w8a8);
+        if w8a8 {
+            self.cache_skip_qkv_w8a8_quant(ctx, normed, n, h, stream)?;
+        }
         let qg_out = ctx.buffers.qkv_output();
         let t0 = std::time::Instant::now();
         self.cache_skip_one_proj(
@@ -62,6 +74,7 @@ impl Qwen3AttentionLayer {
             n,
             q_proj_dim as u32,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -85,6 +98,7 @@ impl Qwen3AttentionLayer {
             n,
             nkv * hd,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -108,6 +122,7 @@ impl Qwen3AttentionLayer {
             n,
             nkv * hd,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -134,6 +149,7 @@ impl Qwen3AttentionLayer {
         n: u32,
         out_dim: u32,
         h: u32,
+        w8a8: bool,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
@@ -192,15 +208,17 @@ impl Qwen3AttentionLayer {
         // (#917 round 3). It mattered again because the 5..16-row decode
         // recipe arms `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`.
         //
-        // Unlike `paged_oproj.rs`, there is no cuBLASLt W8A8 arm to put in its
-        // place HERE: the cache-skip path writes q/k/v into three back-to-back
-        // regions of one buffer (`q_contiguous`, then `+ n*q_dim`, then
-        // `+ n*kv_dim`), and cuBLASLt writes `ceil16(M)` rows — with a prefill
-        // token count that is not a multiple of 16 the pad would cross into the
-        // NEXT projection's region. Giving this path the cuBLASLt arm needs
-        // per-region capacity accounting it does not have today, so it keeps
-        // the transposed W8A16 kernels below, which are byte-identical to what
-        // an un-armed serve already runs.
+        // THE cuBLASLt W8A8 ARM (#928). It used to be absent here — unlike
+        // `paged_oproj.rs` — because this path writes q/k/v into back-to-back
+        // regions of two arena buffers and cuBLASLt writes `ceil16(M)` rows, so
+        // `k`'s pad crosses into `v`'s region. `prefill_qkv_w8a8.rs` now does
+        // the per-region capacity accounting that was missing, and shows why
+        // the k->v overlap is benign (v is written after k, and its real rows
+        // cover k's pad whenever `m >= 16`, which the selector requires). The
+        // decision and the single shared activation quantization are made once
+        // per chain by the caller; `w8a8` is that decision.
+        } else if w8a8 && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8()) {
+            self.cache_skip_qkv_w8a8_gemm(ctx, fp8w, out, n, out_dim, h, stream)?;
         } else if let Some(fp8t) = fp8w_t
             && use_t_pipelined
             && self.w8a16_gemm_t_pipelined_k.0 != 0

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! W8A8 block-scaled cuBLASLt arm for the **cache-skip Q/K/V PREFILL** chain —
+//! the `ATLAS_CUBLAS_GEMM=attn` route for chunk 0 of a prefill, which
+//! `prefill_w8a8.rs` (o_proj) and `paged_qkv.rs` (later chunks) left behind.
+//!
+//! WHY THIS EXISTS (#917 / #928). nsys on 1xH100, 2026-09-11 round 9,
+//! `Qwen/Qwen3.8-27B-FP8`, recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`
+//! (`nsys-r9-prefill`). In the 368.263 ms GPU-busy union of a 1193-token
+//! prefill, `w8a16_gemm_pipelined` is 100.582 ms over 112 launches and
+//! `w8a16_gemm_t_m128` a further 12.012 ms over 32. Resolving them by launch
+//! geometry — `w8a16_gemm_pipelined`'s grid is `(ceil(N/32), ceil(M/128))`,
+//! `w8a16_gemm_n128_m128`'s is `(ceil(N/128), ceil(M/128))` — names the sites:
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | **`q_proj`, this chain** | 32 466.8 |
+//! | 32 | 8x10 | N=1024 K=5120 M=1168 | **`k_proj`+`v_proj`, this chain** | 12 012.2 |
+//!
+//! i.e. one pass per attention layer (16 of them) over the FIRST prefill chunk,
+//! **44.5 ms** of the 1193-token TTFT. The *later* chunks of the same prefill
+//! go through `paged_qkv.rs`, whose W8A8 arm the trace does show
+//! (`fp8_gemm_t_blockscaled`, 48 launches at M=25) — so the split was never
+//! "attention has no W8A8", it was "chunk 0 has no W8A8".
+//!
+//! WHY IT WAS EXCLUDED, and what changed. `cache_skip_one_proj` documented the
+//! reason in place: the three projections write into two arena buffers as
+//! back-to-back regions (`q` alone in `qkv_output`; `k` at `ssm_qkvz` + 0 and
+//! `v` at `ssm_qkvz + num_tokens*kv_dim`), and cuBLASLt writes `ceil16(M)`
+//! rows, so `k`'s padded rows land inside `v`'s region. THE CHOICE MADE HERE is
+//! per-region capacity accounting rather than a padded scratch + copy, because
+//! the overlap is provably benign and a copy would cost a full `[M, kv_dim]`
+//! D2D per projection per layer:
+//!
+//!   * `q` is alone in `qkv_output`; it only needs `ceil16(M) * q_proj_dim`
+//!     BF16 of room, which `sizes.rs` now allocates.
+//!   * `k` runs BEFORE `v` on the same stream, so `k`'s phantom rows
+//!     (`M..ceil16(M)`, at most 15) land in `v`'s region and are then
+//!     OVERWRITTEN by `v`'s own write. With the `m >= 16` clause below,
+//!     `ceil16(M) - M <= 15 < M`, so `v`'s REAL rows cover every one of them —
+//!     no reader ever sees `k`'s pad.
+//!   * `v`'s own phantom rows are the only ones that survive, at the tail, so
+//!     the buffer must hold `(M + ceil16(M)) * kv_dim` BF16. That is the clause
+//!     `ssm_qkvz` is checked against, and the extent `sizes.rs` now allocates.
+//!
+//! Both buffers are bounds-checked at dispatch: if either is too small the
+//! whole chain falls back to the W8A16 kernels, which is what an un-armed serve
+//! runs byte for byte.
+//!
+//! WHAT ELSE IT BUYS. The three projections share one `normed` input, so the
+//! activation is quantized ONCE for all three instead of once per projection —
+//! `paged_qkv.rs` re-quantizes per projection, which the same trace shows as
+//! three `per_token_group_quant_fp8` launches per attention layer.
+//!
+//! ACCURACY. W8A8 quantizes the activation to E4M3 per 128-wide K group and is
+//! lossier than W8A16 by construction — the same deliberate trade the o_proj,
+//! SSM and dense-FFN prefills already made.
+//! `native_fp8_prefill_proj_w8a8_microtest` gates it at cosine >= 0.999 /
+//! rel_rms <= 3e-2 against the W8A16 reference at these shapes.
+//! `ATLAS_ATTN_QKV_W8A16_ONLY` (presence) restores W8A16.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+use super::Qwen3AttentionLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// `ATLAS_ATTN_QKV_W8A16_ONLY` kill switch: PRESENCE (any value, including
+/// empty) keeps the cache-skip Q/K/V prefill on the W8A16 kernels. Presence
+/// rather than `=1`, matching `ATLAS_FFN_W8A16_ONLY` — an escape hatch whose
+/// `=0` spelling must not mean "on".
+pub(super) fn attn_qkv_w8a16_only() -> bool {
+    static ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ONLY.get_or_init(|| std::env::var_os("ATLAS_ATTN_QKV_W8A16_ONLY").is_some())
+}
+
+/// The three destination extents this chain writes, in BF16 elements, given
+/// `m` real rows and the cuBLASLt pad. SSOT for both the selector's capacity
+/// clauses and the module header's argument above.
+///
+/// Returns `(q_elems_in_qkv_output, kv_elems_in_ssm_qkvz)`.
+pub(super) fn cache_skip_qkv_extents(m: u32, q_proj_dim: u32, kv_dim: u32) -> (usize, usize) {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    // `v` starts at row `m` of its buffer and writes `m_pad` rows from there.
+    (
+        m_pad * q_proj_dim as usize,
+        (m as usize + m_pad) * kv_dim as usize,
+    )
+}
+
+/// Whether the WHOLE cache-skip Q/K/V chain takes the cuBLASLt W8A8 arm, as a
+/// pure function so the CPU tests can pin each clause without a GPU.
+///
+/// All three projections or none: the phantom-row argument in the module header
+/// depends on `k` and `v` both going through the same arm in the same order, so
+/// a per-projection decision would be a correctness hazard, not a refinement.
+///
+/// Clauses, each load-bearing:
+///
+/// * `!w8a16_only` — the kill switch above.
+/// * `cublas_attn` — `ATLAS_CUBLAS_GEMM` must name the `attn` family.
+/// * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch.
+/// * `m >= 16` — the covering argument for `k`'s phantom rows (header). It is
+///   stricter than the `m > 4` floor the other prefill arms use, and it is the
+///   clause that makes the shared-buffer overlap safe rather than merely
+///   in-bounds.
+/// * all three weights `Fp8BlockScaled` — cuBLASLt is told the weight scales
+///   are a `[N/128, K/128]` grid; a per-row `row_scale` would be read as
+///   garbage.
+/// * `q_n % 128 == 0`, `kv_n % 128 == 0`, `k % 128 == 0` — that grid, and the
+///   activation quantizer's one-scale-per-128-of-K contract.
+/// * `blk128x128_stride_ok(k)` (`k % 512 == 0`) — cuBLAS requires the weight
+///   scale column stride `K/128` to be a multiple of 4.
+/// * room in BOTH destination buffers for the padded extents above.
+/// * activation scratch room for `ceil16(M) * K` FP8 and its scales —
+///   `cublas_fp8_proj_prequant` zeroes and reads the pad rows of both.
+/// * the quantizer kernel, and the VEC128 scale-layout adapter (kernel,
+///   scratch, capacity). Without the transpose the GEMM is fast and WRONG
+///   (H100 2026-09-11: rel_rms 7.7e-2 on identical FP8 bytes), so a missing
+///   adapter must fall back, never proceed.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn cache_skip_qkv_cublas_selected(
+    cublas_attn: bool,
+    fp8_blockscaled_prefill: bool,
+    w8a16_only: bool,
+    formats: [Option<WeightQuantFormat>; 3],
+    m: u32,
+    q_n: u32,
+    kv_n: u32,
+    k: u32,
+    qkv_output_capacity_bytes: usize,
+    ssm_qkvz_capacity_bytes: usize,
+    act_capacity_bytes: usize,
+    act_scale_capacity_bytes: usize,
+    quant_k: KernelHandle,
+    scale_kmajor_k: KernelHandle,
+    scale_kmajor_buf: DevicePtr,
+    scale_kmajor_capacity_bytes: usize,
+) -> bool {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    let kg = k as usize / 128;
+    let (q_elems, kv_elems) = cache_skip_qkv_extents(m, q_n, kv_n);
+    let kmajor_ready = scale_kmajor_k.0 != 0
+        && scale_kmajor_buf.0 != 0
+        && scale_kmajor_capacity_bytes >= m_pad * kg * 4;
+    !w8a16_only
+        && cublas_attn
+        && fp8_blockscaled_prefill
+        && m >= 16
+        && formats
+            .iter()
+            .all(|f| *f == Some(WeightQuantFormat::Fp8BlockScaled))
+        && q_n.is_multiple_of(128)
+        && kv_n.is_multiple_of(128)
+        && k.is_multiple_of(128)
+        && spark_runtime::cublaslt::scale_layout::blk128x128_stride_ok(k as usize)
+        && q_elems * 2 <= qkv_output_capacity_bytes
+        && kv_elems * 2 <= ssm_qkvz_capacity_bytes
+        && m_pad * (k as usize) <= act_capacity_bytes
+        && m_pad * kg * 4 <= act_scale_capacity_bytes
+        && quant_k.0 != 0
+        && (kmajor_ready || !ops::cublas_scale_layout_kmajor())
+}
+
+impl Qwen3AttentionLayer {
+    /// Whether this layer's cache-skip Q/K/V chain runs on cuBLASLt W8A8.
+    ///
+    /// `m` is the chunk's token count, `k` the hidden size all three contract
+    /// over. Called ONCE per chain, not per projection — see the all-or-none
+    /// note on [`cache_skip_qkv_cublas_selected`].
+    pub(super) fn cache_skip_qkv_w8a8_selected(
+        &self,
+        ctx: &ForwardContext,
+        m: u32,
+        q_proj_dim: u32,
+        kv_dim: u32,
+        k: u32,
+    ) -> bool {
+        let fmt = |w: Option<&crate::weight_map::QuantWeight>| {
+            w.and_then(|w| w.as_fp8()).map(|f| f.scale_format)
+        };
+        cache_skip_qkv_cublas_selected(
+            ctx.dispatch.cublas.attn,
+            ctx.dispatch.fp8_blockscaled_prefill,
+            attn_qkv_w8a16_only(),
+            [
+                fmt(self.q_weight.as_ref()),
+                fmt(self.k_weight.as_ref()),
+                fmt(self.v_weight.as_ref()),
+            ],
+            m,
+            q_proj_dim,
+            kv_dim,
+            k,
+            ctx.buffers.qkv_output_bytes(),
+            ctx.buffers.ssm_qkvz_bytes(),
+            ctx.buffers.fp8_act_bytes(),
+            ctx.buffers.fp8_act_scale_bytes(),
+            self.per_token_group_quant_fp8_k,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            ctx.buffers.fp8_act_scale_kmajor_bytes(),
+        )
+    }
+
+    /// Quantize `normed[m, k]` ONCE into the arena's `fp8_act` /
+    /// `fp8_act_scale` scratch for all three projections.
+    ///
+    /// Q, K and V share one input, so one quantization serves all three. The
+    /// chain is same-stream ordered, so the three GEMMs read it without a host
+    /// sync and nothing else writes it in between.
+    pub(super) fn cache_skip_qkv_w8a8_quant(
+        &self,
+        ctx: &ForwardContext,
+        normed: DevicePtr,
+        m: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+        debug_assert!(m_pad * k as usize <= ctx.buffers.fp8_act_bytes());
+        debug_assert!(m_pad * (k as usize / 128) * 4 <= ctx.buffers.fp8_act_scale_bytes());
+        ops::per_token_group_quant_fp8(
+            ctx.gpu,
+            self.per_token_group_quant_fp8_k,
+            normed,
+            ctx.buffers.fp8_act(),
+            ctx.buffers.fp8_act_scale(),
+            m,
+            k,
+            stream,
+        )
+    }
+
+    /// One projection of the chain: `out[m, n] = a_fp8[m, k] @ weight[n, k]ᵀ`
+    /// with both block-scale sets folded in an FP32 epilogue, through cuBLASLt.
+    ///
+    /// Consumes the activation [`Self::cache_skip_qkv_w8a8_quant`] produced;
+    /// allocates nothing. Callers MUST have checked
+    /// [`Self::cache_skip_qkv_w8a8_selected`] — this does not re-check and does
+    /// not fall back.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn cache_skip_qkv_w8a8_gemm(
+        &self,
+        ctx: &ForwardContext,
+        fp8w: &Fp8Weight,
+        out: DevicePtr,
+        m: u32,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        ops::cublas_fp8_proj_prequant(
+            ctx.gpu,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act(),
+            ctx.buffers.fp8_act_scale(),
+            ctx.buffers.fp8_act_scale_kmajor(),
+            fp8w,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        )
+    }
+
+    /// Log-once route line for the cache-skip Q/K/V prefill, emitted from BOTH
+    /// arms so the absence of the W8A8 line is never ambiguous between "not
+    /// armed" and "log lost".
+    pub(super) fn log_cache_skip_qkv_route(&self, ctx: &ForwardContext, cublas: bool) {
+        if ctx.stats.once("log:attn_cache_skip_qkv_prefill") {
+            if cublas {
+                tracing::info!(
+                    "[atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A8 block-scaled \
+                     via cuBLASLt, activation quantized once for all three \
+                     (per-token 1x128 act scales x 128x128 weight scales, FP32 epilogue). \
+                     ATLAS_CUBLAS_GEMM=attn selected it; ATLAS_ATTN_QKV_W8A16_ONLY restores \
+                     W8A16. This arm allocates nothing."
+                );
+            } else {
+                tracing::info!(
+                    "[atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A16 \
+                     (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `attn` to \
+                     ATLAS_CUBLAS_GEMM; see #917/#928."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "prefill_qkv_w8a8_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8_tests.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Clause-by-clause contract for the cache-skip Q/K/V prefill cuBLASLt arm,
+//! plus the buffer-extent arithmetic the phantom-row argument rests on. Every
+//! selection case defaults to SELECTING and perturbs exactly one thing, so a
+//! failure names the clause.
+
+use super::{cache_skip_qkv_cublas_selected, cache_skip_qkv_extents};
+use crate::layers::ops::cublas_fp8_m_pad;
+use crate::weight_map::WeightQuantFormat;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+/// Qwen3.8-27B attention: hidden 5120, gated `q_proj` 12288 `[Q|gate]`,
+/// kv 1024. The shapes the round-9 H100 trace shows at grid 384x10 (q) and
+/// 8x10 (k, v) on chunk 0 of the 1193-token prompt.
+const H: u32 = 5120;
+const Q_N: u32 = 12288;
+const KV_N: u32 = 1024;
+const M: u32 = 1168;
+const QUANT_K: KernelHandle = KernelHandle(0xBEEF);
+const KMAJOR_K: KernelHandle = KernelHandle(0xC0DE);
+const KMAJOR_BUF: DevicePtr = DevicePtr(0x1000);
+const BLK: Option<WeightQuantFormat> = Some(WeightQuantFormat::Fp8BlockScaled);
+
+fn m_pad(m: u32) -> usize {
+    cublas_fp8_m_pad(m) as usize
+}
+
+fn caps(m: u32) -> (usize, usize, usize, usize) {
+    let (q_elems, kv_elems) = cache_skip_qkv_extents(m, Q_N, KV_N);
+    (
+        q_elems * 2,
+        kv_elems * 2,
+        m_pad(m) * H as usize,
+        m_pad(m) * (H as usize / 128) * 4,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn selected(
+    cublas_attn: bool,
+    blockscaled: bool,
+    w8a16_only: bool,
+    formats: [Option<WeightQuantFormat>; 3],
+    m: u32,
+    q_n: u32,
+    kv_n: u32,
+    k: u32,
+    qkv_cap: usize,
+    qkvz_cap: usize,
+    act_cap: usize,
+    act_scale_cap: usize,
+    quant_k: KernelHandle,
+    kmajor_k: KernelHandle,
+    kmajor_buf: DevicePtr,
+    kmajor_cap: usize,
+) -> bool {
+    cache_skip_qkv_cublas_selected(
+        cublas_attn,
+        blockscaled,
+        w8a16_only,
+        formats,
+        m,
+        q_n,
+        kv_n,
+        k,
+        qkv_cap,
+        qkvz_cap,
+        act_cap,
+        act_scale_cap,
+        quant_k,
+        kmajor_k,
+        kmajor_buf,
+        kmajor_cap,
+    )
+}
+
+fn ready_at(m: u32) -> bool {
+    let (q, kv, a, s) = caps(m);
+    selected(
+        true,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        m,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    )
+}
+
+/// `v` starts at row `m` and writes `ceil16(m)` rows, so the furthest byte is
+/// `(m + ceil16(m)) * kv_dim` — the number the `ssm_qkvz` clause checks and the
+/// number `sizes.rs` allocates. Pinned here because the whole phantom-row
+/// argument in the module header is this arithmetic.
+#[test]
+fn extents_cover_the_furthest_padded_write() {
+    for m in [16u32, 25, 1168, 1193, 4593] {
+        let (q, kv) = cache_skip_qkv_extents(m, Q_N, KV_N);
+        assert_eq!(q, m_pad(m) * Q_N as usize);
+        assert_eq!(kv, (m as usize + m_pad(m)) * KV_N as usize);
+        // Never smaller than the pre-#928 `m * 2 * kv_dim` allocation.
+        assert!(kv >= 2 * m as usize * KV_N as usize);
+        // And k's phantom rows (m..m_pad of k's region) are inside v's region.
+        assert!(m_pad(m) <= m as usize + m_pad(m));
+    }
+}
+
+#[test]
+fn selected_at_prefill_m_with_the_attn_scope_armed() {
+    assert!(ready_at(M), "the round-9 chunk-0 shape must select");
+    assert!(ready_at(4593), "the long-prompt shape must select");
+}
+
+#[test]
+fn not_selected_without_the_attn_scope() {
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        false,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn kill_switch_refuses_even_with_the_scope_armed() {
+    // ATLAS_ATTN_QKV_W8A16_ONLY.
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        true,
+        true,
+        true,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn single_scale_kill_switch_refuses() {
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        true,
+        false,
+        false,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+/// The clause that makes the shared-buffer overlap safe, not merely in-bounds:
+/// below 16 rows `ceil16(m) - m` can exceed `m`, so `v`'s real rows would no
+/// longer cover `k`'s phantom rows.
+#[test]
+fn fewer_than_sixteen_rows_falls_back() {
+    for m in [1u32, 5, 8, 15] {
+        assert!(!ready_at(m), "M={m} must fall back to W8A16");
+    }
+    assert!(ready_at(16));
+}
+
+/// All three or none: a chain where only some weights are block-scaled must
+/// not take the arm for the ones that are.
+#[test]
+fn every_projection_must_be_block_scaled() {
+    let (q, kv, a, s) = caps(M);
+    let case = |formats: [Option<WeightQuantFormat>; 3]| {
+        selected(
+            true, true, false, formats, M, Q_N, KV_N, H, q, kv, a, s, QUANT_K, KMAJOR_K,
+            KMAJOR_BUF, s,
+        )
+    };
+    assert!(case([BLK, BLK, BLK]));
+    let rowwise = Some(WeightQuantFormat::Fp8PerRow);
+    assert!(!case([rowwise, BLK, BLK]), "q per-row");
+    assert!(!case([BLK, rowwise, BLK]), "k per-row");
+    assert!(!case([BLK, BLK, rowwise]), "v per-row");
+    assert!(!case([None, BLK, BLK]), "q not FP8 at all");
+}
+
+#[test]
+fn shape_clauses() {
+    let (q, kv, a, s) = caps(M);
+    let case = |q_n: u32, kv_n: u32, k: u32| {
+        let (qe, kve) = cache_skip_qkv_extents(M, q_n, kv_n);
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            q_n,
+            kv_n,
+            k,
+            qe * 2,
+            kve * 2,
+            m_pad(M) * k as usize,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+        )
+    };
+    let _ = (q, kv, a, s);
+    assert!(case(Q_N, KV_N, H));
+    assert!(!case(Q_N + 64, KV_N, H), "q N must be a multiple of 128");
+    assert!(!case(Q_N, KV_N + 64, H), "kv N must be a multiple of 128");
+    assert!(!case(Q_N, KV_N, H + 64), "K must be a multiple of 128");
+    assert!(!case(Q_N, KV_N, H + 128), "K/128 must be a multiple of 4");
+}
+
+#[test]
+fn capacity_clauses_each_refuse_on_their_own() {
+    let (q, kv, a, s) = caps(M);
+    let case = |q: usize, kv: usize, a: usize, sc: usize, km: usize| {
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            Q_N,
+            KV_N,
+            H,
+            q,
+            kv,
+            a,
+            sc,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            km,
+        )
+    };
+    assert!(case(q, kv, a, s, s));
+    assert!(!case(q - 1, kv, a, s, s), "qkv_output room");
+    assert!(!case(q, kv - 1, a, s, s), "ssm_qkvz room for v's pad");
+    assert!(!case(q, kv, a - 1, s, s), "activation room");
+    assert!(!case(q, kv, a, s - 1, s), "act-scale room");
+    assert!(!case(q, kv, a, s, s - 1), "k-major room");
+}
+
+/// The pre-#928 `ssm_qkvz` sizing (`m * 2 * kv_dim`) is exactly one row short
+/// once M is not a multiple of 16, which is the whole reason `sizes.rs` moved.
+#[test]
+fn the_old_kv_sizing_is_refused_for_a_ragged_m() {
+    let m = 1193;
+    let (q, _kv, a, s) = caps(m);
+    let old = 2 * m as usize * KV_N as usize * 2;
+    assert!(!selected(
+        true,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        m,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        old,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn missing_handles_fall_back() {
+    let (q, kv, a, s) = caps(M);
+    let case = |quant: KernelHandle, kmajor: KernelHandle, buf: DevicePtr| {
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            Q_N,
+            KV_N,
+            H,
+            q,
+            kv,
+            a,
+            s,
+            quant,
+            kmajor,
+            buf,
+            s,
+        )
+    };
+    assert!(case(QUANT_K, KMAJOR_K, KMAJOR_BUF));
+    assert!(!case(KernelHandle(0), KMAJOR_K, KMAJOR_BUF), "quantizer");
+    if crate::layers::ops::cublas_scale_layout_kmajor() {
+        assert!(!case(QUANT_K, KernelHandle(0), KMAJOR_BUF), "kmajor kernel");
+        assert!(!case(QUANT_K, KMAJOR_K, DevicePtr(0)), "kmajor scratch");
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -397,6 +397,7 @@ mod init_fp8;
 mod init_q2;
 mod kernel_select;
 mod lora;
+mod prefill_out_w8a8;
 mod prefill_w8a8;
 mod ssm_forward;
 pub(crate) mod ssm_h_fp16;

--- a/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! W8A8 block-scaled cuBLASLt arm for the SSM/GDN **`out_proj` PREFILL**
+//! projection — the `ATLAS_CUBLAS_GEMM=ssm` route for the second half of the
+//! GDN block, alongside `prefill_w8a8.rs`'s `in_proj_qkvz` arm.
+//!
+//! WHY THIS EXISTS (#917 / #928). nsys on 1xH100, 2026-09-11 round 9,
+//! `Qwen/Qwen3.8-27B-FP8`, best recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`
+//! (`nsys-r9-prefill`, kernel-sum CSV). A 1193-token prefill is **368.263 ms**
+//! of GPU-busy union, and `w8a16_gemm_pipelined` is **100.582 ms = 27.31%** of
+//! it across **112 launches**. Resolved by launch geometry — the kernel's grid
+//! is `(ceil(N/32), ceil(M/128))`, so GrdX names N and GrdY names the chunk —
+//! those 112 are NOT the dense FFN (which the same trace shows on `nvjet…`
+//! cuBLASLt lines for gate/up/down at every M):
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 48 | 160x10 | N=5120 K=6144 M=1168 | **SSM `out_proj`, chunk 0** | 54 119.7 |
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | attn `q_proj`, chunk 0 (`cache_skip_qkv.rs`) | 32 466.8 |
+//! | 48 | 160x1 | N=5120 K=6144 M=25 | **SSM `out_proj`, chunk 1** | 13 995.4 |
+//!
+//! i.e. **96 of the 112 launches and 68.1 ms of the 100.6 ms are this one
+//! projection**, once per GDN layer per prefill chunk, on all 48 GDN layers.
+//! At 4593 tokens it is 163.5 ms of the kernel's 285.5 ms.
+//!
+//! WHY IT WAS EXCLUDED. `prefill_out_proj_dispatch` had no cuBLASLt arm at all,
+//! and its only W8A8 arm was gated on a bare `ATLAS_FP8_W8A8=1` env read —
+//! **not** on `ctx.dispatch.fp8_blockscaled_prefill` (the gate the QKVZ,
+//! attention and dense-FFN prefills use) and **not** on any `ATLAS_CUBLAS_GEMM`
+//! family. So the serve recipe that armed `ssm` moved `in_proj_qkvz` to
+//! cuBLASLt and left `out_proj` — the same layer's other GEMM — on the W8A16
+//! tensor-core kernel, where BF16 activations against E4M3 weights turn the
+//! FP8 bytes into pure memory savings and none of the FLOPs.
+//!
+//! WHAT THIS ADDS. The same quantize-once + k-major-scale pattern as
+//! `prefill_w8a8.rs` / `dense_ffn_w8a8_prefill.rs` / `paged_oproj.rs`: the
+//! `per_token_group_quant_fp8` activation already on this path, re-laid-out by
+//! `fp8_act_scale_to_kmajor`, handed to `ops::cublas_fp8_proj_prequant`. No
+//! dequant, no cache, no device memory — every buffer is arena scratch that
+//! already exists. **The W8A16 kernels remain the fallback** and are what an
+//! un-armed serve still runs, byte for byte.
+//!
+//! ACCURACY. W8A8 quantizes the activation to E4M3 per 128-wide K group, so it
+//! is lossier than W8A16 by construction — the same deliberate trade the other
+//! three prefill families already made. `native_fp8_prefill_proj_w8a8_microtest`
+//! gates it at cosine >= 0.999 / rel_rms <= 3e-2 against the W8A16 reference at
+//! the real shapes. `ATLAS_SSM_OUT_W8A16_ONLY` (presence) restores W8A16.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+use super::Qwen3SsmLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// `ATLAS_SSM_OUT_W8A16_ONLY` kill switch: PRESENCE (any value, including
+/// empty) keeps the SSM `out_proj` prefill on the W8A16 kernels. Presence
+/// rather than `=1` for the same reason as `ATLAS_FFN_W8A16_ONLY` — this is an
+/// escape hatch reached for mid-incident, and `=0` meaning "on" is a trap.
+///
+/// `OnceLock`-cached: the selector runs once per GDN layer per prefill chunk
+/// (48x per chunk on a 27B) and `var_os` walks the whole environment block.
+pub(super) fn ssm_out_w8a16_only() -> bool {
+    static ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ONLY.get_or_init(|| std::env::var_os("ATLAS_SSM_OUT_W8A16_ONLY").is_some())
+}
+
+/// Everything the `out_proj` cuBLASLt arm needs, as a pure function so the CPU
+/// tests can pin each clause without a GPU.
+///
+/// Clauses, each load-bearing:
+///
+/// * `!w8a16_only` — the kill switch above.
+/// * `cublas_ssm` — `ATLAS_CUBLAS_GEMM` must name the `ssm` family. Scoped,
+///   deliberately: arming the dense FFN must not arm this.
+/// * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch that
+///   already governs every other W8A8 prefill arm.
+/// * `m > 4` — the same floor `w8a8_prefill_selected` uses; at M<=4 the GEMV
+///   tier streams each weight once and beats any MMA tile.
+/// * `Fp8BlockScaled` — cuBLASLt is told the weight scales are a `[N/128,
+///   K/128]` BLK128x128 grid; a per-row `row_scale` has a different shape and
+///   would be read as garbage.
+/// * `n % 128 == 0`, `k % 128 == 0` — that grid, and the activation
+///   quantizer's one-scale-per-128-of-K contract.
+/// * `blk128x128_stride_ok(k)` (`k % 512 == 0`) — cuBLAS requires the weight
+///   scale column stride `K/128` to be a multiple of 4.
+/// * output room for `ceil16(M) * N` BF16 — the padded rows are WRITTEN.
+///   `moe_output` is already sized `ceil16(m) * hidden` (`sizes.rs`), so this
+///   is a check that a future re-sizing cannot silently invalidate.
+/// * activation scratch room for `ceil16(M) * K` FP8 and its `ceil16(M) *
+///   K/128` FP32 scales — `cublas_fp8_proj_prequant` ZEROES the pad rows of
+///   both before the matmul, so it writes past M in each.
+/// * the quantizer kernel, and the VEC128 scale-layout adapter, kernel AND
+///   scratch AND its capacity. cuBLASLt reads the activation scales
+///   token-contiguous; handing over the quantizer's `[M, K/128]` order is fast
+///   and WRONG (H100 2026-09-11: rel_rms 7.7e-2 on identical FP8 bytes).
+///   Falling back to W8A16 is the only safe answer when it is missing.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn out_proj_cublas_selected(
+    cublas_ssm: bool,
+    fp8_blockscaled_prefill: bool,
+    w8a16_only: bool,
+    scale_format: WeightQuantFormat,
+    m: u32,
+    n: u32,
+    k: u32,
+    out_capacity_bytes: usize,
+    act_capacity_bytes: usize,
+    act_scale_capacity_bytes: usize,
+    quant_k: KernelHandle,
+    scale_kmajor_k: KernelHandle,
+    scale_kmajor_buf: DevicePtr,
+    scale_kmajor_capacity_bytes: usize,
+) -> bool {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    let kg = k as usize / 128;
+    let kmajor_ready = scale_kmajor_k.0 != 0
+        && scale_kmajor_buf.0 != 0
+        && scale_kmajor_capacity_bytes >= m_pad * kg * 4;
+    !w8a16_only
+        && cublas_ssm
+        && fp8_blockscaled_prefill
+        && m > 4
+        && scale_format == WeightQuantFormat::Fp8BlockScaled
+        && n.is_multiple_of(128)
+        && k.is_multiple_of(128)
+        && spark_runtime::cublaslt::scale_layout::blk128x128_stride_ok(k as usize)
+        && m_pad * (n as usize) * 2 <= out_capacity_bytes
+        && m_pad * (k as usize) <= act_capacity_bytes
+        && m_pad * kg * 4 <= act_scale_capacity_bytes
+        && quant_k.0 != 0
+        && (kmajor_ready || !ops::cublas_scale_layout_kmajor())
+}
+
+impl Qwen3SsmLayer {
+    /// Whether ONE SSM `out_proj` prefill takes the W8A8 cuBLASLt arm.
+    ///
+    /// `n` is the hidden size (the projection's output width) and `k` the GDN
+    /// `value_dim` it contracts over — the 5120 x 6144 of the round-9 receipt.
+    pub(super) fn prefill_out_proj_w8a8_selected(
+        &self,
+        ctx: &ForwardContext,
+        m: u32,
+        n: u32,
+        k: u32,
+        fp8w: &Fp8Weight,
+    ) -> bool {
+        out_proj_cublas_selected(
+            ctx.dispatch.cublas.ssm,
+            ctx.dispatch.fp8_blockscaled_prefill,
+            ssm_out_w8a16_only(),
+            fp8w.scale_format,
+            m,
+            n,
+            k,
+            ctx.buffers.moe_output_bytes(),
+            ctx.buffers.fp8_act_bytes(),
+            ctx.buffers.fp8_act_scale_bytes(),
+            self.per_token_group_quant_fp8_k,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            ctx.buffers.fp8_act_scale_kmajor_bytes(),
+        )
+    }
+
+    /// `out[m, n] = quant(normed_out)[m, k] @ weight[n, k]ᵀ` through cuBLASLt,
+    /// with the per-token 1x128 activation scales and the checkpoint's 128x128
+    /// weight scales folded in an FP32 epilogue.
+    ///
+    /// Quantizes ONCE into the arena's `fp8_act` / `fp8_act_scale` scratch —
+    /// the same buffers the QKVZ arm used earlier in this layer, safely reused
+    /// because the whole chain is same-stream ordered — then hands both to
+    /// `ops::cublas_fp8_proj_prequant`, which does the k-major scale transpose
+    /// and the matmul. Allocates nothing.
+    ///
+    /// Callers MUST have checked [`Qwen3SsmLayer::prefill_out_proj_w8a8_selected`]
+    /// first; this method does not re-check and does not fall back.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prefill_out_proj_w8a8_cublas(
+        &self,
+        ctx: &ForwardContext,
+        normed_out: DevicePtr,
+        fp8w: &Fp8Weight,
+        out: DevicePtr,
+        m: u32,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let a_fp8 = ctx.buffers.fp8_act();
+        let a_scale = ctx.buffers.fp8_act_scale();
+        // Padded extents, because `cublas_fp8_proj_prequant` zeroes and then
+        // READS rows `m..ceil16(m)` of both. The selector already gated on
+        // these; the debug asserts are the loud version for a dev build.
+        let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+        debug_assert!(m_pad * k as usize <= ctx.buffers.fp8_act_bytes());
+        debug_assert!(m_pad * (k as usize / 128) * 4 <= ctx.buffers.fp8_act_scale_bytes());
+        ops::per_token_group_quant_fp8(
+            ctx.gpu,
+            self.per_token_group_quant_fp8_k,
+            normed_out,
+            a_fp8,
+            a_scale,
+            m,
+            k,
+            stream,
+        )?;
+        ops::cublas_fp8_proj_prequant(
+            ctx.gpu,
+            self.fp8_act_scale_kmajor_k,
+            a_fp8,
+            a_scale,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            fp8w,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        )
+    }
+
+    /// Log-once route line for the SSM `out_proj` prefill. Emitted from BOTH
+    /// arms so the absence of the W8A8 line is never ambiguous between "not
+    /// armed" and "log lost" — the failure mode that let round 9's 100.6 ms be
+    /// attributed to the dense FFN, which the same trace shows on `nvjet…`.
+    pub(super) fn log_out_proj_prefill_route(&self, ctx: &ForwardContext, cublas: bool) {
+        if ctx.stats.once("log:ssm_out_proj_prefill") {
+            if cublas {
+                tracing::info!(
+                    "[atlas] SSM out_proj prefill: W8A8 block-scaled via cuBLASLt \
+                     (per-token 1x128 act scales x 128x128 weight scales, FP32 epilogue). \
+                     ATLAS_CUBLAS_GEMM=ssm selected it; ATLAS_SSM_OUT_W8A16_ONLY restores W8A16. \
+                     This arm allocates nothing."
+                );
+            } else {
+                tracing::info!(
+                    "[atlas] SSM out_proj prefill: W8A16 (BF16 act x FP8 weight). \
+                     W8A8 cuBLASLt not selected — add `ssm` to ATLAS_CUBLAS_GEMM; see #917/#928."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "prefill_out_w8a8_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8_tests.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Clause-by-clause contract for the SSM `out_proj` prefill cuBLASLt arm's
+//! selection rule. Every case defaults to SELECTING and perturbs exactly one
+//! thing, so a failure names the clause. The numerics are the GPU microtest's
+//! job (`examples/native_fp8_prefill_proj_w8a8_microtest.rs`).
+
+use super::out_proj_cublas_selected;
+use crate::layers::ops::cublas_fp8_m_pad;
+use crate::weight_map::WeightQuantFormat;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+/// Qwen3.8-27B GDN `out_proj`: N = hidden 5120, K = value_dim 6144. The shape
+/// the round-9 H100 trace shows 48x per prefill chunk at grid 160xceil(M/128).
+const N: u32 = 5120;
+const K: u32 = 6144;
+/// Chunk 0 of the 1193-token trace prompt (chunk 1 is the 25-token tail, which
+/// the `m > 4` clause still admits).
+const M: u32 = 1168;
+const QUANT_K: KernelHandle = KernelHandle(0xBEEF);
+const KMAJOR_K: KernelHandle = KernelHandle(0xC0DE);
+const KMAJOR_BUF: DevicePtr = DevicePtr(0x1000);
+
+fn m_pad(m: u32) -> usize {
+    cublas_fp8_m_pad(m) as usize
+}
+
+fn out_bytes(m: u32) -> usize {
+    m_pad(m) * N as usize * 2
+}
+
+fn act_bytes(m: u32) -> usize {
+    m_pad(m) * K as usize
+}
+
+fn scale_bytes(m: u32) -> usize {
+    m_pad(m) * (K as usize / 128) * 4
+}
+
+/// The full-argument form; every helper below is this with one field moved.
+#[allow(clippy::too_many_arguments)]
+fn selected(
+    cublas_ssm: bool,
+    blockscaled: bool,
+    w8a16_only: bool,
+    fmt: WeightQuantFormat,
+    m: u32,
+    n: u32,
+    k: u32,
+    out_capacity: usize,
+    act_capacity: usize,
+    act_scale_capacity: usize,
+    quant_k: KernelHandle,
+    kmajor_k: KernelHandle,
+    kmajor_buf: DevicePtr,
+    kmajor_capacity: usize,
+) -> bool {
+    out_proj_cublas_selected(
+        cublas_ssm,
+        blockscaled,
+        w8a16_only,
+        fmt,
+        m,
+        n,
+        k,
+        out_capacity,
+        act_capacity,
+        act_scale_capacity,
+        quant_k,
+        kmajor_k,
+        kmajor_buf,
+        kmajor_capacity,
+    )
+}
+
+fn ready_at(m: u32) -> bool {
+    selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        m,
+        N,
+        K,
+        out_bytes(m),
+        act_bytes(m),
+        scale_bytes(m),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(m),
+    )
+}
+
+#[test]
+fn selected_at_prefill_m_with_the_ssm_scope_armed() {
+    assert!(ready_at(M), "the round-9 chunk-0 shape must select");
+    assert!(ready_at(25), "the 25-token tail chunk must select too");
+}
+
+#[test]
+fn not_selected_without_the_ssm_scope() {
+    // The whole point of the scoped lever: `ATLAS_CUBLAS_GEMM=ffn` must leave
+    // this projection exactly where it was.
+    assert!(!selected(
+        false,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn kill_switch_refuses_even_with_the_scope_armed() {
+    // ATLAS_SSM_OUT_W8A16_ONLY.
+    assert!(!selected(
+        true,
+        true,
+        true,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn single_scale_kill_switch_refuses() {
+    // ATLAS_FP8_SINGLE_SCALE clears `dispatch.fp8_blockscaled_prefill`.
+    assert!(!selected(
+        true,
+        false,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn m_at_or_below_four_stays_on_the_gemv_tier() {
+    for m in [1, 2, 4] {
+        assert!(!ready_at(m), "M={m} must stay on the GEMV tier");
+    }
+    assert!(ready_at(5), "M=5 is the first row count this arm claims");
+}
+
+#[test]
+fn per_row_scales_are_refused() {
+    assert!(!selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8PerRow,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn shape_clauses() {
+    let case = |n: u32, k: u32| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            n,
+            k,
+            m_pad(M) * n as usize * 2,
+            m_pad(M) * k as usize,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+        )
+    };
+    assert!(case(N, K));
+    assert!(!case(N + 64, K), "N must be a multiple of 128");
+    assert!(!case(N, K + 64), "K must be a multiple of 128");
+    // k % 512: the weight-scale column stride K/128 must be a multiple of 4.
+    assert!(
+        !case(N, 5120 + 128),
+        "K=5248 has stride 41, not a multiple of 4"
+    );
+}
+
+#[test]
+fn capacity_clauses_each_refuse_on_their_own() {
+    let full = (out_bytes(M), act_bytes(M), scale_bytes(M), scale_bytes(M));
+    let case = |o: usize, a: usize, s: usize, km: usize| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            N,
+            K,
+            o,
+            a,
+            s,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            km,
+        )
+    };
+    assert!(case(full.0, full.1, full.2, full.3));
+    assert!(!case(full.0 - 1, full.1, full.2, full.3), "output room");
+    assert!(!case(full.0, full.1 - 1, full.2, full.3), "activation room");
+    assert!(!case(full.0, full.1, full.2 - 1, full.3), "act-scale room");
+    assert!(!case(full.0, full.1, full.2, full.3 - 1), "k-major room");
+}
+
+#[test]
+fn an_unpadded_output_buffer_is_refused_when_m_is_not_a_multiple_of_16() {
+    // M=25 pads to 32: an arena sized for the REAL rows would be written past.
+    let m = 25;
+    let unpadded = m as usize * N as usize * 2;
+    assert!(!selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        m,
+        N,
+        K,
+        unpadded,
+        act_bytes(m),
+        scale_bytes(m),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(m),
+    ));
+}
+
+#[test]
+fn missing_handles_fall_back() {
+    let case = |quant: KernelHandle, kmajor: KernelHandle, buf: DevicePtr| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            N,
+            K,
+            out_bytes(M),
+            act_bytes(M),
+            scale_bytes(M),
+            quant,
+            kmajor,
+            buf,
+            scale_bytes(M),
+        )
+    };
+    assert!(case(QUANT_K, KMAJOR_K, KMAJOR_BUF));
+    assert!(!case(KernelHandle(0), KMAJOR_K, KMAJOR_BUF), "quantizer");
+    // The k-major clauses only bite in the default layout; guard the assert on
+    // it so `ATLAS_CUBLAS_SCALE_LAYOUT=rowmajor` in the environment does not
+    // turn this into a spurious failure.
+    if crate::layers::ops::cublas_scale_layout_kmajor() {
+        assert!(!case(QUANT_K, KernelHandle(0), KMAJOR_BUF), "kmajor kernel");
+        assert!(!case(QUANT_K, KMAJOR_K, DevicePtr(0)), "kmajor scratch");
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
@@ -133,6 +133,29 @@ impl Qwen3SsmLayer {
                 value_dim as u32,
                 stream,
             )
+        // W8A8 block-scaled cuBLASLt — 96 of the 112 `w8a16_gemm_pipelined`
+        // launches in the round-9 H100 prefill trace (68.1 ms of its 100.6 ms
+        // at 1193 tokens) were THIS projection, once per GDN layer per chunk,
+        // and nothing in `ATLAS_CUBLAS_GEMM` could reach it. See
+        // `prefill_out_w8a8.rs` for the full receipt and the clause list.
+        // Ahead of the `ATLAS_FP8_W8A8` arm below because both compute the same
+        // W8A8 arithmetic and this one is the faster implementation of it; the
+        // env lever alone (without `ssm` in `ATLAS_CUBLAS_GEMM`) still picks
+        // the in-tree kernel.
+        } else if let Some(ref fp8w) = self.out_proj_fp8w
+            && self.prefill_out_proj_w8a8_selected(ctx, k, h as u32, value_dim as u32, fp8w)
+        {
+            self.log_out_proj_prefill_route(ctx, true);
+            self.prefill_out_proj_w8a8_cublas(
+                ctx,
+                normed_out_buf,
+                fp8w,
+                out_proj_buf,
+                k,
+                h as u32,
+                value_dim as u32,
+                stream,
+            )
         } else if force_w8a8
             && let Some(ref fp8w) = self.out_proj_fp8w
             && self.per_token_group_quant_fp8_k.0 != 0
@@ -174,6 +197,10 @@ impl Qwen3SsmLayer {
         } else if let Some(ref fp8w) = self.out_proj_fp8w
             && self.w8a16_gemm_pipelined_k.0 != 0
         {
+            // The 100.6 ms / 27.31% kernel of the round-9 H100 prefill trace,
+            // 96 of whose 112 launches were this line. The counterpart log says
+            // so out loud, so "no W8A8 line" is never read as "log lost".
+            self.log_out_proj_prefill_route(ctx, false);
             ops::w8a16_gemm_pipelined(
                 ctx.gpu,
                 self.w8a16_gemm_pipelined_k,

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -315,7 +315,15 @@ impl BufferSizes {
         // q_heads*head_dim (o_proj). 1 byte/elem fp8 + one f32 per 128-block.
         // Mamba-2 out_proj contracts over d_inner (may exceed hidden), and its
         // prefill input is FP8-precast into this buffer.
-        let max_proj_k = h.max(q_heads * hd).max(mamba2_d_inner);
+        // ...and the GDN `out_proj`, which contracts over `value_dim`. It
+        // happens to equal `q_heads * hd` on Qwen3.8-27B (6144), so naming it
+        // changes no allocation there — but the W8A8 cuBLASLt arm added in
+        // #928 quantizes into this buffer, and a model whose value_dim is the
+        // widest contract would otherwise size it short and silently fall back.
+        let max_proj_k = h
+            .max(q_heads * hd)
+            .max(mamba2_d_inner)
+            .max(config.linear_num_value_heads * config.linear_value_head_dim);
         // Padded to 16 rows: `ops::cublas_fp8_proj` hands cuBLASLt `ceil16(M)`
         // and the matmul reads those phantom activation/scale rows.
         let fp8_act = m_pad * max_proj_k;
@@ -422,7 +430,12 @@ impl BufferSizes {
             hidden_states: m * h * residual_elem,
             residual: m * h * residual_elem,
             norm_output: m * max_dim * bf16,
-            qkv_output: m * qkv_dim * bf16,
+            // `m_pad`, not `m`: the cache-skip Q/K/V prefill's cuBLASLt arm
+            // WRITES `ceil16(M)` rows of `q_proj` here (readers still touch
+            // only the real M). Same headroom `ssm_qkvz` and `moe_output`
+            // already carry, and the reason is the same one (#928). ~0.4 MB on
+            // a 27B.
+            qkv_output: m_pad * qkv_dim * bf16,
             attn_output: (m * config.num_attention_heads * config.head_dim * bf16)
                 .max(m * mamba2_d_inner * bf16)
                 // MLA absorbed: attention output is [M, nq, mla_cache_dim=kv_lora+rope]
@@ -466,7 +479,11 @@ impl BufferSizes {
             // to 15 rows into the NEXT arena buffer. ~0.4 MB on a 27B.
             ssm_qkvz: (m_pad * config.ssm_qkvz_size() * bf16)
                 .max(m * config.mamba2_in_proj_size() * bf16)
-                .max(m * 2 * kv_heads * hd * bf16)
+                // `k` at row 0 and `v` at row `m`, each `ceil16(M)` rows
+                // tall on the cuBLASLt arm: the furthest byte is
+                // `(m + m_pad) * kv_dim` (#928, `prefill_qkv_w8a8.rs`). Was
+                // `m * 2 * kv_dim`, which this is never smaller than.
+                .max((m + m_pad) * kv_heads * hd * bf16)
                 .max(m * config.shared_expert_intermediate_size * bf16) // MoE shared up scratch
                 .max(256),
             ssm_ba: (m * config.ssm_ba_size() * bf16)

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -34,9 +34,14 @@ fn test_buffer_sizes_qwen3() {
     // (Was FP32 = 8192 in earlier prototypes; NVFP4 path keeps the
     // residual stream in BF16, halving the buffer size.)
     assert_eq!(sizes.hidden_states, 4096);
-    // qkv: 1 * (16*2 + 2*2) * 256 * 2 = 1 * 36 * 256 * 2 = 18432
-    // Q+gate: 16*2*256, K: 2*256, V: 2*256
-    assert_eq!(sizes.qkv_output, 18432);
+    // qkv: ceil16(1) * (16*2 + 2*2) * 256 * 2 = 16 * 36 * 256 * 2 = 294912
+    // Q+gate: 16*2*256, K: 2*256, V: 2*256 — and the row extent is the
+    // cuBLASLt M-pad, exactly as for `ssm_qkvz` / `ssm_deinterleaved` below:
+    // the cache-skip Q/K/V prefill's cuBLASLt arm hands the library ceil16(M)
+    // and WRITES the phantom rows (#928, `sizes.rs`'s `m_pad`). The 16x here
+    // is an artifact of sizing at M=1; at a real prefill arena the pad is
+    // <= 15 rows out of thousands.
+    assert_eq!(sizes.qkv_output, 294912);
     // attn: 1 * 16 * 256 * 2 = 8192
     assert_eq!(sizes.attn_output, 8192);
     // gate: 1 * 512 * 2 = 1024


### PR DESCRIPTION
> **Stacked on #994** (which is itself stacked on #984 → #986 → #987 → #988 → #989). This PR's own content is the **last** of the twenty-two commits here; the twenty-one below it belong to those six PRs. Review this PR alone with `git diff cac361d7c..`, or just the commit titled `spark-model: route the remaining W8A16 prefill projections through the W8A8 cuBLASLt arm (#928)`. Merge order: **#984 → #986 → #987 → #988 → #989 → #994 → this**. Base is `main` rather than a stack branch so this PR does not become unreviewable if any of them is rebased.
>
> Why #994 is in the base, in one line: it supplies `ops::cublas_fp8_proj_prequant`, the k-major VEC128 activation-scale transpose and the per-family `ATLAS_CUBLAS_GEMM` scoping (via #989) that this PR's two new arms are built out of, and it owns `prefill_w8a8.rs` and `cache_skip_qkv.rs` in the shape this diff extends — including the source comment in `cache_skip_qkv.rs` that says, in #994, that the chunk-0 Q/K/V chain *cannot* take cuBLASLt. **This PR is the answer to that comment.** See **Conflicts** below.

## Summary

**The largest single kernel in an H100 prefill is 100.6 ms of W8A16 GEMM that no route change had ever reached — and it is not what the round-9 report said it was.**

nsys, 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8`, native FP8, 1193-token prompt, C=1: the prefill is **368.263 ms** of GPU-busy union, and `w8a16_gemm_pipelined` is **100.582 ms over 112 launches (27.31%)**, with `w8a16_gemm_t_m128` a further **12.012 ms over 32**. Round 9 read those 112 launches as the dense FFN's prefill GEMM. **Resolving them by grid geometry says otherwise:** they are the SSM `out_proj` (96 launches, 68.1 ms) and the attention `q_proj` of prefill chunk 0 (16 launches, 32.5 ms), with the `t_m128` 32 being that same chunk's `k_proj`/`v_proj`. The dense FFN is on `nvjet…` cuBLASLt lines at both chunk widths in the very same trace — #987 had already moved it.

So **112.6 ms — 30.6% of the prefill — is two projection sites that the `ssm` and `attn` cuBLASLt scopes were already armed for and simply did not reach.** One had no cuBLASLt arm at all and read a stale `ATLAS_FP8_W8A8=1` env var instead of the dispatch flag; the other documented its own exclusion in the source, because cuBLASLt writes `ceil16(M)` rows and its padded rows would cross into the next projection's region of a shared buffer.

This PR gives both sites the arm, under those same existing scopes, with per-region phantom-row accounting instead of a staging copy. **Measured on 1×H100, same binary, arms toggled by the two kill switches: 1193-token TTFT 371.6 → 267.9 ms (−27.9%)** and 4593-token **1,171.7 → 890.3 ms (−24.0%)**, with **C=1 TPOT unchanged at 17.86 ms** as the built-in null check and coherency 4/4.

Refs #928 and #917.

## What was wrong

nsys, 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8, recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn ATLAS_LM_HEAD_M16_TC=1`, C=1, `--cuda-graph-trace=node`, 2026-09-11 (run record `nsys-r9-prefill`). Prefill = first kernel of the drive segment to the end of its first `argmax_bf16_batch`; `%busy` is against the GPU-busy union, which matches the independently measured TTFT to **0.3%** (368.263 ms union vs 369.3 ms ladder p50).

| # | kernel | count | µs | % of busy |
|---|---|---|---|---|
| 1 | `w8a16_gemm_pipelined` | 112 | **100 581.9** | **27.31** |
| 2 | `gated_delta_rule_chunk_delta_h_vfused` | 96 | 97 830.3 | 26.57 |
| 3 | `nvjet_sm90_qqtst_128x128_128x6_1x2_h_bz_coopA_algo2…` | 176 | 32 462.8 | 8.82 |
| 7 | `w8a16_gemm_t_m128` | 32 | **12 012.2** | **3.26** |

**The kernels do not carry a label, so the sites were resolved from the launchers' own grid formulas** — `w8a16_gemm_pipelined` launches `(ceil(N/32), ceil(M/128))`, `w8a16_gemm_n128_m128` launches `(ceil(N/128), ceil(M/128))` — against a prompt the scheduler served as two chunks of **1168 + 25** tokens:

| launches | grid | shape | site | µs |
|---|---|---|---|---|
| 48 | 160×10 | N=5120 K=6144 M=1168 | **SSM `out_proj`, chunk 0** | 54 119.7 |
| 16 | 384×10 | N=12288 K=5120 M=1168 | **attn `q_proj`, chunk 0** | 32 466.8 |
| 48 | 160×1 | N=5120 K=6144 M=25 | **SSM `out_proj`, chunk 1** | 13 995.4 |
| 32 | 8×10 | N=1024 K=5120 M=1168 | **attn `k_proj`+`v_proj`, chunk 0** | 12 012.2 |

48 = the GDN layer count, 16 = the attention layer count. **112 launches, 112.6 ms, two sites.**

**🪤 This supersedes the round-9 report's reading of the same 100.6 ms as the dense FFN's prefill GEMM, and the mechanism of that error is worth naming**: the inference came from a `log:ffn_w8a16_prefill` route line, and that line is emitted under a log-once latch — it records what the *first* observation selected, not what the steady state runs. The trace itself shows the FFN's gate/up/down on `nvjet…` cuBLASLt lines at both chunk widths. The fix for that class of mistake is in this diff: **both new route lines are emitted from both arms**, so the absence of a W8A8 line can never be ambiguous between "not armed" and "log lost".

The two sites were excluded for two different reasons, and only one of them was ever written down:

- **`prefill_out_proj_dispatch` had no cuBLASLt arm at all.** Its only W8A8 arm was gated on a bare `ATLAS_FP8_W8A8=1` environment read — not `ctx.dispatch.fp8_blockscaled_prefill`, not any `ATLAS_CUBLAS_GEMM` family. So a serve that armed `ssm` moved `in_proj_qkvz` to cuBLASLt and left **the same layer's other GEMM** on W8A16, where FP8 weight bytes buy memory and none of the FLOPs. At M=1193 that kernel runs at **65.5 TFLOP/s**.
- **`cache_skip_one_proj` documented its own exclusion in place.** The chain writes q/k/v into back-to-back regions of two arena buffers — `q` alone in `qkv_output`, `k` at `ssm_qkvz + 0`, `v` at `ssm_qkvz + num_tokens*kv_dim` — and cuBLASLt writes `ceil16(M)` rows, so `k`'s padded rows land inside `v`'s region. That is a real hazard, and it is what this PR has to answer rather than hand-wave.

Only **chunk 0** was affected on the attention side: the *later* chunks of the same prefill go through `paged_qkv.rs`, whose W8A8 arm the same trace does show (`fp8_gemm_t_blockscaled`, 48 launches at M=25). The split was never "attention has no W8A8" — it was "chunk 0 has no W8A8".

## What the fix does

Both sites take the pattern the dense-FFN, QKVZ and `o_proj` prefill arms already use, under the existing `ctx.dispatch.cublas.ssm` / `.attn` scopes: one `per_token_group_quant_fp8` over the normed input, one `fp8_act_scale_to_kmajor` into the VEC128 layout cuBLASLt documents (#989), then `nvjet` against the checkpoint's own FP8 bytes and its 128×128 FP32 block scales, FP32 epilogue. **No dequant, no weight twin, no device allocation** — every buffer is arena scratch that already exists. **The W8A16 kernels remain the fallback and are what an un-armed serve runs byte for byte.**

**🪤 The phantom rows are the whole difficulty, and the answer is per-region accounting, not a staging copy.** cuBLASLt is handed `ceil16(M)`, and those pad rows **are written**. Per region:

- **`q` is alone in `qkv_output`.** It needs `ceil16(M) * q_proj_dim` BF16 of room; `sizes.rs` now allocates `m_pad` rather than `m` there (~0.4 MB on a 27B). Readers still touch only the real `M`.
- **`k` runs before `v` on the same stream**, so `k`'s pad rows (`M..ceil16(M)`, at most 15) land in `v`'s region and are then **overwritten by `v`'s own real write**. The selector carries an **`m >= 16` clause** precisely so that `ceil16(M) − M <= 15 < M` holds and `v`'s real rows cover every one of them. No reader ever sees `k`'s pad.
- **`v`'s own pad is the only one that survives**, at the tail, so the buffer must hold `(M + ceil16(M)) * kv_dim` BF16. That is the extent `ssm_qkvz` is both **checked against at dispatch** and sized for in `sizes.rs`.

Both buffers are bounds-checked at dispatch; **if either is too small the whole chain declines to the W8A16 kernels** rather than writing past its end. A staging buffer plus copy was the alternative and was rejected: it would have cost a full `[M, kv_dim]` D2D per projection per attention layer per chunk.

**The three projections also share one activation quantization** instead of one each — `paged_qkv.rs` re-quantizes per projection, which the same trace shows as three `per_token_group_quant_fp8` launches per attention layer.

`sizes.rs` also gains `linear_num_value_heads * linear_value_head_dim` in the `max_proj_k` fold. It happens to equal `q_heads * head_dim` (6144) on Qwen3.8-27B so it changes no allocation there, but the SSM `out_proj` arm quantizes into that buffer, and a model whose `value_dim` were the widest contraction would otherwise size it short and silently fall back.

**Kill switches:** `ATLAS_SSM_OUT_W8A16_ONLY` and `ATLAS_ATTN_QKV_W8A16_ONLY`, both **presence** (any value, including empty), `OnceLock`-cached — matching `ATLAS_FFN_W8A16_ONLY`, whose spelling was chosen because an escape hatch reached for mid-incident must not have `=0` mean "on". Nothing reads the environment per step; every selector is a pure function of the prefill row count, the resolved `GemmDispatch`, and handles and capacities fixed at model build.

**🪤 NUMERICS, stated plainly.** These projections move from W8A16 (BF16 activation × E4M3 weight) to W8A8 (dynamic per-token 1×128 E4M3 activation quant × the checkpoint's 128×128 weight scales, FP32 epilogue) — **the same arithmetic the dense-FFN, QKVZ and `o_proj` prefills already use, and vLLM's.** It is a deliberate precision trade, not a defect, and the measurements below sit exactly on the E4M3 floor.

## Oracle and evidence

### Microtest — `native_fp8_prefill_proj_w8a8_microtest`

1×H100 80 GB, 2026-09-11, at the four real Qwen3.8-27B prefill shapes, M ∈ {64, 1193}, 10 reps, `MT_EXIT=0`. Gates **`cosine >= 0.999`, `rel_rms <= 3.0e-2`** — a quantisation-noise tolerance, not a bit gate, because the E4M3 activation-quant floor is ~2–2.6e-2 and a bit gate on a deliberate precision change would be meaningless. Reference is the W8A16 kernel each site actually ships (`pipelined` for `out_proj`/`q_proj`, `t_m128` for `k`/`v`).

```
rows [64, 1193], cuBLASLt M pad reaches 1200
```

| M | projection | ref | cosine | rel_rms | phantom rows |
|---|---|---|---|---|---|
| 64 | ssm `out_proj` N=5120 K=6144 | pipelined | 0.999677 | 2.5444e-2 | — (pad = 64) |
| 64 | attn `q_proj` N=12288 K=5120 | pipelined | 0.999679 | 2.5335e-2 | — |
| 64 | attn `k_proj` N=1024 K=5120 | t_m128 | 0.999680 | 2.5319e-2 | — |
| 64 | attn `v_proj` N=1024 K=5120 | t_m128 | 0.999681 | 2.5291e-2 | — |
| 1193 | ssm `out_proj` | pipelined | 0.999680 | 2.5322e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `q_proj` | pipelined | 0.999680 | 2.5323e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `k_proj` | t_m128 | 0.999680 | 2.5303e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `v_proj` | t_m128 | 0.999680 | 2.5310e-2 | `1193..1200` finite, `max_abs=0.000` |

**The deviation is flat in M and pinned at the E4M3 floor (cosine 0.999677–0.999681, rel_rms 2.529e-2–2.544e-2) — which is the thing that says this is activation quantisation and not an indexing bug.** And the phantom rows are finite with `max_abs=0.000` in the gap region, i.e. the write extent is where the argument above says it is.

**Three negative controls, all refused, so the harness is shown able to fail before it is believed:**

```
KNOWN_BAD guard:     refused: route wrote outside its extent at byte 0
KNOWN_BAD nonfinite: refused: nonfinite projection output (phantom rows included)
KNOWN_BAD value:     refused: cosine 0.316981 < 0.999
```

Timing, µs per projection, 10 reps:

| projection | M=64 W8A16 → W8A8 | **M=1193 W8A16 → W8A8** | **M=1193 speedup** |
|---|---|---|---|
| ssm `out_proj` N=5120 K=6144 | 267.6 → 25.0 | **1 145.2 → 127.8** | **8.96×** |
| attn `q_proj` N=12288 K=5120 | 291.8 → 37.3 | **2 066.0 → 168.1** | **12.29×** |
| attn `k_proj` N=1024 K=5120 | 369.5 → 24.7 | **370.3 → 54.7** | **6.77×** |
| attn `v_proj` N=1024 K=5120 | 372.7 → 24.4 | **370.2 → 55.0** | **6.73×** |

In TFLOP/s the story is one line: **the W8A16 tier runs these prefill shapes at 33.8–72.7 TFLOP/s while cuBLASLt W8A8 runs the identical work at 228–893** — and the small-N `k`/`v` pair, which was a *regression* at the decode widths in #994, is a 6.7× win here because at M=1193 there is finally enough work to fill a tile.

**The microtest and the serving trace agree on the baseline, independently.** `out_proj` at M=1193 measures 1 145.2 µs here; nsys measured 48 launches at M=1168 for 54 119.7 µs = **1 127.5 µs each** (1.6% apart). `q_proj` 2 066.0 µs here vs 32 466.8/16 = **2 029.2 µs** (1.8%). `k`/`v` 370.3/370.2 µs here vs 12 012.2/32 = **375.4 µs** (1.4%). That agreement is what licenses the grid-geometry attribution above — three independent shapes, all within 2%.

### Serving ladder — diagnostic single-H100 evidence

1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8, 2026-09-11 round 11. **Same binary in both cells** — the control differs only by `ATLAS_SSM_OUT_W8A16_ONLY=1 ATLAS_ATTN_QKV_W8A16_ONLY=1`, verified live in `/proc/<pid>/environ`. Recipe otherwise frozen: bs16, ring auto, batched GDN, head band 16, `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`, `ATLAS_LM_HEAD_M16_TC=1`, `ATLAS_FFN_NO_BATCH16=1`. Temp 0 / seed 42, thinking off, frozen ladder, 1 warmup + 3 recorded reps, rep spread 0.00–0.35%, **0 errors in every rep**.

**The route lines are the A/B, verbatim from the two boot logs, and only the two new ones move:**

```
A  [atlas] SSM out_proj prefill: W8A8 block-scaled via cuBLASLt … ATLAS_SSM_OUT_W8A16_ONLY restores W8A16. This arm allocates nothing.
B  [atlas] SSM out_proj prefill: W8A16 (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `ssm` to ATLAS_CUBLAS_GEMM; see #917/#928.

A  [atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A8 block-scaled via cuBLASLt, activation quantized once for all three …
B  [atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A16 (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `attn` …

A and B, identical:  [atlas] SSM QKVZ prefill: W8A8 block-scaled via cuBLASLt …
A and B, identical:  [atlas] attention prefill: W8A8 block-scaled via cuBLASLt …
```

**1193-token prompt / 256 output**

| cell | tok/s agg C=1 | **TTFT p50 C=1** | TPOT C=1 | tok/s agg C=16 | **TTFT p50 C=16** | TPOT C=16 |
|---|---|---|---|---|---|---|
| control (arms off) | 51.96 | 371.6 ms | 17.86 ms | 366.37 | 3 142.5 ms | 31.48 ms |
| **this PR** | **53.06** | **267.9 ms** | **17.86 ms** | **429.46** | **2 283.8 ms** | **28.44 ms** |
| | +2.1% | **−27.9%** | **0.00%** | **+17.2%** | **−27.3%** | −9.7% |

**4593-token prompt / 512 output**

| cell | tok/s agg C=1 | **TTFT p50 C=1** | TPOT C=1 | tok/s agg C=16 | **TTFT p50 C=16** | TPOT C=16 |
|---|---|---|---|---|---|---|
| control (arms off) | 43.77 | 1 171.7 ms | 20.60 ms | 263.73 | 9 928.3 ms | 41.27 ms |
| **this PR** | **44.84** | **890.3 ms** | **20.60 ms** | **309.09** | **7 511.5 ms** | **37.07 ms** |
| | +2.4% | **−24.0%** | **0.00%** | **+17.2%** | **−24.3%** | −10.2% |

**🪤 Read the control row carefully — it is assembled from two cells, and the reason is stated rather than smoothed over.** The kill-switch cell measured on this binary is the **1193 / C=1** row (51.96 tok/s, 371.6 ms, 17.86 ms TPOT); the remaining three rows are the previous round's cell at the identical recipe on the previous build (`r10-XY-919`, which itself reproduces round 9's XY to within rep spread across all twelve cells). **What licenses splicing them is that the one cell measured both ways agrees to 0.1%**: kill-switch 51.96 tok/s / 371.6 ms against `r10-XY` 51.91 / 371.2. That is the evidence that the switches restore the prior binary's behaviour, and it is a same-recipe cross-build agreement, not an assumption. The C=16 and 4593-token control cells were **not** re-measured with the kill switches on this build.

**The arithmetic closes to 3%, and that is the strongest single result here.** The four kernel families this PR replaces are 112.59 ms of the 368.26 ms short prefill. Feeding the microtest's measured W8A8 timings back through the same launch counts — 48 × 127.8 + 16 × 168.1 + 32 × 54.85 + 48 × 25.0 — predicts **≈11.8 ms** in their place, i.e. a **≈100.8 ms** saving. **Measured TTFT delta: 103.7 ms.** A prefill-only change, predicted from a kernel microtest, landing within 3% of an independently measured end-to-end latency is the check that says the attribution, the microtest and the serve are all describing the same thing.

**The null check passes exactly.** This PR touches prefill only; **C=1 TPOT is 17.86 ms in both cells** on the short shape and **20.60 ms in both** on the long one. Steady-state decode is untouched to four digits, which is what a prefill-only change must show.

**C=16 TPOT moves anyway, and the reason is not decode.** At 16 concurrent requests the ladder's TPOT window contains the *other* sequences' prefill chunks interleaved with decode steps, so a cheaper prefill shortens it (31.48 → 28.44 ms short, 41.27 → 37.07 ms long). That is scheduling, not arithmetic, and the C=1 rows above are the control that shows it.

**Memory is flat and no coherency gate is paid.** Both cells: **73 829 MiB at ready** and **+6 MiB** across the gates; +24 MiB across this PR's full two-shape ladder. KV identical in both (`13.6 GB → 22205 blocks → 355 280 max KV tokens`), ring identical (`8 slots × 16 seqs × 151.5 MB/seq = 18.94 GB`). **Coherency gate 4/4 PASS in both** (`passed: true`; `'391' OK; 'Tokyo' OK; 'rotaregirfer' OK`), 16-way concurrent arithmetic probe **16/16 correct in both** — and its wall time is a free side-measurement that tracks the result: **1.47 s (control) → 0.97 s (this PR)**.

The `sizes.rs` growth is real but below the resolution of the memory poll: `qkv_output` goes from `m` to `m_pad` rows and `ssm_qkvz` gains `(m + m_pad)` over `2m` in one `max` term — ~0.4 MB each on a 27B, against 73.8 GB resident. Both cells report the same MiB at ready.

### Scope of the evidence — read this before citing the ladder

- **Diagnostic single-H100 evidence, not a perf gate.** One box, one model (`Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`), one quantization, one recipe. Nothing here is a claim about GB10 or a released number.
- **The arms require `ATLAS_CUBLAS_GEMM` to name `ssm` and `attn`.** They are not on by default; an unset or `ffn`-only serve runs today's W8A16 kernels byte for byte. The per-family scoping that makes `ssm,attn` expressible is #989's.
- **Three of the four control cells are the previous build's**, as stated above, bridged by a 0.1% agreement on the one cell measured both ways. A full four-cell kill-switch control on this binary is owed and is not here.
- **The numerics change is real and default-on once the lever is set.** ~2.5e-2 relative RMS at cosine ~0.99968 against W8A16 — the E4M3 floor, and the same trade three other prefill families already take. The two `_W8A16_ONLY` switches are the off switches.
- **The `m >= 16` clause is load-bearing, not a tuning knob.** Below it the k/v overlap argument does not hold, and the selector declines. It is unit-tested as a clause, not left to a comment.
- **The round-9 report's dense-FFN attribution of this kernel is superseded by this PR's grid-geometry resolution**, corroborated by the three-shape microtest agreement above. Anyone citing round 9 §"Reading the prefill" item 3 should read this section instead.

**Host dispatch tests** pin both selectors clause by clause without building a `ForwardContext`: selected at prefill M with the scope armed and not without, the kill switch, the `m` floor, the scale format, the shape and per-region capacity clauses, and the missing-handle declines — plus the buffer-extent arithmetic the phantom-row argument rests on, as an SSOT shared by the selector and the test.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, in an isolated worktree against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda prefill` — **98 passed, 0 failed, 4 ignored**
- [x] `cargo test -p spark-model --features cuda w8a8` — **56 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda ssm` — **156 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda attn` — **15 passed, 0 failed, 1 ignored**
- [x] `cargo test -p spark-model --features cuda cublas` — **6 passed, 0 failed**
- [x] `cargo build -p spark-model --examples --features cuda,gpu-examples` — clean (builds the new microtest)
- [x] `cargo clippy -p spark-model -p spark-runtime -p spark-server --tests --features cuda,nccl -- -D warnings` — clean, **0 warnings emitted**
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `kernel shadow structure: OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] **No `.cu` files touched** — confirmed, `git diff --name-only` over this PR's commit is 11 files, all `.rs`/`.toml`, `CU_COUNT=0`. No kernel source changes, so no PTX gate is owed.
- [x] Tested against real hardware — the H100 microtest, the two-cell ladder, the coherency gates and the 16-way probes above (2026-09-11)

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates every committed `.benchmarks/` record on landing and a GB10 re-measure is owed before merge.

**Almost all of this PR is inert on an un-armed GB10 serve, and one part is not.** The two W8A8 arms need `ATLAS_CUBLAS_GEMM` to name `ssm`/`attn`, which no GB10 recipe does today, so on GB10 both sites keep running the same W8A16 kernels they run now. **The exception is `crates/spark-runtime/src/buffers/sizes.rs`**, which grows `qkv_output` to `m_pad` rows and adds one term to each of the `ssm_qkvz` and `max_proj_k` folds **unconditionally, on every target**. That is ~0.4 MB each on a 27B-class model and is pure allocation arithmetic — no kernel, no route — but it is the part of this PR a GB10 re-measure actually exercises, and the part to watch if a GB10 fit is close to its ceiling.

No `kernels/` file is touched, so no PTX gate applies.

## Conflicts

Cherry-picked from `fix/prefill-last-w8a16-gemm` on the fork with an `-x` provenance line, onto #994's branch. **It applied with no conflict at all and nothing was adapted** — the two new modules are new files, and the three edited call sites (`cache_skip_qkv.rs`, `trait_prefill_helper.rs`, `sizes.rs`) are exactly the shapes #994 leaves behind. The `crates/spark-model/Cargo.toml` `[[example]]` stanza for `native_fp8_prefill_proj_w8a8_microtest` is a pure addition alongside #994's own.

One thing a reviewer of #994 should know: **this PR deletes the comment in `cache_skip_qkv.rs` that #994 added saying that chain cannot take cuBLASLt.** That comment was correct when it was written — it is the exclusion this PR's per-region accounting is the answer to — and the two should be read together.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
