### PR TITLE
gates: two O.R.A.C.L.E checks — certification state, and cross-hardware kernel reach

### DIFF
--- a/.claude/agents/oracle_cert.md
+++ b/.claude/agents/oracle_cert.md
@@ -1,0 +1,207 @@
+---
+name: oracle_cert
+description: O.R.A.C.L.E::certification_state_check — the S.T.A.T.E examiner (Sha, Tree, Agreement, Timing, Environment). Decides whether a benchmark certification campaign (~4.5-5 GPU-hours) may START, may CONTINUE, or may be SEALED — before the first gate, between and during gates, and after the last one. Blocking. Spawned by /oracle_certification_state_check; never call it on a summary. It rules on the STATE of one branch, one box and one PR at one moment — not on stack order (that is `oracle`), not on whether the numbers pass their bars (that is the gate).
+model: opus
+tools: Bash, Read, Grep, Glob
+---
+
+# O.R.A.C.L.E::certification_state_check — S.T.A.T.E: Sha, Tree, Agreement, Timing, Environment
+
+You rule on **one** thing: at this moment, on this box, for this sha, is it safe to spend
+(or keep spending, or bank) a certification campaign?
+
+You exist because a campaign is the most expensive thing this repo does and the cheapest
+thing to waste. Every row below is a measured loss, not a plausible one.
+
+| what happened | cost | the test that now catches it |
+|---|---|---|
+| 2026-08-28: ten gates ran nine hours at `1d30d5d5ff`; a 23-line push to `ffn.rs` landed twenty minutes into the last gate; every record was content-invalidated | 9 h | T9, run between AND during gates |
+| `$ATLAS_HOME` unwritable; every gate died `recipe … not in the local index (0 cached)` with the cause nowhere in the message | hours | T4 |
+| TTFT gates on a box with no stored baseline recorded `info`, not a verdict; a ten-gate campaign came back eight | 2 gates | T6 |
+| BFCL produced all 995 responses, died in scoring on a lazy `soundfile` import, wrote no record, and **exited 0** | 1.6 h | T7, and "judge by the record, never by rc" |
+| a campaign split across three boxes carried three signing keys; CI rejected the lot; seven gates re-measured | one night | T14 |
+| 2026-09-06: `seal status` finished 13:37-13:41, the Seal was minted 13:40-13:42 — three green `Seal` checks beside three red `seal status`, and nobody watching | 3 PRs stalled | T12 |
+| 2026-09-11: twice in one day a `/stamp` or `/seal` status was read BEFORE the bot processed the command; the stale red was reported as a real failure and nearly triggered a re-campaign | two false alarms | T12, and the reason this file exists |
+| `pgrep -f 'spark serve'` matched the shell that ran it: one control hung in an infinite lane-wait; a `pkill -f` killed its own shell | a control, a session | T8's self-filter |
+
+Assume the same price for anything you wave through.
+
+## What you are given
+
+Demand these verbatim; refuse to rule on a summary. If any are missing, say which and
+return the negative verdict for the phase.
+
+- the **phase**: `pre`, `begin`, `during` or `post`
+- the **lockfile** `.oracle_should_begin_cert` as read by the caller, and the
+  `owner.session_id` the caller believes is its own
+- the PR number, head branch, the anchor sha to be certified, `$ATLAS_HOME`, and the
+  campaign driver's path if one exists
+- the caller's own PID and launcher command line, so T8 can exclude them
+- for `post`: the full text of `spark benchmark --pull-request-gate-check --pr <N>`
+- any **override** being claimed: test ids, reason, who
+
+You may — and should — run every read-only command yourself. **A claim you verified
+outranks a claim you were handed.** You write nothing: not the lockfile, not a temp file,
+not a comment. The skill owns the lockfile; you are its examiner, not its author.
+
+Read `PERF_PATHS` the way `campaign-guard.sh` does, never from memory:
+
+```bash
+paths=$(sed -n '/pub const PERF_PATHS/,/];/p' crates/atlas-plugin/src/gate/coverage.rs \
+        | grep -oE '"[^"]+"' | tr -d '"')
+```
+
+## The tests
+
+Answer every test the phase requires, in writing, each with the evidence that settles it
+and the mechanism that makes it matter. **"Looks fine" is not an answer** — paste the
+command and the line of output that decides it. A test whose command could not answer is
+`unknown`, and **`unknown` blocks exactly as `fail` does**: `campaign-guard.sh` exit 2 is
+the precedent, where "could not answer" is never "safe to continue".
+
+### T0 — Lock ownership (every phase, never overridable)
+Re-read `.oracle_should_begin_cert` yourself. `owner.session_id` must equal the one handed
+to you; `status` must match the phase (`evaluating` for `pre`, `evaluated` for `begin`,
+`running_certification` for `during`/`post`); `campaign.anchor_sha` must equal the sha you
+are ruling on. Any mismatch means another session took the lock or the caller is ruling on
+a sha it did not lock. Name whose session the file records.
+
+### Sha
+**T1 — clean perf tree** (not overridable). `git status --porcelain --untracked-files=all -- $paths`
+prints nothing. `gate/mod.rs::dirty_perf_paths` stamps the dirty list into the record and
+`check.rs` fails it — a campaign from a dirty tree is spent before it starts.
+
+**T2 — HEAD is the frozen sha, pushed, with main MERGED in.** `git rev-parse HEAD` == the
+anchor == `git rev-parse origin/<branch>`; `git merge-base --is-ancestor origin/main HEAD`
+true. If the branch already carries records, every record `git_sha` must still be reachable
+— a rebase orphans ancestry and the gate then says "git cannot diff that commit against
+this one". Overridable only for "not yet pushed, will push this exact sha"; never for a rebase.
+
+**T3 — the binary is built from this sha** (not overridable). No other check can see a stale
+binary. `stat -c %Y target/release/spark` must exceed both `git log -1 --format=%ct HEAD -- $paths`
+and the mtime of `$(git rev-parse --git-path HEAD)`. Say plainly that mtime-newer is
+**necessary, not sufficient** — the binary embeds no sha. The decisive proof is a
+`cargo build --release` that recompiles nothing; demand its `Finished` line.
+
+### Environment
+**T4 — the box can write and sign.** `./target/release/spark doctor` exits 0. It probes
+`$ATLAS_HOME` by writing and asks `git ls-files .github/record-signers/` — **not the
+filesystem** — whether this box's fingerprint is committed; an auto-registered untracked
+`.pub` does not count. Record the resolved `$ATLAS_HOME`: every Speed-class gate must run
+under that one home, because the key is per-home, not per-box. Overridable only for a
+signer whose `.pub` will be committed beside the records.
+
+**T5 — `.benchmarks/` carries nothing from another life.** No `bfcl-subset-[abcd]` or
+`bfcl-subset-echolp-[abcd]` dirs — one flips the gate onto the group path and it then
+demands all four. `git status --porcelain --untracked-files=all -- .benchmarks` empty: an
+untracked record from an aborted run at another sha is a `Disagreement::Commits` waiting to
+happen. Overridable for a deliberate sharded run.
+
+**T6 — subjects resolve and pins are complete.** For each required gate the
+`kernels/<hw>/<model>/BENCH.toml` entry marked `default = true` names a recipe present in
+the local index; any entry with `hermetic = "true"` pins every `gate/hermetic.rs::CLOSED_KEYS`
+pair — `gate::bench` refuses an under-pinned entry at parse time, after the serve has loaded.
+Then `ls $ATLAS_HOME/runs/ttft-{cold,warm}-gate/baseline-*.json`: absent means each TTFT gate
+needs TWO runs. State which case applies. Overridable only for the two-run question.
+
+**T7 — the BFCL scorer imports.** Run exactly what `score.py` performs:
+`$ATLAS_HOME/artifacts/bfcl/venv/bin/python -c "from bfcl_eval.constants.enums import Language; from bfcl_eval.eval_checker.ast_eval.ast_checker import ast_checker"`.
+Importing `bfcl_eval` alone proves nothing — the 1.6 h loss was a lazy transitive import.
+Overridable only if no BFCL gate is planned.
+
+**T8 — the box is free, and the tester is not counting itself.**
+`nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader` empty; `pgrep -x spark`
+empty; `pgrep -af 'release/spark serve|inference-endpoint|cargo|nvcc'` empty **after removing
+the caller's PID, its launcher line, and the pgrep itself** — `pgrep -f` matches its own argv
+and has hung a control here; prefer `-x`. `MemAvailable/MemTotal` at or above
+`bench_selfstart.rs::MIN_FREE_FRACTION`. `git worktree list` shows no other checkout of this
+branch. Overridable only for the memory fraction, with the holder named.
+
+### Timing
+**T9 — the branch has not moved where the gate looks** (not overridable).
+`scripts/campaign-guard.sh <anchor> <branch>` exits 0. Exit 1 = a perf path moved and whatever
+is running measures a dead tree; **exit 2 = could not answer, which is a stop, never a pass.**
+
+**T10 — no other PR is mid-certification.** For every other open PR whose diff touches
+`$paths`: it is mid-certification if it adds `.benchmarks/` records at a sha not on main, its
+bot comment carries `<!-- atlas-certification-state:` with `stage-2`, `stage-3` or `queued`,
+or `isInMergeQueue` is true. Two record-bearing PRs cannot share a queue group. Overridable
+when the owner is serialising by hand — name the other PR.
+
+**T11 — this PR is the top of its stack.** `gh pr list --base <head-branch> --state open`
+empty. A lower layer must not pay for certification. Overridable only when `oracle` ruled
+"one campaign per PERF_PATHS layer" — quote its verdict line.
+
+**T12 — stamp/seal sequencing.** `stamp status` and `seal status` are JOBS inside the `CI`
+run. They read the check-runs API when they execute, **a job's outputs are frozen for the
+life of its run, and a job inside an in-progress run cannot be re-run.** Therefore:
+- `/stamp` or `/seal` may be commented only when the newest `CI` run for the head sha is
+  `completed` (the handler re-runs it), OR it is in flight AND none of `stamp status`,
+  `seal status`, `PR Benchmark Certifications` has `status==completed` yet.
+- **A red `stamp status`/`seal status` is a REAL failure only if the `Stamp`/`Seal` check run
+  on the head sha was created BEFORE that job's `started_at`.** If the mark is newer than the
+  job, the red is stale; the remedy is a FULL `gh run rerun <id>` once the run completes —
+  `--failed` cannot work, because those jobs **succeeded while emitting `false`**.
+- If the bot has not yet posted "Stamp recorded." / "Seal recorded.", the state is `unknown`,
+  not red. Say "not yet processed" and how long ago the comment was posted. **Do not report a
+  failure you cannot date.**
+- `/seal` is voided by the next commit; `/stamp` survives.
+Overridable only in `pre`; never in `post`.
+
+### Agreement
+**T13 — one sha across everything the PR adds** (not overridable).
+`git diff --name-only --diff-filter=AM $(git merge-base origin/main HEAD)...HEAD -- .benchmarks`,
+then `jq -r .git_sha` on each: exactly one distinct value. `Disagreement::Commits` is "always
+fatal, every class". **`--pull-request-gate-check` does NOT ask this** — coverage and
+agreement are different questions, and it will report PASS on a set that CI rejects.
+
+**T14 — one signer per Speed class.** Same set, grouped by `registry::find(id).sensitivity`:
+Speed-class records share ONE fingerprint; Correctness-class may span boxes. Every fingerprint
+must be in `git ls-files .github/record-signers/`. The Speed split is not overridable.
+
+## Phases
+
+| phase | tests | verdicts |
+|---|---|---|
+| `pre` | T0, T1-T12 (+T13/T14 if the diff already adds records) | `CERT-GO` / `CERT-NO-GO` |
+| `begin` | T0, T1, T2, T8, T9 — the cheap re-check between verdict and launch | `CERT-GO` / `CERT-NO-GO` |
+| `during` | T0, T1, T2, T8, T9 | `CERT-CONTINUE` / `CERT-ABORT` |
+| `post` | T0, T1, T2, T9, T12, T13, T14 + the gate-check text (refuse on `NONE`, `FAIL`, `still need`) | `CERT-SEAL` / `CERT-HOLD` |
+
+## Override
+
+For tests marked overridable, with a reason and a name. You still **RUN** the test and record
+its true `observed` result; mark it `overridden` and exclude it from the verdict. State both
+verdicts on separate lines. An override claimed on a non-overridable test is refused and the
+verdict is negative — say which test, and that CI rejects the outcome regardless, so the
+override would only convert a refusal into wasted hours.
+
+## Verdict
+
+End with exactly one line:
+
+```
+CERT-GO
+CERT-NO-GO — T<n> <name>: <the one line of evidence>
+```
+
+(`CERT-CONTINUE`/`CERT-ABORT` for `during`; `CERT-SEAL`/`CERT-HOLD` for `post`.) With an
+override in force the positive line carries it — `CERT-GO (override: T10 — <reason>)` — and
+the line above reads `without override: CERT-NO-GO — T10 …`.
+
+**Anything hedged is the negative verdict.** "Probably idle", "the stamp should be processed
+by now", "the binary is likely current" — each is a test you did not finish. Saying so costs
+minutes; getting it wrong costs the campaign.
+
+## Output the caller reuses
+
+Before the verdict line, emit the JSON the skill writes into the lockfile, in a fenced
+```json block, conforming to the schema in the skill's "The JSON" section: one object per
+test in `tests`, evidence verbatim and trimmed to the deciding lines, `blocking` listing every
+failing or unknown non-overridden test. The skill copies it unchanged — make it valid JSON.
+
+## What you do not rule on
+
+Whether the stack is ordered correctly (`oracle`), whether the group is worth a campaign,
+whether the numbers pass their bars (the gate), whether a green re-run is evidence. If you
+notice one, note it in a single line under the verdict and move on.

--- a/.claude/agents/oracle_chki.md
+++ b/.claude/agents/oracle_chki.md
@@ -1,0 +1,131 @@
+---
+name: oracle_chki
+description: O.R.A.C.L.E::pre_commit_cross_hardware_check — Ownership Reach And Cross-hardware Leakage Examiner. Rules, BEFORE a commit is pushed, on whether a kernel change meant for one hardware (gb10, strix, strix-hip, metal) alters what ANOTHER hardware compiles — through a symlink, a common/ fan-out, a kernel_source redirect, or a shared KERNEL.toml / MODEL.toml / HARDWARE.toml. That is cross-hardware kernel interference, CHKI. Blocking. Use whenever scripts/check_cross_hardware.py reports CHKI or a structural violation, whenever a diff touches kernels/gb10/common/, a __SCALE__ / __HIP / __CUDA_ARCH__ arm, or cfg!(atlas_scale) host dispatch, and before writing a Hardware: or CHKI-Verdict: trailer. It rules on REMEDY — benign, parameterize in HARDWARE.toml, or a separate kernel with no symlink. Ordering is `oracle`'s question; whether the numbers pass is the gate's.
+model: opus
+tools: Bash, Read, Grep, Glob
+---
+
+# O.R.A.C.L.E::pre_commit_cross_hardware_check — Ownership Reach And Cross-hardware Leakage Examiner
+
+You rule on **one** thing: does this change alter what another hardware compiles, and if so,
+which of the three remedies is right?
+
+You exist because the tree shares kernels across hardware by three mechanisms that no path
+prefix reveals — symlinks (strix: 105 into gb10, strix-hip: 86), `common/` fan-out, and
+`[model] kernel_source` redirects — and the only signal that a gb10 edit changed AMD's compile
+has ever been a compile failure. A performance-only effect has never been visible.
+
+| incident | what happened | how it was caught |
+|---|---|---|
+| `d584c0c50` | `__syncwarp()` added to `gb10/common/w4a16_gemv.cu`, symlinked into strix and strix-hip; hipcc rejects it | ONLY because the windows-hip release leg failed. Author: "the convention was already there and I broke it." |
+| `17fe989ec` | a Strix workaround left inside gb10 common device code | invalidated 27 targets' benchmark records; full GPU re-measurement demanded |
+| 109 `__SCALE__` guards in 32 gb10-owned files | AMD branches living inside NVIDIA files — the state this check exists to unwind | never caught; it accreted |
+| `taxon.rs` comment | states the OPPOSITE policy ("kernels are shared, so an AMD port must pass both hardwares' benches in one PR") | being replaced |
+
+A wrong `CHKI-OK` costs a silent regression on a hardware with **no benchmark records, no CI
+box, and a PR compile leg for one model only**. Nobody will measure it.
+
+## What you are given
+
+Demand these verbatim; refuse to rule on a summary. If any are missing, say which and return
+`CHKI-FAIL`.
+
+- `python3 scripts/check_cross_hardware.py --base <base> --worktree --json`, in full — the
+  per-path `reach_hw`, `via` symlink chains, and `structural` findings
+- `git diff <base>...HEAD -- kernels/` — the actual hunks, not a description
+- for every reached shared file: `unifdef -k -D__SCALE__=1` (and `-U__SCALE__`) of the BEFORE
+  and AFTER file, with each reached hardware's `extra_nvcc_flags` `-D`s applied, and the diff
+- the intended hardware and the evidence for it: the `Hardware:` trailer if any, the branch,
+  the measurement in the commit body
+- `grep -rn 'atlas_scale\|atlas_hip' crates/ --include=*.rs` restricted to files in the diff
+- if a de-share is proposed: `git show <base>:<target> | sha256sum` and `sha256sum <new file>`
+
+Run read-only commands yourself. **A claim you verified outranks a claim you were handed.**
+
+## The eight questions
+
+Answer each in writing with the evidence that settles it. "Looks fine" is not an answer — name
+the file, the line, the symlink, the macro, or the sha.
+
+1. **Reach.** For every changed kernel path, which targets on which hardware consume its bytes?
+   Re-derive it: `readlink` the chain, then confirm membership **after stem-shadowing** — a real
+   file with the same stem in the consuming hardware's dir means the gb10 copy is NOT consumed
+   there (`strix-hip/qwen3.6-27b/nvfp4/w4a16_gemm.cu` is the standing example). Include headers:
+   quoted includes resolve against the **symlink's** directory, which is why strix-hip's real
+   `prefill_paged_compute.cuh` shadows gb10's even though the including `.cu` is a symlink.
+
+2. **Intent versus ownership.** Which hardware was this change made FOR, and which owns the
+   bytes? If they differ — a Strix fix written into a gb10 file — say so: that is CHKI in the
+   other direction, and the remedy is never (a).
+
+3. **Arm classification.** For each hunk in each reached shared file: inside which preprocessor
+   arm does it sit — `#if defined(__SCALE__)` / `__HIP*` (AMD-only), its `#else` (NVIDIA-only), a
+   `__CUDA_ARCH__` band, or unguarded (both)? Evidence is the `unifdef` diff per hardware, not a
+   reading of the source. `extra_nvcc_flags` differ per hardware (`-DTQ_PLUS_SIGNS` is gb10-only):
+   apply them.
+
+4. **Host dispatch.** Does any `cfg!(atlas_scale)` / `cfg(atlas_hip)` site pair with a device
+   constant this change moved? The standing pair is `BR64` (gb10 `prefill_paged_compute.cuh` = 64,
+   strix-hip's = 32) with `prefill_attn_main_a.rs`. A pairing broken on one side is interference
+   that touches no `kernels/strix*` path at all.
+
+5. **Config fan-out.** Did a symlinked `KERNEL.toml` (`strix/common/` → gb10) or `MODEL.toml`
+   (`strix-hip/qwen3.6-35b-a3b/` → gb10) carry the change? `[modules]`, `[shadow_exempt]`,
+   `[build] extra_nvcc_flags` and every behaviour key now differ for that hardware. Name the keys.
+
+6. **Performance relevance on the OTHER hardware.** For anything reaching an arm that hardware
+   compiles: does it change register use, shared memory (RDNA3.5 caps LDS at 64 KB/workgroup),
+   unroll factors, tile shapes, or intrinsics? Produce byte-identical compiled output for that
+   hardware, an empty `unifdef` diff for it, or a measurement. **"Unmeasured" is not "benign".**
+
+7. **Remedy.** Choose exactly one:
+   - **benign** — state which proof from Q6 you hold, per hardware.
+   - **parameterize** — name the `kernels/<hw>/HARDWARE.toml` key AND the reader that the SAME
+     change adds in `crates/atlas-kernels/build.rs`. **Only `vendor` and `arch` are read today**;
+     `compute_capability`, `memory_bandwidth_gbps` and `memory_gb` have no reader at all. A key
+     without a reader is decoration, and `kernels/strix/HARDWARE.toml` already forbids it in
+     writing: *"Do not re-add either key without adding a reader in the same change."*
+   - **separate** — name the file that becomes a real file in the intended tree, the file in the
+     other tree pinned at the base revision's bytes (sha256 both sides), and confirm **no symlink
+     is created**.
+
+8. **Cost of being wrong.** For THIS change: is a mistake a compile break (visible — the strix
+   release legs compile `qwen3.6-27b` only) or a performance change (invisible — no strix record
+   exists)? Say which, and whether the evidence in front of you is enough to spend it.
+
+## Verdict
+
+Exactly one line:
+
+```
+CHKI-OK — benign: <proof, per reached hardware>
+CHKI-OK — parameterize: kernels/<hw>/HARDWARE.toml <KEY>, reader crates/atlas-kernels/build.rs
+CHKI-OK — separate: <path> de-shared, <other-hw path> pinned at <base sha> bytes, no symlink
+CHKI-FAIL — <what is missing, or which question has no evidence>
+```
+
+**Anything hedged is `CHKI-FAIL`.** "Probably only NVIDIA sees it", "AMD is not a priority",
+"the guard should cover it" — each means the reach was not checked. Saying so costs a de-share
+or a define; getting it wrong costs a regression nobody will measure.
+
+## Output the caller reuses
+
+The trailer block the commit must carry:
+
+```
+Hardware: gb10, strix, strix-hip
+CHKI-Verdict: benign — unifdef -D__SCALE__ diff empty for strix and strix-hip; gb10 PTX sha256 unchanged
+```
+
+And the reach table, reproduced in the PR description:
+
+```
+| path | owner | reaches | via | remedy |
+```
+
+## What you do not rule on
+
+Whether the change is correct or fast on its OWN hardware; stack order; whether a benchmark
+threshold moves; whether the 192 grandfathered symlinks should be de-shared wholesale; anything
+under `kernels/metal/` unless a symlink into it appears (none exist). Note it in one line under
+your verdict and move on — do not let it change your remedy call.

--- a/.claude/skills/oracle_certification_state_check/SKILL.md
+++ b/.claude/skills/oracle_certification_state_check/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: oracle_certification_state_check
+description: "O.R.A.C.L.E::certification_state_check — BLOCKING pre-flight, in-flight and post-flight oracle for a benchmark certification campaign (~4.5-5 GPU-hours). Invoke BEFORE starting a certification campaign, running the gates, `spark benchmark run … --pull-request-gate`, or `queue-perf-pr.sh`; between and DURING gates; and AFTER the campaign before committing `.benchmarks/` records, commenting `/stamp` or `/seal`, or believing `stamp status` / `seal status` / `PR Benchmark Certifications`. Also invoke when a stamp or seal check looks red, when asking whether the box or GPU is free, whether the tree is frozen, whether a signer is committed, or whether records agree. Fourteen litmus tests — clean PERF_PATHS tree, frozen sha, binary built from it, ATLAS_HOME and signer, stray shard dirs, subjects and hermetic pins, BFCL scorer imports, box free with a self-filtered pgrep, campaign-guard, other PRs mid-certification, top of stack, stamp/seal job sequencing, one git_sha across added records, one Speed-class signer — each tied to the code that enforces it. Hard block with advisory overrides recorded in the gitignored lockfile `.oracle_should_begin_cert`, read on start to detect a concurrent campaign and removed on release. Born from the 2026-08-28 nine-hour campaign invalidated twenty minutes before its end, and from two same-day false reds where a /stamp or /seal status was evaluated before the bot processed the command."
+argument-hint: "<pre | begin | during | post | release | status> [--pr <N>] [--branch <name>] [--session <id>] [--override T<n>[,T<n>] --reason \"…\"] [--abandon]"
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# /oracle_certification_state_check — may this campaign start, continue, or be banked?
+
+A certification campaign is ~4.5-5 GPU-hours and the box can do nothing else while it runs.
+This skill puts a blocking oracle in front of it, beside it, and after it. The oracle is an
+`opus` subagent (`.claude/agents/oracle_cert.md`). **Give it verbatim inputs, never a
+summary**, and treat its one-line verdict as the decision.
+
+Two incidents own this file. On 2026-08-28 a nine-hour, ten-gate campaign was
+content-invalidated by a 23-line push twenty minutes into its final gate, and the loss was
+discovered at the end. And twice on one day in 2026-09 a `/stamp` or `/seal` status was read
+**before** the bot had processed the command; the stale red looked like a failure and was
+reported as one. Everything below either prevents the first or dates the second.
+
+## Reuse, not invention
+
+| question | answered by | not by |
+|---|---|---|
+| did a perf path move? | `scripts/campaign-guard.sh <anchor> <branch>` (0/1/2) | a sha compare |
+| can the box write, sign, find recipes? | `./target/release/spark doctor` | `ls -ld ~/.atlas` |
+| what got recorded? | `spark benchmark --pull-request-gate-check --pr <N>` — read the words | the gate's `rc` |
+| what counts as a perf path? | `sed -n '/pub const PERF_PATHS/,/];/p' crates/atlas-plugin/src/gate/coverage.rs` | a list copied here |
+| is another PR mid-certification? | the bot's `<!-- atlas-certification-state: -->` marker, `isInMergeQueue`, added records | a guess from titles |
+| were the stamp/seal jobs stale? | `gh api …/actions/runs/<id>/jobs` vs the `Stamp`/`Seal` check-run times | the colour of the check |
+
+The one thing this skill adds is the lockfile, because none of the above remembers that a
+campaign is in progress across sessions.
+
+## Phases
+
+```
+pre ──▶ begin ──▶ during (× many) ──▶ post ──▶ release
+ │        │            │                │
+ │        │            │                └─ CERT-SEAL: commit records, /seal
+ │        │            └─ CERT-ABORT: kill the gate, release --abandon
+ │        └─ lockfile: evaluated → running_certification
+ └─ lockfile: (none) → evaluating → evaluated
+```
+
+| verb | when | tests | writes |
+|---|---|---|---|
+| `pre` | before the first gate | T0-T12 (+T13/T14 if records already added) | creates lock `evaluating` → `evaluated` |
+| `begin` | the moment before the driver launches | T0, T1, T2, T8, T9 | `evaluated` → `running_certification`, records `driver_pid` |
+| `during` | between gates, and on a 5-min timer inside long ones | T0, T1, T2, T8, T9 | heartbeat, `current_gate`, `guard_last_rc` |
+| `post` | after the last gate, BEFORE `git add .benchmarks`, BEFORE `/seal` | T0, T1, T2, T9, T12, T13, T14 + gate-check text | the `post` verdict |
+| `release` | after `post` returned `CERT-SEAL` and records are pushed; or `--abandon --reason` | T0 | renames the lock to `.released.<ts>` |
+| `status` | any time | none | nothing — prints the lock and its liveness |
+
+`pre` is the default when no verb is given.
+
+## Step 0 — read the lockfile before anything else
+
+Every verb starts here. The file is `<repo-root>/.oracle_should_begin_cert` (gitignored).
+
+```bash
+root=$(git rev-parse --show-toplevel); lock="$root/.oracle_should_begin_cert"
+[ -f "$lock" ] && jq . "$lock"
+```
+
+Then, in this order:
+
+1. **No file, verb `pre`** → create it (below).
+2. **No file, any other verb** → refuse: "no campaign is locked here; run `pre` first".
+   Never create a lockfile from `begin`/`during`/`post`.
+3. **File exists, LIVE, and not yours** → refuse, printing the owner block verbatim. **No
+   override bypasses a live lock**; wait, or kill the named driver.
+4. **File exists, yours, status matches the verb** → proceed.
+5. **File exists and is STALE** → **do not delete it.** Rename to
+   `.oracle_should_begin_cert.stale.<utc-ts>`, print the reason, and (for `pre` only) create a
+   fresh lock whose `superseded` field records the old path and reason. For any other verb,
+   refuse — a stale lock under `begin`/`during`/`post` means the campaign it described is gone.
+
+### How stale is stale — liveness beats age
+
+A lock whose campaign is demonstrably running is never stale, however old.
+
+| status | stale when |
+|---|---|
+| `evaluating` | `updated_at` older than **20 min** (an evaluation takes 2-5) |
+| `evaluated` | `expires_at` passed (**90 min**), OR `anchor_sha` != `git rev-parse HEAD`, OR `campaign-guard.sh` exits non-zero — a verdict describes one sha on one branch |
+| `running_certification` | **ALL** of: `kill -0 <driver_pid>` fails; `pgrep -x spark` empty; `nvidia-smi --query-compute-apps` empty; heartbeat older than **30 min**. Any one liveness signal positive → LIVE. If LIVE and started >12 h ago, still LIVE — print "runaway?" with the pid and let a human decide. |
+
+## `pre` — create, evaluate, record
+
+**Create atomically.** `ln(2)` fails `EEXIST` for exactly one of two racing sessions:
+
+```bash
+sid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ); tmp="$lock.$$.tmp"
+jq -n --arg sid "$sid" --arg now "$now" --arg host "$(hostname)" --arg user "$(id -un)" \
+      --arg cwd "$root" --arg br "$BRANCH" --arg sha "$(git rev-parse HEAD)" \
+      --arg home "${ATLAS_HOME:-$HOME/.atlas}" '{
+  schema:"oracle_should_begin_cert/v1", status:"evaluating",
+  created_at:$now, updated_at:$now, expires_at:null,
+  owner:{session_id:$sid, hostname:$host, user:$user, cwd:$cwd},
+  campaign:{pr:null, branch:$br, anchor_sha:$sha, atlas_home:$home, driver_pid:null,
+            driver_cmdline:null, started_at:null, current_gate:null, gates_done:[],
+            heartbeat_at:null, guard_last_rc:null},
+  oracle:null, overrides:[], history:[], superseded:null }' > "$tmp"
+if ln "$tmp" "$lock" 2>/dev/null; then rm -f "$tmp"; echo "locked as $sid"
+else rm -f "$tmp"; echo "LOST THE RACE"; jq . "$lock"; exit 1; fi
+```
+
+Keep `$sid` — every later verb passes `--session $sid`.
+
+**Spawn the oracle** (`Agent`, `subagent_type: oracle_cert`) with, verbatim: the phase; the
+lockfile contents; `$sid`; PR, branch, anchor sha, `$ATLAS_HOME`; your own `$$` and the
+launcher line you will use; the exact override claim if any.
+
+**Record**: re-read the lock, confirm `owner.session_id` is still `$sid` (if not, another
+session superseded you — stop and print both), then write via temp + `mv -f`: `status=evaluated`,
+`expires_at` = now + 90 min, `oracle` = the JSON, append `history`.
+
+On `CERT-NO-GO` the lock **stays** as `evaluated` with the negative verdict, so a second
+session sees that a campaign was attempted and why.
+
+## `begin` — the read-on-start race check
+
+Lock must be yours, `evaluated`, unexpired, verdict GO. Spawn the oracle for phase `begin`
+(seconds). **This is the window between verdict and launch** in which a co-tenant can appear
+or the branch can move — the second half of "read on start". On `CERT-GO`, launch the driver,
+capture its PID, and write `status=running_certification` with `driver_pid`, `driver_cmdline`,
+`started_at`, `heartbeat_at`, `expires_at=null`.
+
+The driver runs this itself between Claude ticks, because a 1.6 h BFCL leg must not wait for
+an agent turn:
+
+```bash
+scripts/campaign-guard.sh "$ANCHOR" "$BRANCH"; rc=$?
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg g "$g" --argjson rc $rc \
+   '.campaign.heartbeat_at=$now|.updated_at=$now|.campaign.current_gate=$g|.campaign.guard_last_rc=$rc' \
+   "$lock" > "$lock.$$.tmp" && mv -f "$lock.$$.tmp" "$lock"
+[ $rc -eq 0 ] || { pkill -x spark; echo "ABORT: guard rc=$rc"; exit 1; }
+```
+
+`pkill -x`, never `pkill -f` — the latter has killed its own shell here.
+
+## `during` — continue or abort
+
+Lock yours, `running_certification`, LIVE. The oracle re-runs the guard, the clean-tree check,
+the anchor check (someone checking out another sha **in this worktree** is the same loss as a
+push), and the box check. On `CERT-ABORT`: **kill the running gate rather than let it finish**
+— a completed record for a superseded tree is the mistake repeated — then
+`release --abandon --reason "<verdict line>"`.
+
+## `post` — may the records be banked?
+
+Run `spark benchmark --pull-request-gate-check --pr <N>` and hand the oracle the full text.
+Its rule: refuse on `NONE`, `FAIL`, or `still need` — **`rc` is not the evidence**. The oracle
+adds T13 (one `git_sha` across added records — the gate check does not ask this) and T14 (one
+Speed-class signer). On `CERT-SEAL`: commit and push the records, wait for the `CI` run on the
+new head to reach the point T12 allows, **then** comment `/seal`, then `release`.
+
+## Overrides — advisory, recorded, never silent
+
+```
+/oracle_certification_state_check pre --pr 951 --override T10 --reason "owner serialising #946 by hand"
+```
+
+- The oracle still **runs** the overridden test and records its true `observed`.
+- Both verdicts are printed and stored: `verdict` and `verdict_without_override`.
+- Written twice: inside `oracle.override`, and appended to top-level `overrides[]`, never trimmed.
+- `by` is `git config user.email` plus hostname; an empty `--reason` is refused.
+- **Never overridable**: T0, T1, T3, T9, T13, the Speed-signer half of T14, and T12 in `post`.
+  Each is a case where CI rejects the outcome anyway, so the override would only buy wasted hours.
+- Quote any override verbatim in the wave report and the PR evidence comment. **An override
+  nobody can see afterwards is not advisory, it is a bypass.**
+
+## The JSON
+
+Returned to the caller and stored unchanged under `oracle` in the lockfile. ISO-8601 UTC `Z`.
+
+```json
+{
+  "schema": "oracle_certification_state_check/v1",
+  "phase": "pre|begin|during|post",
+  "verdict": "GO|NO-GO|CONTINUE|ABORT|SEAL|HOLD",
+  "verdict_line": "CERT-GO (override: T10 — owner serialising #946 by hand)",
+  "verdict_without_override": "NO-GO",
+  "evaluated_at": "2026-09-11T14:02:11Z",
+  "evaluation_ms": 41830,
+  "subject": {
+    "repo_root": "…", "pr": 951, "branch": "…", "head_sha": "…",
+    "origin_branch_sha": "…", "origin_main_sha": "…", "merge_base": "…",
+    "atlas_home": "…", "signer_fingerprint": "…", "signer_committed": true,
+    "hostname": "dgx2", "caller_pid": 412233, "caller_launcher": "…"
+  },
+  "tests": [{
+    "id": "T1", "name": "clean-perf-tree",
+    "group": "lock|sha|tree|agreement|timing|environment",
+    "result": "pass|fail|unknown|skipped|overridden",
+    "observed": "pass|fail|unknown|skipped",
+    "overridable": false, "overridden": false,
+    "command": "git status --porcelain --untracked-files=all -- …",
+    "evidence": "", "mechanism": "gate/mod.rs::dirty_perf_paths → check.rs fails a dirty-tree record",
+    "remedy": "commit or stash, rebuild, re-run pre",
+    "checked_at": "2026-09-11T14:01:40Z"
+  }],
+  "blocking": ["T10"],
+  "override": { "tests": ["T10"], "reason": "…", "by": "…@dgx2", "at": "…Z", "invocation": "…" },
+  "notes": ["TTFT baselines present for both gates; single runs suffice"],
+  "next": "run: /oracle_certification_state_check begin --session 6f1c… --pr 951"
+}
+```
+
+`result` is `overridden` iff `overridden`, and then `observed` holds the real outcome.
+`blocking` is every test whose `result` is `fail` or `unknown`. `override` is `null` when none
+was claimed.
+
+## What the lockfile can and cannot promise
+
+It is a file, not a mutex. Exactly:
+
+- **Creation is atomic** on a local filesystem (`ln` → `EEXIST`), so two `pre` invocations in
+  one checkout cannot both own a lock.
+- **Every rewrite re-checks ownership**, and `begin` re-runs the cheap tests, so the window
+  between verdict and launch is covered on both ends. What remains is the interval between
+  `begin` writing `running_certification` and the driver's first `spark serve` appearing on the
+  GPU (model load, minutes) — another checkout's `pre` in that window sees a free GPU.
+- **The lock is per checkout, not per box.** A second worktree has its own root and its own
+  lockfile. The box-level guard is T8 (GPU, `pgrep -x spark`, memory), which is real but polls.
+- **It does not stop a human** running `spark benchmark run` by hand, nor a push from another
+  machine — that is `campaign-guard.sh`'s job, and why `during` is on a timer.
+- **GitHub state lags.** T10 reads the marker and queue flag as of now.
+- **Session identity is a uuid you carry**, not a pid: each Bash call is a new shell. The
+  driver's pid is the only long-lived one, and it is the liveness signal.
+
+What the skill does about the residual TOCTOU: both sides re-read (`begin`, and the oracle's
+T0), evidence is kept rather than deleted (`.stale.*`, `.released.*`), "could not tell" is
+treated as "not safe", and the expensive guard runs on a timer inside the driver where no agent
+turn is needed.
+
+## Where this sits
+
+- `oracle` rules on stack ORDER before registration; this rules on STATE before the GPU is
+  spent. Different questions, both blocking.
+- `/measurement-discipline` governs the numbers a record carries; this governs whether the
+  record may exist.

--- a/.claude/skills/oracle_pre_commit_cross_hardware_check/SKILL.md
+++ b/.claude/skills/oracle_pre_commit_cross_hardware_check/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: oracle_pre_commit_cross_hardware_check
+description: "O.R.A.C.L.E::pre_commit_cross_hardware_check — run BEFORE pushing any commit that touches kernels/ (especially kernels/gb10/common/), a __SCALE__ / __HIP / __CUDA_ARCH__ arm, cfg!(atlas_scale) or cfg(atlas_hip) host dispatch, a KERNEL.toml / MODEL.toml / HARDWARE.toml, or a symlink under kernels/. Detects cross-hardware kernel interference (CHKI): a change meant for one hardware (gb10, strix, strix-hip, metal) that alters what another hardware compiles through symlinks, common/ fan-out, or kernel_source redirects — strix is 7 real files and 105 symlinks into gb10, so a gb10 edit silently changes what AMD builds. Runs the static reach check, gathers verbatim evidence, launches the oracle for the remedy verdict (benign / parameterize in HARDWARE.toml with a reader / separate kernel with no symlink), and writes the Hardware: and CHKI-Verdict: trailers the CI job cross-hardware-reach requires. Also use when that CI job is red, when a strix or strix-hip compile leg fails on a gb10 edit, or when tempted to add a __SCALE__ guard to a gb10 file. Born from d584c0c50 (a gb10 edit broke hipcc, caught only by a compile leg) and 17fe989ec (a Strix workaround in gb10 common code invalidated 27 targets' records)."
+argument-hint: "[<base-ref>=origin/main] [--staged | --range A..B | --paths p1 p2 ...]"
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# /oracle_pre_commit_cross_hardware_check — CHKI before push
+
+One question, answered before `git push`: **did this change alter another hardware's compiled
+inputs, and what is the remedy?** The static half is provable and runs in seconds; the
+judgement half goes to the `opus` agent `.claude/agents/oracle_chki.md`. The CI job
+`cross-hardware-reach` runs the same script and will fail the PR on anything this procedure
+would have caught — so run it here first.
+
+Why it exists, in two lines: `d584c0c50` (a gb10 edit broke hipcc, caught **only** because a
+compile leg failed) and `17fe989ec` (a Strix workaround in gb10 common code invalidated 27
+benchmark records). A performance-only leak has never been visible at all.
+
+## Step 1 — the static check (seconds, no GPU, no cargo)
+
+```bash
+python3 scripts/check_cross_hardware.py --base "${1:-origin/main}" --worktree
+```
+
+Modes: `--staged`, `--range A..B`, `--paths ...` (attribution only, never fails).
+
+Read the table. Every row saying `CHKI` or `DECLARED`, and every `structural:` finding, is an
+input to Step 3. **If the verdict is `OK` and no row is `DECLARED`, you are done — do not
+invent work.**
+
+`S1` (new cross-hardware symlink) and `S4` (dangling symlink) cannot be declared away. Replace
+the symlink with a real file, or restore the target, then re-run.
+
+Exit codes: `0` clean · `1` violation · `2` **cannot see the inputs**, which is as red as `1`
+— the same doctrine as `campaign-guard.sh`'s exit 2.
+
+## Step 2 — gather the verbatim inputs
+
+The oracle refuses summaries. Collect all of it:
+
+```bash
+python3 scripts/check_cross_hardware.py --base "$BASE" --worktree --json
+git diff "$BASE"...HEAD -- kernels/
+git log --format=%B "$BASE"..HEAD | grep -E '^(Hardware|CHKI-Verdict):' || true
+git diff --name-only "$BASE"...HEAD -- crates/ | xargs -r grep -ln 'atlas_scale\|atlas_hip' || true
+```
+
+For every file whose `reach_hw` has more than one entry, per reached AMD hardware:
+
+```bash
+git show "$BASE:$F" > /tmp/before.cu
+unifdef -k -D__SCALE__=1 /tmp/before.cu > /tmp/b.amd; unifdef -k -D__SCALE__=1 "$F" > /tmp/a.amd
+diff -u /tmp/b.amd /tmp/a.amd | wc -l      # 0 = the text AMD sees is unchanged
+unifdef -k -U__SCALE__  /tmp/before.cu > /tmp/b.nv;  unifdef -k -U__SCALE__  "$F" > /tmp/a.nv
+diff -u /tmp/b.nv /tmp/a.nv | wc -l        # 0 = the text NVIDIA sees is unchanged
+```
+
+If `unifdef` is absent, say so in the prompt — the oracle will classify arms by hand and hold
+you to a stricter proof. If `nvcc` is present, add a PTX sha256 before/after for the gb10 side.
+
+## Step 3 — launch the oracle
+
+Launch `oracle_chki` with everything from Step 2 pasted verbatim, plus one sentence naming the
+intended hardware and the evidence for it. Wait for exactly one verdict line. **Anything hedged
+is `CHKI-FAIL`.** On `CHKI-FAIL`, fix what it names and return to Step 1 — do not re-prompt for
+a softer answer.
+
+## Step 4 — apply the remedy
+
+**benign** — nothing changes in `kernels/`. Go to Step 5.
+
+**parameterize** — in the SAME commit: add the key to `kernels/<hw>/HARDWARE.toml`; add the
+reader in `crates/atlas-kernels/build.rs` beside the `arch`/`vendor` reads; replace the
+`__SCALE__` branch with `#if KEY == VALUE`. ★ Only `vendor` and `arch` are read today — a key
+with no reader is decoration, and `kernels/strix/HARDWARE.toml` says so in writing.
+
+**separate** — never a symlink: the intended hardware gets the changed kernel as a REAL file;
+every other hardware whose symlink pointed at it gets a real copy of the BASE bytes, proven by
+`sha256sum` on both sides. Then run `python3 scripts/check_kernel_shadows.py` — RULE 1 still
+applies within the hardware you just wrote into.
+
+## Step 5 — trailers, then re-run
+
+```
+Hardware: <every hardware in the reach table, comma-separated>
+CHKI-Verdict: <benign|parameterized|de-shared> — <the oracle's proof line>
+```
+
+Then `python3 scripts/check_cross_hardware.py --base "$BASE" --worktree` must print
+`verdict: OK`. Paste the reach table into the PR description; if the PR will be squash-merged,
+copy both trailers into the PR body too.
+
+## Do not
+
+- **Do not add a `__SCALE__` / `__HIP*` guard to a gb10-owned file as the remedy.** That is the
+  state this check exists to unwind; it passes only as `DECLARED`, and the oracle will send it
+  to (b) or (c).
+- **Do not create a symlink under `kernels/` that resolves into another hardware's tree.** S1
+  fails it with no override.
+- **Do not write `Hardware:` from memory.** Copy the reach column; R1 fails on any hardware you
+  omit, including the one that owns the bytes.
+- **Do not call a change benign for strix because "nobody can measure strix".** Unmeasured is
+  `CHKI-FAIL`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,66 @@ jobs:
       # violation. Stdlib-only; the runner's system python3 suffices.
       - run: python3 scripts/check_kernel_shadows.py
 
+  cross-hardware-reach:
+    name: cross-hardware kernel reach (CHKI)
+    runs-on: >-
+      ${{ vars.USE_AVAROK_UBUNTU_RUNNERS == '1'
+          && (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (vars.PR_CHEAP_RUNNER || 'ubuntu-latest')
+          || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history: the check reads file bytes at HEAD (symlink
+          # resolution, lexical include walk) and needs the base to diff.
+          fetch-depth: 0
+      # Which hardware compiles the bytes this diff changed? `taxon::hardware_of`
+      # is a path prefix and cannot see that kernels/strix/common/*.cu are 105
+      # symlinks into kernels/gb10/common/, so a gb10 edit reads as gb10-only
+      # while hipcc compiles it verbatim. d584c0c50 was caught ONLY because a
+      # release compile leg failed; a performance-only leak has no leg at all.
+      #
+      # FAIL-CLOSED, unlike classify-diff.sh: that script decides what to SKIP
+      # and must fail open; this decides a VERDICT. rc 2 (cannot see inputs) is
+      # as red as rc 1, the same doctrine as campaign-guard.sh's exit 2. The
+      # script runs RED/GREEN self-fixtures first and refuses to scan if any
+      # rule cannot fire.
+      #
+      # Passing honestly costs one trailer pair, written after running
+      # /oracle_pre_commit_cross_hardware_check. Stdlib python3, no GPU, no cargo.
+      - name: Cross-hardware reach of changed kernel paths
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          # Through the environment, never interpolated into the script text:
+          # the body is attacker-controlled on a fork PR and is read only for a
+          # `Hardware:` / `CHKI-Verdict:` trailer.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              git fetch --no-tags origin "${PR_BASE_REF}"
+              python3 scripts/check_cross_hardware.py --base "origin/${PR_BASE_REF}" \
+                      --head "${PR_HEAD_SHA}" --merge-base ;;
+            merge_group)
+              python3 scripts/check_cross_hardware.py --base "${MG_BASE_SHA}" --head "${MG_HEAD_SHA}" ;;
+            push)
+              base="${PUSH_BEFORE}"
+              case "$base" in 0000000000000000000000000000000000000000|"") base="${GITHUB_SHA}~1" ;; esac
+              python3 scripts/check_cross_hardware.py --base "$base" --head "${GITHUB_SHA}" ;;
+            *)
+              # No diff to attribute; the self-fixtures and the consumer index
+              # still run, so a tree that cannot be indexed fails here too.
+              python3 scripts/check_cross_hardware.py --paths ;;
+          esac
+
   bench-threshold-prose:
     name: BENCH.toml threshold prose
     runs-on: ubuntu-latest
@@ -749,11 +809,12 @@ jobs:
           needs.license-headers.result == 'success' &&
           needs.typos.result == 'success' &&
           needs.kernel-structure.result == 'success' &&
+          needs.cross-hardware-reach.result == 'success' &&
           (needs.clippy.result == 'success' || needs.clippy.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.test-macos-metal.result == 'success' || needs.test-macos-metal.result == 'skipped') &&
           needs.stamp.outputs.stamped != 'false' }}
-    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
+    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, cross-hardware-reach, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
       version: 0.0.0-pr${{ github.event.number || 'queue' }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ docker/gb10/spark-fastbin
 # scratch; everything else under .claude/ stays ignored.
 .claude/*
 !.claude/skills/
+# `.claude/agents/` likewise: an agent file is a blocking review contract
+# (.claude/agents/oracle*.md), and a gate nobody can read is not a gate.
+!.claude/agents/
 .gemini/
 .agent*/
 .codex/
@@ -156,3 +159,7 @@ bench/ngram_ref/ngram_golden.npz
 *.swp
 bench/qwen4_exp/qwen4exp_forward_golden.npz
 .ncclstub
+
+# The certification-state oracle's per-checkout campaign lockfile, and its
+# .stale./.released. rotations. An interlock, never meant to travel.
+/.oracle_should_begin_cert*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,47 @@ bash scripts/check-license-headers.sh
 
 # 4. Typos
 typos  # crate-ci/typos — install once, `cargo install typos-cli`
+
+# 5. Cross-hardware kernel reach — ONLY if the diff touches kernels/.
+#    kernels/<hw>/ looks like one tree per hardware and is not: strix is 7 real
+#    files and 105 symlinks into kernels/gb10/common/. A gb10 edit therefore
+#    changes what AMD compiles, and the CI job `cross-hardware kernel reach
+#    (CHKI)` will say so.
+python3 scripts/check_cross_hardware.py --base origin/main --worktree
 ```
 
 A real build + test cycle requires a CUDA-capable host; see
 [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### If the diff touches a perf path
+
+`crates`, `kernels`, `Cargo.*`, `vendor`, `jinja-templates`, `rust-toolchain.toml`,
+`3rdparty_patches` — the gate's `PERF_PATHS` — mean the PR owes a benchmark certification
+campaign of **~4.5–5 GPU-hours**, and campaigns have been wasted. Before spending one, and
+again before reading `stamp status` / `seal status`, committing `.benchmarks/` records, or
+commenting `/stamp` or `/seal`:
+
+```
+/oracle_certification_state_check pre --pr <N>     # then: begin → during → post → release
+```
+
+It is a blocking oracle (`.claude/agents/oracle_cert.md`) running fourteen litmus tests —
+clean perf tree, frozen sha, binary built from it, `spark doctor`, stray shard dirs, hermetic
+pins, BFCL scorer imports, box free, `campaign-guard.sh`, other PRs mid-certification, top of
+stack, stamp/seal job sequencing, one `git_sha` across added records, one Speed-class signer —
+and holding the gitignored lockfile `.oracle_should_begin_cert` for the life of the campaign.
+Overrides exist for what it cannot see and are recorded in the lockfile; quote them in the PR.
+
+★ **A red `stamp status` or `seal status` is not a failure until it is dated.** Those jobs
+freeze their outputs for the life of a CI run, so a mark minted *after* they ran leaves them
+red until a FULL `gh run rerun <id>` — `--failed` cannot work, because they *succeeded* while
+emitting `false`. The oracle's T12 does the dating; do not do it by eye.
+
+For a `kernels/` change that reaches a second hardware, run
+`/oracle_pre_commit_cross_hardware_check` before pushing: it chooses the remedy (benign,
+parameterize in `kernels/<hw>/HARDWARE.toml` **with a reader added in the same change**, or a
+separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers CI
+requires.
 
 ## Adding a new model
 

--- a/scripts/check_cross_hardware.py
+++ b/scripts/check_cross_hardware.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Cross-hardware kernel interference (CHKI): who else compiles the bytes you changed?
+
+`kernels/<hw>/` LOOKS like one tree per hardware. It is not. strix is 7 real files and
+105 symlinks, 97 of them into `kernels/gb10/common/`; strix-hip is 22 real and 87
+symlinks. So an edit to a gb10 file silently changes what AMD compiles, and the only
+signal has ever been a compile failure:
+
+  d584c0c50  `__syncwarp()` added to gb10/common/w4a16_gemv.cu, which is symlinked into
+             strix and strix-hip; hipcc rejects it. Caught ONLY because the windows-hip
+             release leg failed. A performance-only effect would have been invisible.
+  17fe989ec  A Strix workaround left inside gb10 common device code invalidated 27
+             targets' benchmark records and forced a full GPU re-measurement.
+
+`gate/taxon.rs::hardware_of()` cannot see any of this — it is a path prefix. This script
+resolves the three real sharing mechanisms (symlinks, `common/` fan-out, `[model]
+kernel_source` redirects, plus symlinked KERNEL.toml/MODEL.toml) and says which hardware
+actually consumes each changed path.
+
+WHY IT IS FAIL-CLOSED, unlike classify-diff.sh: that script decides what to SKIP and must
+fail open. This one decides a VERDICT. "Cannot see the inputs" (rc 2) is as red as a
+violation (rc 1) — the same doctrine as campaign-guard.sh's exit 2.
+
+WHAT IT CANNOT DECIDE, and hands to the oracle
+(.claude/skills/oracle_pre_commit_cross_hardware_check): whether a hunk sits inside a
+`#if defined(__SCALE__)` arm the other hardware never compiles; whether a `cfg!(atlas_scale)`
+host site pairs with a device constant you moved; and whether a textually-shared change is
+performance-relevant to a hardware with no benchmark record and no CI box. Reach is provable;
+harm is not.
+"""
+import argparse, json, os, subprocess, sys, tempfile
+from pathlib import Path
+
+HW_SOURCE_EXT = {"gb10": ".cu", "metal": ".metal", "strix": ".cu", "strix-hip": ".cu"}
+CONFIG_NAMES = {"HARDWARE.toml", "KERNEL.toml", "MODEL.toml"}
+AMD_TOKENS = ("__SCALE__", "__HIPCC__", "__HIP_DEVICE_COMPILE__", "__HIP_PLATFORM")
+
+
+def git(*a, cwd=None, check=True):
+    r = subprocess.run(["git", *a], cwd=cwd, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(a)}: {r.stderr.strip()}")
+    return r.stdout
+
+
+def hardware_of(path):
+    p = Path(path).parts
+    return p[1] if len(p) > 1 and p[0] == "kernels" else None
+
+
+def kernel_source(model_dir):
+    """`[model] kernel_source = "other"` redirects where a model's quant dirs are read from."""
+    mt = model_dir / "MODEL.toml"
+    if not mt.exists():
+        return None
+    for line in mt.read_text(errors="replace").splitlines():
+        s = line.split("#", 1)[0].strip()
+        if s.startswith("kernel_source"):
+            v = s.split("=", 1)[1].strip().strip('"').strip("'")
+            return v or None
+    return None
+
+
+def quoted_includes(path):
+    """Quoted #includes, resolved LEXICALLY against the file's own directory.
+
+    Lexical, not canonical, because nvcc is handed the SYMLINK path (build.rs passes the
+    read_dir entry and sets no -I), so `#include "x.cuh"` inside a symlinked .cu resolves
+    against the LINKING hardware's dir. That is how strix-hip's real prefill_paged_compute.cuh
+    (BR64 32) shadows gb10's (BR64 64) even though the .cu including it is a symlink.
+    """
+    out = []
+    try:
+        txt = Path(path).read_text(errors="replace")
+    except OSError:
+        return out
+    for line in txt.splitlines():
+        s = line.strip()
+        if s.startswith("//") or not s.startswith("#include"):
+            continue
+        rest = s[len("#include"):].strip()
+        if not rest.startswith('"'):
+            continue
+        end = rest.find('"', 1)
+        if end > 1:
+            out.append(rest[1:end])
+    return out
+
+
+def build_index(root):
+    """realpath -> set of (hw, model, quant) targets that consume it."""
+    kroot = root / "kernels"
+    missing = [h for h in HW_SOURCE_EXT if not (kroot / h).is_dir()]
+    if missing:
+        raise RuntimeError(f"hardware tree(s) absent from {kroot}: {', '.join(missing)} "
+                           f"— refusing to scan a tree I cannot index")
+    consumers, targets = {}, []
+    for hw, ext in HW_SOURCE_EXT.items():
+        hwdir = kroot / hw
+        if not (hwdir / "HARDWARE.toml").exists():
+            continue
+        common = hwdir / "common"
+        for model_dir in sorted(p for p in hwdir.iterdir() if p.is_dir() and p.name != "common"):
+            if not (model_dir / "MODEL.toml").exists():
+                continue
+            src_dir = model_dir
+            ks = kernel_source(model_dir)
+            if ks:
+                cand = hwdir / ks
+                if not (cand / "MODEL.toml").exists():
+                    # unresolved redirect: fail closed, this model reaches everything on hw
+                    src_dir = hwdir
+                else:
+                    src_dir = cand
+            for quant_dir in sorted(p for p in src_dir.iterdir() if p.is_dir()):
+                t = (hw, model_dir.name, quant_dir.name)
+                targets.append(t)
+                # stem-keyed merge: common first, the model's quant dir SHADOWS it
+                merged = {}
+                for d in (common, quant_dir):
+                    if d.is_dir():
+                        for f in sorted(d.glob(f"*{ext}")):
+                            merged[f.stem] = f
+                seen = set()
+                for f in list(merged.values()):
+                    stack = [f]
+                    while stack:
+                        cur = stack.pop()
+                        rp = os.path.realpath(cur)
+                        if rp in seen:
+                            continue
+                        seen.add(rp)
+                        consumers.setdefault(rp, set()).add(t)
+                        for inc in quoted_includes(cur):
+                            cand = Path(cur).parent / inc
+                            if cand.exists():
+                                stack.append(cand)
+                for cfg in (hwdir / "HARDWARE.toml", common / "KERNEL.toml",
+                            model_dir / "MODEL.toml", quant_dir / "KERNEL.toml"):
+                    if cfg.exists():
+                        consumers.setdefault(os.path.realpath(cfg), set()).add(t)
+    return consumers, targets
+
+
+def changed_paths(root, base, head, three_dot, worktree):
+    if worktree:
+        spec = [base]
+    else:
+        spec = [f"{base}...{head}"] if three_dot else [f"{base}..{head}"] if head else [base]
+    out = git("diff", "--name-status", "--no-renames", *spec, "--", "kernels/", cwd=root)
+    rows = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            rows.append((parts[0][0], parts[-1]))
+    return rows
+
+
+def symlink_via(root, realpath_target):
+    """Every symlink under kernels/ that resolves to this file, for the operator."""
+    via = []
+    kroot = root / "kernels"
+    for dirpath, dirnames, filenames in os.walk(kroot):
+        for n in list(dirnames) + filenames:
+            p = Path(dirpath) / n
+            if p.is_symlink() and os.path.realpath(p) == realpath_target:
+                via.append((str(p.relative_to(root)), os.readlink(p)))
+    return via
+
+
+def trailers(root, base, head):
+    """`Hardware:` and `CHKI-Verdict:` over BASE..HEAD, plus PR_BODY if present."""
+    hw, verdict = set(), ""
+    try:
+        body = git("log", "--format=%B", f"{base}..{head or 'HEAD'}", cwd=root, check=False)
+    except Exception:
+        body = ""
+    body += "\n" + os.environ.get("PR_BODY", "")
+    for line in body.splitlines():
+        s = line.strip()
+        if s.lower().startswith("hardware:"):
+            hw |= {t.strip() for t in s.split(":", 1)[1].split(",") if t.strip()}
+        elif s.lower().startswith("chki-verdict:"):
+            verdict = s.split(":", 1)[1].strip()
+    return hw, verdict
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--base")
+    ap.add_argument("--head")
+    ap.add_argument("--merge-base", action="store_true", help="three-dot diff (pull_request)")
+    ap.add_argument("--worktree", action="store_true", help="include uncommitted changes")
+    ap.add_argument("--paths", nargs="*", help="attribution only; never fails on R1")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-selftest", action="store_true")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    try:
+        if not args.no_selftest:
+            selftest()
+        consumers, targets = build_index(root)
+    except Exception as e:
+        print(f"cross-hardware: CANNOT SEE INPUTS — {e}", file=sys.stderr)
+        return 2
+
+    attribution_only = args.paths is not None
+    if attribution_only:
+        rows = [("M", p) for p in args.paths]
+    else:
+        if not args.base:
+            print("cross-hardware: no base given", file=sys.stderr)
+            return 2
+        try:
+            rows = changed_paths(root, args.base, args.head, args.merge_base, args.worktree)
+        except Exception as e:
+            print(f"cross-hardware: CANNOT SEE INPUTS — {e}", file=sys.stderr)
+            return 2
+
+    declared, verdict_trailer = (set(), "") if attribution_only else trailers(root, args.base, args.head)
+    results, structural = [], []
+
+    for status, rel in rows:
+        owner = hardware_of(rel)
+        if owner is None:
+            continue
+        ap_ = root / rel
+        rp = os.path.realpath(ap_) if ap_.exists() else str(ap_)
+        reach = consumers.get(rp, set())
+        reach_hw = sorted({t[0] for t in reach})
+        leak = sorted(set(reach_hw) - {owner})
+
+        # S1: a NEW symlink that crosses hardware is never allowed.
+        if status in ("A", "T") and ap_.is_symlink():
+            tgt_hw = hardware_of(os.path.relpath(os.path.realpath(ap_), root))
+            if tgt_hw and tgt_hw != owner:
+                structural.append(("S1", rel, f"new cross-hardware symlink -> {tgt_hw}"))
+
+        if attribution_only:
+            v = "ATTRIBUTION"
+        elif not leak:
+            v = "OK"
+        elif not declared:
+            v = f"CHKI (undeclared: {', '.join(leak)})"
+        elif not (set(reach_hw) | {owner}) <= declared:
+            miss = sorted((set(reach_hw) | {owner}) - declared)
+            v = f"CHKI (unnamed: {', '.join(miss)})"
+        else:
+            v = f"DECLARED ({', '.join(leak)})"
+        results.append({"path": rel, "status": status, "owner": owner,
+                        "reach_hw": reach_hw, "targets": len(reach),
+                        "via": [f"{a} -> {b}" for a, b in symlink_via(root, rp)] if leak else [],
+                        "verdict": v})
+
+    # S4: dangling symlinks anywhere under kernels/
+    for dirpath, dirnames, filenames in os.walk(root / "kernels"):
+        for n in list(dirnames) + filenames:
+            p = Path(dirpath) / n
+            if p.is_symlink() and not p.exists():
+                structural.append(("S4", str(p.relative_to(root)), f"dangling -> {os.readlink(p)}"))
+
+    bad = [r for r in results if r["verdict"].startswith("CHKI")]
+    declared_rows = [r for r in results if r["verdict"].startswith("DECLARED")]
+    needs_verdict = bool(declared_rows) and not verdict_trailer
+
+    if args.json:
+        print(json.dumps({"base": args.base, "head": args.head,
+                          "trailers": {"hardware": sorted(declared), "verdict": verdict_trailer},
+                          "paths": results,
+                          "structural": [{"rule": a, "path": b, "detail": c} for a, b, c in structural],
+                          "verdict": "OK" if not (bad or structural or needs_verdict) else "CHKI"},
+                         indent=2))
+    else:
+        print(f"cross-hardware reach: {len(results)} changed kernel path(s)")
+        for r in results:
+            print(f"  {r['path']:<58} {r['owner']:<10} {','.join(r['reach_hw']) or '-':<22} "
+                  f"{r['targets']:>4}  {r['verdict']}")
+            for v in r["via"]:
+                print(f"      via: {v}")
+        for a, b, c in structural:
+            print(f"  {a} {b}: {c}")
+        print(f"Hardware trailer: {', '.join(sorted(declared)) or '(none)'}    "
+              f"CHKI-Verdict: {verdict_trailer or '(none)'}")
+        if attribution_only:
+            print("verdict: ATTRIBUTION (no pass/fail in --paths mode)")
+        elif bad or structural or needs_verdict:
+            print("verdict: CHKI")
+            print("next: /oracle_pre_commit_cross_hardware_check, then ONE of")
+            print("  (a) Hardware: <every reached hw>  +  CHKI-Verdict: benign -- <proof>")
+            print("  (b) parameterize in kernels/<hw>/HARDWARE.toml AND add the reader in")
+            print("      crates/atlas-kernels/build.rs in the SAME change (only `vendor` and")
+            print("      `arch` are read today; a key with no reader is decoration)")
+            print("  (c) separate kernel in the intended tree, pinned to base bytes, NO symlink")
+        else:
+            print("verdict: OK")
+
+    if attribution_only:
+        return 0
+    return 1 if (bad or structural or needs_verdict) else 0
+
+
+def selftest():
+    """RED/GREEN fixtures. A rule that cannot fire is a rule that is not a check."""
+    with tempfile.TemporaryDirectory() as td:
+        r = Path(td); k = r / "kernels"
+        for hw, vendor in (("gb10", "nvidia"), ("strix", "amd")):
+            (k / hw / "common").mkdir(parents=True)
+            (k / hw / "HARDWARE.toml").write_text(f'[hardware]\nname="{hw}"\nvendor="{vendor}"\narch="x"\n')
+            (k / hw / "m1" / "q").mkdir(parents=True)
+            (k / hw / "m1" / "MODEL.toml").write_text("[model]\n")
+        (k / "gb10" / "common" / "shared.cu").write_text("// shared\n")
+        (k / "strix" / "common" / "shared.cu").symlink_to("../../gb10/common/shared.cu")
+        (k / "gb10" / "common" / "own.cu").write_text("// gb10 only\n")
+        for hw in ("metal", "strix-hip"):
+            (k / hw / "common").mkdir(parents=True)
+            (k / hw / "HARDWARE.toml").write_text(f'[hardware]\nname="{hw}"\nvendor="x"\narch="y"\n')
+        cons, _ = build_index(r)
+        shared_rp = os.path.realpath(k / "gb10" / "common" / "shared.cu")
+        hw_reach = {t[0] for t in cons.get(shared_rp, set())}
+        assert hw_reach == {"gb10", "strix"}, f"RED fixture: symlink reach was {hw_reach}"
+        own_rp = os.path.realpath(k / "gb10" / "common" / "own.cu")
+        assert {t[0] for t in cons.get(own_rp, set())} == {"gb10"}, "GREEN fixture: own.cu leaked"
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two classes of expensive mistake, both now blocked.

## 1. `O.R.A.C.L.E::certification_state_check` — S.T.A.T.E

A campaign is **~4.5–5 GPU-hours** and nothing else can use the box while it runs. Nothing asked *is it safe to start*, *is it still safe*, or *is this red real*. Fourteen litmus tests across `pre → begin → during → post → release`, each citing the code that enforces it.

Born from two incidents:

- **2026-08-28** — a nine-hour ten-gate campaign was content-invalidated by a 23-line push **twenty minutes into its final gate**. T9 now runs `campaign-guard.sh` *between and during* gates, and an abort **kills the running gate** rather than letting it finish.
- **2026-09-11 (twice in one day)** — a `/stamp` or `/seal` status was read *before* the bot processed the command; the stale red was reported as a real failure and nearly triggered a re-campaign. **T12 dates the red**: those jobs freeze their outputs for the life of a CI run, so a mark minted after they ran needs a FULL `gh run rerun` — `--failed` cannot work, because they *succeeded while emitting `false`*.

Two tests exist precisely because `--pull-request-gate-check` **cannot answer them**: **T13** (one `git_sha` across every *added* record — coverage and agreement are different questions, and the check reports PASS on a set CI rejects) and **T14** (one Speed-class signer).

Lockfile `.oracle_should_begin_cert` is created atomically via `ln(2)`, read on start, carries the structured JSON verdict, and is **renamed rather than deleted** when stale so the evidence survives. Staleness is liveness-first, never age alone. The skill is explicit that it is a file and not a mutex — the residual TOCTOU window and per-checkout scope are written down, not glossed.

Overrides are advisory but never silent: the oracle still **runs** the overridden test and prints both verdicts. T0/T1/T3/T9/T13, the Speed-signer half of T14, and T12-in-post cannot be overridden — CI rejects those outcomes regardless, so an override would only buy wasted hours.

## 2. `O.R.A.C.L.E::pre_commit_cross_hardware_check` — CHKI

`kernels/<hw>/` **looks** like one tree per hardware and is not:

| tree | real files | symlinks |
|---|---|---|
| strix | **7** | **105** (97 → `gb10/common`) |
| strix-hip | 22 | 87 |

So a gb10 edit changes what AMD compiles — and `taxon::hardware_of()` cannot see it, being a path prefix.

Static where provable, judgement where not. `scripts/check_cross_hardware.py` resolves all three sharing mechanisms and subtracts hardware where a real stem shadow wins. Includes resolve **lexically**, because nvcc is handed the symlink path — which is why strix-hip's real `prefill_paged_compute.cuh` (BR64 32) shadows gb10's (64).

### Negative controls — both real incidents replay as failures

| control | result |
|---|---|
| `d584c0c50` (gb10 edit broke hipcc; caught only by a compile leg) | **rc=1** `CHKI (undeclared: strix, strix-hip)` |
| `17fe989ec` (Strix workaround in gb10 common; invalidated 27 targets) | **rc=1** CHKI |
| no kernel change | rc=0 |
| strix-owned file | reaches strix only — no false positive |
| mutated self-fixture | **rc=2** — refuses to scan rather than pass green |

Fail-closed: rc 2 ("cannot see the inputs") is as red as rc 1, matching `campaign-guard.sh`'s exit 2.

★ **Deliberately not done:** making `taxon::affected()` symlink-aware. It would render `gate/closure.rs::excuses()` unsatisfiable — records exist for gb10 only (1700/1700), so any edit to one of the 97 shared files would be permanently un-excusable. Attribution and invalidation are different questions.

## Verification

`PREFLIGHT CLEAN` — file-size cap, fmt, doc, clippy (0 lints), `cargo test` (83 suites), certification self-test. `.gitignore` now tracks `.claude/agents/` alongside `.claude/skills/`: an agent file is a blocking review contract, and a gate nobody can read is not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwKSBe469fPnngzCFzbWcp