### PR TITLE
ci: bound the sanitized PR body without closing the input pipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1030,6 +1030,8 @@ jobs:
           # from a sibling repo's tree listing, which is not this repo's data.
           d="__ATLAS_EOF_$RANDOM$RANDOM"
           { printf 'names<<%s\n' "$d"; cat recipes.txt; printf '\n%s\n' "$d"; } >> "$GITHUB_OUTPUT"
+      - name: Test PR body sanitization
+        run: python3 scripts/ci_pr_body_test.py
       - name: Sanitize the PR body
         id: body
         # The body is the author's own statement of intent — evidence the
@@ -1049,10 +1051,10 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
+          # Bound output after consuming the input; head can cause SIGPIPE.
           printf '%s' "${PR_BODY:-}" \
             | tr -d '\000-\010\013-\037\177' \
-            | perl -0777 -pe 's/<!--.*?-->//gs' \
-            | head -c 2000 > body.txt
+            | perl -0777 -pe 's/<!--.*?-->//gs; $_ = substr($_, 0, 2000)' > body.txt
           d="__ATLAS_EOF_$RANDOM$RANDOM"
           {
             printf 'text<<%s\n' "$d"

--- a/scripts/ci_pr_body_test.py
+++ b/scripts/ci_pr_body_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Exercise the actual workflow body sanitizer, including pipe-sized inputs."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml"
+
+
+def sanitizer_step():
+    text = WORKFLOW.read_text()
+    step = text.split("      - name: Sanitize the PR body\n", 1)[1]
+    run = step.split("        run: |\n", 1)[1]
+    lines = []
+    for line in run.splitlines(keepends=True):
+        if line.strip() and not line.startswith("          "):
+            break
+        lines.append(line)
+    return textwrap.dedent("".join(lines))
+
+
+class BodySanitizerTests(unittest.TestCase):
+    def run_step(self, body, *, fail_perl=False):
+        with tempfile.TemporaryDirectory(prefix="atlas-pr-body-") as directory:
+            root = Path(directory)
+            output = root / "output"
+            env = dict(os.environ, PR_BODY=body, GITHUB_OUTPUT=str(output))
+            if fail_perl:
+                perl = root / "perl"
+                perl.write_text("#!/bin/sh\ncat >/dev/null\nexit 73\n")
+                perl.chmod(0o755)
+                env["PATH"] = str(root) + os.pathsep + env["PATH"]
+            result = subprocess.run(
+                ["bash", "-c", sanitizer_step()],
+                cwd=root,
+                env=env,
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+            data = (root / "body.txt").read_bytes()
+            emitted = output.read_bytes() if output.exists() else None
+            return result, data, emitted, (root / "injected").exists()
+
+    def assert_sanitized(self, body, expected):
+        result, data, emitted, injected = self.run_step(body)
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.assertEqual(result.stderr, b"")
+        self.assertEqual(data, expected)
+        self.assertLessEqual(len(data), 2000)
+        self.assertFalse(injected)
+        first, payload = emitted.split(b"\n", 1)
+        self.assertRegex(first, rb"^text<<__ATLAS_EOF_[0-9]+$")
+        delimiter = first.removeprefix(b"text<<")
+        framed = data + (b"\n" if data and not data.endswith(b"\n") else b"")
+        self.assertEqual(payload, framed + delimiter + b"\n")
+
+    def test_empty_short_and_newline_framing(self):
+        for body in ("", "hello", "hello\n", "one\ntwo\n"):
+            with self.subTest(body=body):
+                self.assert_sanitized(body, body.encode())
+
+    def test_long_bodies_across_pipe_buffer_boundaries(self):
+        # The old early-closing head consumer failed intermittently on Linux.
+        for size in (2000, 2001, 8000, 10000, 12000, 16384, 20000, 60000):
+            for repetition in range(3):
+                with self.subTest(size=size, repetition=repetition):
+                    self.assert_sanitized("x" * size, b"x" * min(size, 2000))
+
+    def test_controls_and_multiline_comments_removed_before_cap(self):
+        body = "\x01\x1bvisible\t\n<!--" + "hidden\n" * 2000 + "-->after\x7f"
+        self.assert_sanitized(body, b"visible\t\nafter")
+
+    def test_byte_limit_preserves_existing_utf8_truncation(self):
+        body = "z" * 1999 + "\u00e9" * 4000
+        self.assert_sanitized(body, body.encode()[:2000])
+
+    def test_shell_metacharacters_remain_data(self):
+        body = "$(touch injected) `touch injected` ${PATH}\nEOF\n"
+        self.assert_sanitized(body, body.encode())
+
+    def test_real_upstream_failure_is_not_suppressed(self):
+        result, _, emitted, injected = self.run_step("text", fail_perl=True)
+        self.assertEqual(result.returncode, 73)
+        self.assertIsNone(emitted)
+        self.assertFalse(injected)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The PR-body sanitizer in `ci.yml` ends its pipeline with `head -c 2000`. `head` **closes the pipe the moment it has its 2000 bytes**, so on a body longer than that, `perl` gets `SIGPIPE` and `tr` can too. Under `set -euo pipefail` that is a non-zero pipeline status — the step fails on a *long PR body*, which is a property of the author's prose and nothing to do with the change under review.

The fix moves the byte cap **inside** `perl`, which already slurps the whole input (`-0777`): `$_ = substr($_, 0, 2000)`. Nothing closes a pipe early, so nothing gets `SIGPIPE`, and the cap is applied to exactly the same bytes as before — after control-character stripping and after HTML-comment removal.

`scripts/ci_pr_body_test.py` is added and wired into the same job, so the sanitizer has an oracle instead of being a shell one-liner nobody can exercise.

**Base is `main`.** No stack, no `crates/` change, no `kernels/` change.

## What was wrong

```
printf '%s' "${PR_BODY:-}" \
  | tr -d '\000-\010\013-\037\177' \
  | perl -0777 -pe 's/<!--.*?-->//gs' \
  | head -c 2000 > body.txt
```

Three things are true at once and only the combination bites:

1. `head -c N` exits as soon as it has `N` bytes, closing its stdin.
2. `perl -0777` reads the *entire* input before writing anything, so it is still writing when `head` leaves — it takes `SIGPIPE`.
3. `set -euo pipefail` makes any non-zero element of the pipeline the pipeline's status.

So the step's failure is a function of body length, not of content. Below ~2000 bytes it never fires; above it, it fires depending on buffer timing — which is exactly the shape of an intermittent red that gets re-run rather than fixed.

## What the fix does

- **The cap moves into the process that already holds the whole string.** `perl -0777 -pe 's/<!--.*?-->//gs; $_ = substr($_, 0, 2000)'` — same input, same two transformations in the same order, same 2000-byte bound, no early close.
- **The order is preserved deliberately.** Controls are stripped, then comments are removed, *then* the cap is applied. Capping first would let a removed comment pull real prose back under the limit, which changes what downstream steps see.
- **The sanitizer gets a test, and CI runs it.** `scripts/ci_pr_body_test.py` is stdlib-only `unittest` and is invoked from the same job, before the sanitize step, so a regression in the sanitizer fails the job that uses it rather than silently changing what a downstream consumer reads.

## Oracle and evidence

`scripts/ci_pr_body_test.py`, 6 cases, all shelling out to the *actual* pipeline text so the test cannot drift from the workflow by paraphrasing it:

- `test_long_bodies_across_pipe_buffer_boundaries` — **this is the regression pin.** Bodies spanning the pipe buffer boundary must exit 0 and produce exactly 2000 bytes.
- `test_byte_limit_preserves_existing_utf8_truncation` — the cap is a *byte* cap, as before; the test pins the pre-existing behaviour rather than quietly improving it.
- `test_controls_and_multiline_comments_removed_before_cap` — the ordering above.
- `test_shell_metacharacters_remain_data` — a body containing `$(...)`, backticks and `;` stays data.
- `test_empty_short_and_newline_framing` — the empty and under-cap paths.
- `test_real_upstream_failure_is_not_suppressed` — **the control.** A genuine failure inside the pipeline must still be red; the fix must not have turned `pipefail` into a no-op for this step.

## Test plan

Spark 1 (GB10), in an isolated worktree against this branch fetched from the fork.

- [x] `python3 scripts/ci_pr_body_test.py` — **`Ran 6 tests in 0.193s` / `OK`**, rc=0
- [x] `python3 -m py_compile scripts/ci_pr_body_test.py` — rc=0
- [x] No `crates/` and no `kernels/` change: the diff is `.github/workflows/ci.yml` and one new script.

## GB10 perf-gate records

No `crates/` path is touched, so no committed `.benchmarks/` record is invalidated.

## What is NOT claimed

- This does not change what the sanitizer *produces* for any body that was already succeeding — same bytes, same order, same cap. It changes only whether the step can fail because of length.
- It does not audit the rest of the job, nor the consumers of `body.txt`.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
