### PR TITLE
scheduler: include grammar preparation in service TTFT (#918)

### DIFF
--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -57,6 +57,8 @@ mod prefill_a_step_params;
 mod prefill_b_step;
 #[cfg(test)]
 mod prefill_fifo_tests;
+#[cfg(test)]
+mod prefill_timing_tests;
 mod repetition;
 mod rollback;
 mod sample_step;

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -83,6 +83,9 @@ pub fn start_chunked_prefill(
     let req_prompt_logprobs = req.prompt_logprobs();
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
+    // Scheduler-service TTFT includes grammar compilation and mask warmup.
+    // HTTP handling/queue time precedes this clock; decode_start stays unchanged.
+    let request_start = Instant::now();
     let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
     let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
@@ -118,7 +121,6 @@ pub fn start_chunked_prefill(
         ),
     };
 
-    let request_start = Instant::now();
     let total = prompt_tokens.len();
     let chunk_len = total.min(max_prefill_tokens);
     let is_last = chunk_len >= total;

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -68,6 +68,9 @@ pub fn prefill_request(
     let req_top_logprobs = req.top_logprobs();
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
+    // Match the chunked path: include grammar preparation once in service TTFT,
+    // while retaining the existing exclusion of HTTP handling and queue time.
+    let request_start = Instant::now();
     let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
     let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
@@ -103,7 +106,6 @@ pub fn prefill_request(
         ),
     };
 
-    let request_start = Instant::now();
     tracing::info!(
         "Prefilling: {} prompt tokens, max_tokens={max_tokens}",
         prompt_tokens.len(),

--- a/crates/spark-server/src/scheduler/prefill_timing_tests.rs
+++ b/crates/spark-server/src/scheduler/prefill_timing_tests.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The scheduler-service TTFT clock must include grammar preparation.
+//! Exercise the real deferred-prefill entry point without GPU work. A parser
+//! records the instant its real grammar compile begins; request_start must
+//! precede that instant, including a cache hit. No wall-time threshold/sleep.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::api::InferenceRequest;
+use crate::api::inference_types::GrammarSpec;
+use crate::grammar::{GrammarEngine, GrammarError};
+use crate::tool_parser::{
+    IncomingToolCall, PromptLevers, ToolCallParser, ToolChoice, ToolDefinition,
+};
+use xgrammar::CompiledGrammar;
+
+struct ObservedParser(Arc<Mutex<Option<Instant>>>);
+
+impl ToolCallParser for ObservedParser {
+    fn name(&self) -> &str {
+        "observed-grammar"
+    }
+    fn system_prompt(&self, _: &[ToolDefinition], _: &ToolChoice, _: &PromptLevers) -> String {
+        unreachable!("request is already tokenized")
+    }
+    fn format_tool_calls(&self, _: &[IncomingToolCall]) -> String {
+        unreachable!("request is already tokenized")
+    }
+    fn compile_tool_grammar(
+        &self,
+        engine: &mut GrammarEngine,
+        _: &[ToolDefinition],
+        _: bool,
+    ) -> Option<Result<CompiledGrammar, GrammarError>> {
+        *self.0.lock().unwrap() = Some(Instant::now());
+        Some(engine.compile_ebnf("root ::= \"x\"", "root"))
+    }
+}
+
+fn request(grammar_spec: Option<GrammarSpec>) -> InferenceRequest {
+    let (response_tx, _rx) = tokio::sync::oneshot::channel();
+    InferenceRequest::Blocking {
+        prompt_tokens: Arc::new(vec![0]),
+        session_hash: 0,
+        adapter_slot: -1,
+        src_lang_id: 0,
+        tgt_lang_id: 0,
+        num_beams: 1,
+        length_penalty: 1.0,
+        early_stopping: false,
+        image_pixels: vec![],
+        max_tokens: 2,
+        min_tokens: 0,
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        top_n_sigma: 0.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        dry_multiplier: 0.0,
+        dry_base: 0.0,
+        dry_allowed_length: 0,
+        lz_penalty: 0.0,
+        logit_bias: vec![],
+        stop_tokens: vec![],
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: None,
+        require_tool_call: false,
+        tools_present: grammar_spec.is_some(),
+        suppress_tool_call: false,
+        disable_mtp: true,
+        grammar_spec,
+        seed: Some(42),
+        top_logprobs: None,
+        prompt_logprobs: None,
+        echo: false,
+        timeout_at: None,
+        response_tx,
+    }
+}
+
+#[test]
+fn deferred_prefill_clock_includes_cold_and_cached_grammar_preparation() {
+    let marker = Arc::new(Mutex::new(None));
+    let mut engine = Some(GrammarEngine::new(&["x".to_string()], &[]).unwrap());
+    for cached in [false, true] {
+        let spec = GrammarSpec::ToolCall {
+            tools: vec![],
+            parser: Arc::new(ObservedParser(Arc::clone(&marker))),
+            use_triggers: true,
+        };
+        let result = super::prefill_a_step::start_chunked_prefill(
+            &super::sched_ctx::SchedCtx::for_test(),
+            None,
+            None,
+            None,
+            None,
+            &super::lifecycle_tests::StubModel,
+            request(Some(spec)),
+            &[],
+            1,
+            0,
+            0,
+            &mut engine,
+            0,
+            true,
+            None,
+            None,
+        )
+        .unwrap();
+        let super::emit_step::StartPrefillResult::InProgress(prefill) = result else {
+            panic!("deferred prefill unexpectedly performed inference");
+        };
+        assert!(
+            prefill.grammar_state.is_some(),
+            "real grammar must be prepared"
+        );
+        let compiled_at = marker.lock().unwrap().unwrap();
+        assert!(
+            prefill.request_start <= compiled_at,
+            "TTFT origin excluded grammar preparation (cached={cached})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The scheduler's service-TTFT clock started **after** grammar compilation, in both prefill entry points. Any request that carries a `GrammarSpec` — every tool-calling request — had its grammar compile and mask warmup excluded from the TTFT it reported.

That is not a small bias. On the #918 receipt a **cold** tool-call grammar cost **3.4 s** before the mask cache landed; the TTFT the engine reported for that request did not contain it. The number was measuring the wrong interval, and the interval it omitted was the one being optimised.

Both paths now take `request_start` **before** `compile_grammar_state`. HTTP handling and queue time still precede the clock, unchanged, and `decode_start` is untouched.

**Base is `main`.** No stack. 4 files, +137/−2, of which 129 lines are the test.

Refs #918.

## What was wrong

`prefill_a_step.rs::start_chunked_prefill` and `prefill_b_step.rs::prefill_request` both did:

```rust
let grammar_spec = req.take_grammar_spec();
let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
let (prompt_tokens, max_tokens, ...) = match req { ... };

let request_start = Instant::now();   // <- after the compile
```

So `service TTFT = first_token - request_start` excluded:

- grammar compilation (cold: the EBNF/JSON-schema compile),
- top-k mask preparation (the expensive half),
- the cache lookup on a warm hit (cheap, but it should still be inside the interval).

The two paths had the same bug for the same reason, so a fix to one alone would have made the chunked and non-chunked numbers incomparable.

## What the fix does

One line moves in each file, with the comment that says why:

```rust
// Scheduler-service TTFT includes grammar compilation and mask warmup.
// HTTP handling/queue time precedes this clock; decode_start stays unchanged.
let request_start = Instant::now();
let mut grammar_state = compile_grammar_state(...);
```

Nothing else changes: not the compile, not the cache, not what a client sees, not `decode_start`, not the queue-time exclusion. **TTFT for grammar requests will go up** — that is the point; the reported number was short by the compile.

## Oracle and evidence

`crates/spark-server/src/scheduler/prefill_timing_tests.rs` (129 lines, new). It drives the **real deferred-prefill entry point** with no GPU work, and it does not use a sleep or a wall-time threshold — a timing test pinned to a duration is a flake generator.

Instead, `ObservedParser` records `Instant::now()` inside its own `compile_tool_grammar`, at the moment the real compile begins. The assertion is an **ordering** one: `request_start <= observed_compile_start`. That holds on a cold compile and on a **cache hit**, which is the case the old code looked correct on and the case a threshold test would have missed.

**No hardware receipt is claimed.** This is a clock, not a kernel. The H100 box for this campaign is down, and re-running the #918 cold/warm tool-call ladder under the corrected clock is owed — every TTFT recorded for a grammar request before this fix is short by the compile, and this PR does not restate any of them.

## Test plan

Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, private `CARGO_TARGET_DIR`, isolated worktree against this branch fetched from the fork.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p spark-server --features cuda --all-targets --jobs 8 -- -D warnings` — **clean, rc=0**
- [x] `cargo test -p spark-server --bins --features cuda -- prefill_timing` — **1 passed, 0 failed** (2467 filtered)
- [x] `cargo test -p spark-server --bins --features cuda` — **2456 passed, 0 failed, 12 ignored** (`main`: 2455 → **+1**)
- [x] `cargo test -p spark-server --features cuda --lib` — **114 passed, 0 failed** (the thin library; the scheduler lives in the bins)
- [x] No `kernels/` change; `crates/spark-server` only.

## GB10 perf-gate records

Touches `crates/` (a PERF_PATH), so committed `.benchmarks/` records are invalidated on landing. **Worth flagging beyond the formality:** any recorded TTFT for a grammar-bearing request was measured on the old clock and is not comparable to one measured after this lands. Records that contain tool-calling rungs should be re-measured, not carried.

## What is NOT claimed

- No performance change. Nothing gets faster; a reported number gets *longer and correct*.
- No claim about which portion of the compile is cache-servable — that is #918/#999's subject.
- The test asserts ordering, not a bound. It cannot tell you the compile is fast, only that it is inside the interval.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
