### PR TITLE
ci(CHKI): make the cross-hardware reach check advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,28 @@ jobs:
       - run: python3 scripts/check_kernel_shadows.py
 
   cross-hardware-reach:
-    name: cross-hardware kernel reach (CHKI)
+    # ADVISORY, by maintainer decision 2026-09-11 (tbraun96): "make it an
+    # advisory since AMD is second tier support".
+    #
+    # What that trades away, stated plainly so a later reader does not have to
+    # rediscover it: the reach this check reports is real. `taxon::hardware_of`
+    # is a path prefix, so a `kernels/gb10/common/*.cu` edit reads as gb10-only
+    # while hipcc compiles the same bytes through 105 symlinks. d584c0c50 was
+    # caught ONLY because a release compile leg failed, and a
+    # performance-only leak on AMD has no leg at all. Advisory means that class
+    # of defect can now land; it is accepted because strix/strix-hip are
+    # second-tier targets with no serving receipt, not because the risk is
+    # imaginary.
+    #
+    # The signal stays visible and stays honest: the job still runs on every
+    # PR, still fails closed on rc 2, and still prints the full reach table and
+    # remedies. Nothing `needs:` it, so a red blocks no merge.
+    #
+    # To make it enforcing again, delete `continue-on-error`, drop "advisory"
+    # from the name, and restore the two `release-matrix` references removed in
+    # this commit. Do that when AMD gets a compile leg on PRs.
+    name: cross-hardware kernel reach (CHKI, advisory)
+    continue-on-error: true
     runs-on: >-
       ${{ vars.USE_AVAROK_UBUNTU_RUNNERS == '1'
           && (github.event_name != 'pull_request'
@@ -809,12 +830,11 @@ jobs:
           needs.license-headers.result == 'success' &&
           needs.typos.result == 'success' &&
           needs.kernel-structure.result == 'success' &&
-          needs.cross-hardware-reach.result == 'success' &&
           (needs.clippy.result == 'success' || needs.clippy.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.test-macos-metal.result == 'success' || needs.test-macos-metal.result == 'skipped') &&
           needs.stamp.outputs.stamped != 'false' }}
-    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, cross-hardware-reach, test, test-macos-metal]
+    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
       version: 0.0.0-pr${{ github.event.number || 'queue' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ typos  # crate-ci/typos — install once, `cargo install typos-cli`
 #    kernels/<hw>/ looks like one tree per hardware and is not: strix is 7 real
 #    files and 105 symlinks into kernels/gb10/common/. A gb10 edit therefore
 #    changes what AMD compiles, and the CI job `cross-hardware kernel reach
-#    (CHKI)` will say so.
+#    (CHKI, advisory)` will say so. ADVISORY since 2026-09-11 — AMD is
+#    second-tier support, so a red does not block a merge. It is still the only
+#    thing that sees this class of reach: read it, do not skip it.
 python3 scripts/check_cross_hardware.py --base origin/main --worktree
 ```
 
@@ -98,8 +100,13 @@ emitting `false`. The oracle's T12 does the dating; do not do it by eye.
 For a `kernels/` change that reaches a second hardware, run
 `/oracle_pre_commit_cross_hardware_check` before pushing: it chooses the remedy (benign,
 parameterize in `kernels/<hw>/HARDWARE.toml` **with a reader added in the same change**, or a
-separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers CI
-requires.
+separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers.
+
+The CI job is **advisory** (AMD second-tier), so those trailers are no longer enforced at merge
+— which makes running the oracle a judgement you make rather than one CI makes for you. The
+reach it reports is real either way: a `kernels/gb10/common/` edit is compiled verbatim by
+hipcc through 105 symlinks, and `d584c0c50` was caught only because a release compile leg
+happened to fail.
 
 ## Adding a new model
 


### PR DESCRIPTION
Maintainer decision, 2026-09-11: **"make it an advisory since AMD is second tier support"**.

## What changes

* `continue-on-error: true` and `(advisory)` in the job name — the idiom `metal device parity (self-hosted, advisory)` already uses.
* Removes the two `release-matrix` references: its `needs:` entry and its clause in the `if:`.

That second half is the part that actually mattered on #895. CHKI sat in the matrix's `needs:`, so one red **skipped the release matrix and cancelled all nine compile legs** — `nvcc → PTX (hopper, sm_90a)`, `(b200)`, `(all gb10)`, `spark hopper`, `spark b200`, metal. The compile legs are exactly what would show whether a flagged reach is harmless, so the check was withholding its own evidence.

## What this trades away

The reach the check reports is real. `taxon::hardware_of` is a path prefix, so a `kernels/gb10/common/*.cu` edit reads as gb10-only while hipcc compiles the same bytes through 105 symlinks. `d584c0c50` was caught **only** because a release compile leg failed; a performance-only leak on AMD has no leg at all. Advisory means that class of defect can now land — accepted because strix/strix-hip are second-tier targets with no serving receipt, not because the risk is imaginary.

The signal stays visible: the job still runs on every PR, still fails closed on rc 2, still prints the full reach table and remedies. Nothing `needs:` it, so a red blocks no merge.

## Its first live run is the argument for keeping it visible

On #895, 505 changed kernel paths resolved to three different things:

| class | count | what it is |
|---|---|---|
| **real findings** | 2 | `gb10/common/rms_norm.cu` edited, reaches **strix, strix-hip**, undeclared; `gb10/common/KERNEL.toml` reaches **strix** |
| S1 new cross-hardware symlink | 470 | **all** in the brand-new `hopper/` (240) and `b200/` (230) trees; none in an existing tree |
| R1 remainder | ~462 | follows from the above |

It returned **OK** for `gated_delta_rule_chunk_tc.cu` and `w8a16_gemv_batch4.cu` (both gb10-only), so it discriminates rather than flagging every kernel path.

## Reverting

Delete `continue-on-error`, drop `advisory` from the name, restore the two `release-matrix` references. The condition worth waiting for is an AMD compile leg on PRs.

## Verification

```
bash .github/scripts/certification-selftest.sh
226 passed, 0 failed        # identical to the count before this change
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwKSBe469fPnngzCFzbWcp