### PR TITLE
spark-server: stop injecting a second tool prompt when the checkpoint template owns one

### DIFF
--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -228,25 +228,9 @@ pub(crate) async fn chat_completions_inner(
         return ChatOutcome::Http(resp);
     }
 
-    // Tool-parser behavioral system prompt REMOVED again (2026-05-25 PM).
-    //
-    // Re-injecting the qwen3_coder `system_prompt` (with its
-    // `<parameter=content>[package]\nname = "x"</parameter>` example
-    // and `For 'Write'/'Edit' tools specifically: ...` guidance) was a
-    // mid-day attempt to give the model better multi-line content
-    // hints. Live opencode v39 session showed the opposite effect:
-    // the model emitted LITERAL `<tool_call><bash><command>` XML as
-    // CONTENT (with HTML-entity escaping like `&amp;`) because TWO
-    // tool-format guidances were competing — the chat template's
-    // `tools` argument AND my injected prompt — combined with PR 73's
-    // `qwen3_xml` parser. The model got confused which format to use
-    // and emitted free-form XML that the parser couldn't recognise.
-    //
-    // Per user's recall: the "MUCH better" state had `thinking_in_tools=true`
-    // and the chat template alone (no injection). Reverting matches
-    // that state. PR 73's qwen3_xml + native FP8 SSM + streaming
-    // byte-exact + gate-BF16 + thinking_in_tools=true is the live
-    // combination.
+    // Parser/native-template ownership is resolved by prepare_chat_prompt.
+    // Native Qwen templates provide their own instructions; fallback,
+    // custom-template, Hermes, and TSCG paths retain parser contributions.
 
     // M2 per-request LoRA routing: resolve the optional `adapter` name to a
     // pool slot ONCE here (both dispatch paths inherit it). Unset defers to the

--- a/crates/spark-server/src/api/chat/prepare.rs
+++ b/crates/spark-server/src/api/chat/prepare.rs
@@ -293,3 +293,7 @@ mod tests {
         assert_eq!(messages[0].text(), "tool instructions\n\noriginal");
     }
 }
+
+#[cfg(test)]
+#[path = "../../tokenizer/tests/native_tool_prompt.rs"]
+mod native_tool_prompt;

--- a/crates/spark-server/src/api/chat/prepare.rs
+++ b/crates/spark-server/src/api/chat/prepare.rs
@@ -54,16 +54,20 @@ pub(crate) fn prepare_chat_prompt(
         && !req.tools.is_empty()
         && !req.tool_choice.as_ref().is_some_and(|tc| tc.is_none());
 
-    // ST-995 fix: restore the parser-specific behavioral system prompt #90
-    // removed. For the hermes parser this is the canonical NousResearch
-    // function-calling prompt ("you MAY call one or more functions...
-    // don't make assumptions"), which the GDN model needs to correctly
-    // DECLINE on irrelevance prompts. With it (and compact tool-JSON)
-    // hallucination returns to ~96 (vs 30/64 without).
+    // Preserve parser-owned prompts (including Hermes and TSCG). Native
+    // Qwen checkpoint templates already render their tool instructions;
+    // adding the parser block there duplicates the schema and changes the
+    // request with unrelated behavioral guidance.
     if tools_active && let Some(ref parser) = state.tool_call_parser {
         let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
         let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
-        let tool_prompt = parser.system_prompt(&req.tools, tool_choice, &state.chat.prompt);
+        let tool_prompt = parser_tool_prompt(
+            parser.as_ref(),
+            &req.tools,
+            tool_choice,
+            &state.chat.prompt,
+            state.tokenizer.uses_native_qwen_tool_template(),
+        );
         inject_tool_system_prompt(&mut req.messages, tool_prompt);
     }
 
@@ -185,9 +189,32 @@ fn effective_reasoning_effort(
     }
 }
 
+/// Resolve the parser contribution independently of the native template renderer.
+pub(crate) fn parser_tool_prompt(
+    parser: &dyn crate::tool_parser::ToolCallParser,
+    tools: &[crate::tool_parser::ToolDefinition],
+    choice: &crate::tool_parser::ToolChoice,
+    levers: &crate::tool_parser::PromptLevers,
+    native_qwen_template: bool,
+) -> String {
+    if native_qwen_template && !levers.tscg && matches!(parser.name(), "qwen3_coder" | "qwen3_xml")
+    {
+        // The checkpoint template already owns the schema and XML format.
+        // Keep required/named tool-choice constraints, but do not inject a
+        // second copy or unrelated Bash/Write/Edit behavioral instructions.
+        let mut prompt = String::new();
+        crate::tool_parser::append_tool_choice_instruction(&mut prompt, choice);
+        return prompt;
+    }
+    parser.system_prompt(tools, choice, levers)
+}
+
 /// Inject a parser's behavioral prompt without changing requests for parsers
 /// whose native chat template already owns tool instructions.
-fn inject_tool_system_prompt(messages: &mut Vec<crate::ir::Message>, tool_prompt: String) {
+pub(crate) fn inject_tool_system_prompt(
+    messages: &mut Vec<crate::ir::Message>,
+    tool_prompt: String,
+) {
     if tool_prompt.is_empty() {
         return;
     }

--- a/crates/spark-server/src/tokenizer.rs
+++ b/crates/spark-server/src/tokenizer.rs
@@ -62,9 +62,9 @@ fn normalize_tool_call_arguments(messages: &[serde_json::Value]) -> Vec<serde_js
 
 /// Wraps a HuggingFace tokenizer with Jinja chat template support.
 mod chat_impl;
-mod chat_render;
+pub(crate) mod chat_render;
 mod deepseek_v4;
-mod jinja_helpers;
+pub(crate) mod jinja_helpers;
 mod message_preprocess;
 
 pub(crate) use message_preprocess::{

--- a/crates/spark-server/src/tokenizer.rs
+++ b/crates/spark-server/src/tokenizer.rs
@@ -82,6 +82,8 @@ pub struct ChatTokenizer {
     eos_token_id: u32,
     supports_thinking: bool,
     chat_encoding: ChatEncoding,
+    /// Checkpoint Qwen tool instructions own schema rendering (no override selected).
+    native_qwen_tool_template: bool,
     /// Compiled Jinja chat template (from tokenizer_config.json).
     #[allow(dead_code)]
     chat_template: String,

--- a/crates/spark-server/src/tokenizer/chat_impl.rs
+++ b/crates/spark-server/src/tokenizer/chat_impl.rs
@@ -90,13 +90,16 @@ impl ChatTokenizer {
         } else {
             super::jinja_helpers::load_override_template(model_type, repo_root)
         };
-        let chat_template = if let Some(override_tmpl) = override_tmpl {
-            override_tmpl
+        let (chat_template, checkpoint_template) = if let Some(override_tmpl) = override_tmpl {
+            (override_tmpl, false)
         } else if let Some(config_tmpl) = super::jinja_helpers::load_config_template(model_dir)? {
-            config_tmpl
+            (config_tmpl, true)
         } else {
             tracing::warn!("No chat template found — using default ChatML");
-            super::jinja_helpers::default_chatml_template(supports_thinking)
+            (
+                super::jinja_helpers::default_chatml_template(supports_thinking),
+                false,
+            )
         };
 
         let jinja_env = super::jinja_helpers::build_jinja_env(&chat_template)?;
@@ -116,16 +119,29 @@ impl ChatTokenizer {
             ChatEncoding::Jinja
         };
 
+        let native_qwen_tool_template = checkpoint_owns_qwen_tool_prompt(
+            model_type,
+            checkpoint_template,
+            openai_jinja_env.is_some(),
+        ) && jinja_env
+            .get_template("chat")?
+            .undeclared_variables(false)
+            .contains("tools");
         tracing::info!("Loaded tokenizer from {}", tokenizer_path.display());
         Ok(Self {
             tokenizer,
             eos_token_id,
             supports_thinking,
             chat_encoding,
+            native_qwen_tool_template,
             chat_template,
             jinja_env,
             openai_jinja_env,
         })
+    }
+
+    pub(crate) fn uses_native_qwen_tool_template(&self) -> bool {
+        self.native_qwen_tool_template
     }
 
     /// Returns a borrowed reference to the underlying HF tokenizer (for
@@ -446,4 +462,19 @@ impl ChatTokenizer {
         }
         out
     }
+}
+
+/// Only the known Qwen checkpoint templates own XML tool instructions.
+/// Custom overrides and ChatML fallback retain parser-provided instructions.
+fn checkpoint_owns_qwen_tool_prompt(
+    model_type: &str,
+    checkpoint: bool,
+    openai_override: bool,
+) -> bool {
+    checkpoint
+        && !openai_override
+        && matches!(
+            model_type,
+            "qwen3_5" | "qwen3_5_moe" | "qwen3_6" | "qwen3_6_moe"
+        )
 }

--- a/crates/spark-server/src/tokenizer/jinja_helpers.rs
+++ b/crates/spark-server/src/tokenizer/jinja_helpers.rs
@@ -412,7 +412,7 @@ pub(super) fn default_chatml_template(supports_thinking: bool) -> String {
 
 /// Convert Python Jinja2 syntax to minijinja-compatible syntax.
 /// Handles: slice reversal, string methods, etc.
-pub(super) fn convert_python_jinja_to_minijinja(template: &str) -> String {
+pub(crate) fn convert_python_jinja_to_minijinja(template: &str) -> String {
     let mut t = template.to_string();
 
     // messages[::-1] → messages | reverse

--- a/crates/spark-server/src/tokenizer/tests.rs
+++ b/crates/spark-server/src/tokenizer/tests.rs
@@ -7,7 +7,6 @@ use serde_json::json;
 
 mod laguna;
 mod mistral_effort;
-mod native_tool_prompt;
 mod qwen_dense;
 mod qwen_dense_parity;
 

--- a/crates/spark-server/src/tokenizer/tests.rs
+++ b/crates/spark-server/src/tokenizer/tests.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Extracted piecewise from `tokenizer.rs` (500-LoC cap).
-
 use super::*;
 
 mod deepseek_v4;
@@ -9,6 +7,7 @@ use serde_json::json;
 
 mod laguna;
 mod mistral_effort;
+mod native_tool_prompt;
 mod qwen_dense;
 mod qwen_dense_parity;
 

--- a/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
+++ b/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
@@ -4,10 +4,10 @@
 //! 1135 tokens and vLLM as 320. Test the production parser contribution and
 //! render core against the pinned checkpoint template, without loading a GPU.
 
-use super::super::chat_render::{RenderFlags, render_chat};
-use super::super::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
 use crate::api::chat::prepare::{inject_tool_system_prompt, parser_tool_prompt};
 use crate::ir::{ContentPart, Message, Role};
+use crate::tokenizer::chat_render::{RenderFlags, render_chat};
+use crate::tokenizer::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
 use crate::tool_parser::{
     HermesParser, PromptLevers, Qwen3CoderParser, Qwen3XmlParser, ToolCallParser, ToolChoice,
     ToolChoiceFunction, ToolDefinition,
@@ -41,7 +41,7 @@ fn tools() -> Vec<ToolDefinition> {
 fn render(messages: &[Message], style: ToolJsonStyle) -> String {
     // Qwen/Qwen3.6-35B-A3B-FP8 @ 95a723d08a9490559dae23d0cff1d9466213d989.
     let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
-    let converted = super::super::jinja_helpers::convert_python_jinja_to_minijinja(raw);
+    let converted = crate::tokenizer::jinja_helpers::convert_python_jinja_to_minijinja(raw);
     let env = build_jinja_env_with(&converted, style).unwrap();
     let messages: Vec<_> = messages
         .iter()
@@ -162,7 +162,7 @@ fn native_qwen_tool_prompt_preserves_user_system_message() {
 
 #[test]
 fn native_qwen_tool_prompt_ownership_tracks_actual_template_selection() {
-    use super::super::ChatTokenizer;
+    use crate::tokenizer::ChatTokenizer;
     let root = tempfile::tempdir().unwrap();
     let model = root.path().join("model");
     let repo = root.path().join("repo");

--- a/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
+++ b/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! H100 rental reproduction: the same get_weather request reached Atlas as
+//! 1135 tokens and vLLM as 320. Test the production parser contribution and
+//! render core against the pinned checkpoint template, without loading a GPU.
+
+use super::super::chat_render::{RenderFlags, render_chat};
+use super::super::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
+use crate::api::chat::prepare::{inject_tool_system_prompt, parser_tool_prompt};
+use crate::ir::{ContentPart, Message, Role};
+use crate::tool_parser::{
+    HermesParser, PromptLevers, Qwen3CoderParser, Qwen3XmlParser, ToolCallParser, ToolChoice,
+    ToolChoiceFunction, ToolDefinition,
+};
+use serde_json::json;
+
+fn user() -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentPart::Text(
+            "What is the weather in Reykjavik over the next three days? Use the tool.".into(),
+        )],
+        tool_calls: Vec::new(),
+        tool_call_id: None,
+        name: None,
+        reasoning: None,
+        tool_error: false,
+    }
+}
+
+fn tools() -> Vec<ToolDefinition> {
+    serde_json::from_value(json!([{"type":"function","function":{
+        "name":"get_weather","description":"Look up the current weather for a city.",
+        "parameters":{"type":"object","properties":{
+            "city":{"type":"string","description":"City name."},
+            "days":{"type":"integer","description":"Forecast horizon in days."}},
+            "required":["city","days"]}}}]))
+    .unwrap()
+}
+
+fn render(messages: &[Message], style: ToolJsonStyle) -> String {
+    // Qwen/Qwen3.6-35B-A3B-FP8 @ 95a723d08a9490559dae23d0cff1d9466213d989.
+    let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
+    let converted = super::super::jinja_helpers::convert_python_jinja_to_minijinja(raw);
+    let env = build_jinja_env_with(&converted, style).unwrap();
+    let messages: Vec<_> = messages
+        .iter()
+        .map(|m| {
+            json!({
+                "role": if m.role == Role::System {"system"} else {"user"},
+                "content": m.text(),
+            })
+        })
+        .collect();
+    let tools: Vec<_> = tools()
+        .iter()
+        .map(|t| serde_json::to_value(t).unwrap())
+        .collect();
+    render_chat(&env, &messages, Some(&tools), RenderFlags::default()).unwrap()
+}
+
+#[test]
+fn native_qwen_tool_prompt_has_one_instruction_source() {
+    let original = vec![user()];
+    let mut messages = original.clone();
+    let contribution = parser_tool_prompt(
+        &Qwen3CoderParser,
+        &tools(),
+        &ToolChoice::Mode("auto".into()),
+        &PromptLevers::OFF,
+        true,
+    );
+    inject_tool_system_prompt(&mut messages, contribution);
+    let actual = render(&messages, ToolJsonStyle::Compact);
+    let native = render(&original, ToolJsonStyle::Compact);
+    let hf = render(&original, ToolJsonStyle::HfSpaced);
+    println!(
+        "RENDER_RECEIPT={}",
+        json!({"actual":actual,"native_compact":native,"native_hf_spaced":hf})
+    );
+    assert_eq!(
+        actual.matches("# Tools").count(),
+        1,
+        "duplicate tool instructions"
+    );
+    assert_eq!(
+        actual, native,
+        "parser must not duplicate checkpoint tool instructions"
+    );
+    assert_eq!(
+        messages, original,
+        "client messages must not gain an unrelated system block"
+    );
+}
+
+#[test]
+fn native_qwen_tool_prompt_keeps_required_and_named_choices() {
+    for parser in [&Qwen3CoderParser as &dyn ToolCallParser, &Qwen3XmlParser] {
+        for choice in [
+            ToolChoice::Mode("required".into()),
+            ToolChoice::Specific {
+                function: ToolChoiceFunction {
+                    name: "get_weather".into(),
+                },
+            },
+        ] {
+            let prompt = parser_tool_prompt(parser, &tools(), &choice, &PromptLevers::OFF, true);
+            assert!(
+                prompt.contains("MUST call"),
+                "tool choice enforcement retained"
+            );
+            assert!(
+                !prompt.contains("# Tools"),
+                "schema belongs to native template"
+            );
+            if matches!(choice, ToolChoice::Specific { .. }) {
+                assert!(prompt.contains("'get_weather'"));
+            }
+        }
+    }
+}
+
+#[test]
+fn native_qwen_tool_prompt_preserves_fallback_tscg_and_other_parsers() {
+    let choice = ToolChoice::Mode("auto".into());
+    for parser in [
+        &Qwen3CoderParser as &dyn ToolCallParser,
+        &Qwen3XmlParser,
+        &HermesParser,
+    ] {
+        for (native, tscg) in [(false, false), (false, true), (true, true)] {
+            let levers = PromptLevers::new(tscg);
+            assert_eq!(
+                parser_tool_prompt(parser, &tools(), &choice, &levers, native),
+                parser.system_prompt(&tools(), &choice, &levers)
+            );
+        }
+    }
+    assert_eq!(
+        parser_tool_prompt(&HermesParser, &tools(), &choice, &PromptLevers::OFF, true),
+        HermesParser.system_prompt(&tools(), &choice, &PromptLevers::OFF)
+    );
+}
+
+#[test]
+fn native_qwen_tool_prompt_preserves_user_system_message() {
+    let mut messages = vec![
+        Message::synthetic_system("User supplied system policy".into()),
+        user(),
+    ];
+    let before = messages.clone();
+    let contribution = parser_tool_prompt(
+        &Qwen3CoderParser,
+        &tools(),
+        &ToolChoice::Mode("auto".into()),
+        &PromptLevers::OFF,
+        true,
+    );
+    inject_tool_system_prompt(&mut messages, contribution);
+    assert_eq!(messages, before);
+}
+
+#[test]
+fn native_qwen_tool_prompt_ownership_tracks_actual_template_selection() {
+    use super::super::ChatTokenizer;
+    let root = tempfile::tempdir().unwrap();
+    let model = root.path().join("model");
+    let repo = root.path().join("repo");
+    std::fs::create_dir_all(&model).unwrap();
+    std::fs::create_dir_all(repo.join("jinja-templates/openai")).unwrap();
+    tokenizers::Tokenizer::new(tokenizers::models::wordlevel::WordLevel::default())
+        .save(model.join("tokenizer.json"), false)
+        .unwrap();
+    let load =
+        |kind| ChatTokenizer::from_model_dir(&model, 0, true, kind, Some(&repo), false).unwrap();
+    // No template is the ChatML fallback, even for a known Qwen model type.
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+    std::fs::write(
+        model.join("tokenizer_config.json"),
+        json!({"chat_template":"{{ messages }}"}).to_string(),
+    )
+    .unwrap();
+    assert!(
+        !load("qwen3_6_moe").uses_native_qwen_tool_template(),
+        "a custom checkpoint template without tools needs parser instructions"
+    );
+    let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
+    std::fs::write(
+        model.join("tokenizer_config.json"),
+        json!({"chat_template":raw}).to_string(),
+    )
+    .unwrap();
+    for kind in ["qwen3_5", "qwen3_5_moe", "qwen3_6", "qwen3_6_moe"] {
+        assert!(load(kind).uses_native_qwen_tool_template(), "{kind}");
+    }
+    assert!(!load("nemotron_h").uses_native_qwen_tool_template());
+    let custom = repo.join("jinja-templates/qwen3_6_moe.jinja");
+    std::fs::write(&custom, "{{ messages }}").unwrap();
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+    std::fs::remove_file(custom).unwrap();
+    std::fs::write(
+        repo.join("jinja-templates/openai/qwen3_6_moe.jinja"),
+        "{{ messages }}",
+    )
+    .unwrap();
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+}

--- a/crates/spark-server/src/tool_parser.rs
+++ b/crates/spark-server/src/tool_parser.rs
@@ -54,43 +54,6 @@ fn is_normalized_tool_name(name: &str) -> bool {
     !name.is_empty() && !name.contains(':')
 }
 
-/// Normalize a model-emitted function name to the client-visible tool name.
-///
-/// This keeps existing parser salvage behaviour (`Bash=Bash` -> `Bash`,
-/// `name="Write"` -> `Write`) and adds namespace stripping for colon-prefixed
-/// names (`namespace:tool` -> `tool`). Dot characters are preserved because
-/// some callers use them in actual tool names; only `:` is treated as the
-/// namespace delimiter.
-fn normalize_tool_name(raw: &str) -> String {
-    let mut name = raw.trim().trim_matches('"').trim_matches('\'').to_string();
-
-    if name.starts_with("name=") || name.starts_with("name =") {
-        name = name
-            .trim_start_matches("name")
-            .trim_start_matches('=')
-            .trim()
-            .trim_matches('"')
-            .trim_matches('\'')
-            .to_string();
-    }
-
-    if let Some(eq_pos) = name.find('=') {
-        name = name[..eq_pos].trim().to_string();
-    }
-
-    if let Some(colon) = name.rfind(':') {
-        let head = &name[..colon];
-        let tail = &name[colon + 1..];
-        let head_is_namespace =
-            !head.is_empty() && head.chars().all(is_tool_name_or_namespace_char);
-        if head_is_namespace && is_tool_name_component(tail) {
-            name = tail.to_string();
-        }
-    }
-
-    name
-}
-
 // ── Request types (from OpenAI-compatible clients) ──
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -495,6 +458,7 @@ pub use bare_json::*;
 pub use deepseek_v4_dsml::*;
 pub use gemma4::*;
 use helpers_a::*;
+pub(crate) use helpers_b::append_tool_choice_instruction;
 use helpers_b::*;
 pub use hermes::*;
 pub use minimax_xml::*;

--- a/crates/spark-server/src/tool_parser/helpers_a.rs
+++ b/crates/spark-server/src/tool_parser/helpers_a.rs
@@ -348,3 +348,40 @@ fn append_repaired_member(out: &mut String, member: &str, first: &mut bool) -> b
     out.push_str(&val_quoted);
     true
 }
+
+/// Normalize a model-emitted function name to the client-visible tool name.
+///
+/// This keeps existing parser salvage behaviour (`Bash=Bash` -> `Bash`,
+/// `name="Write"` -> `Write`) and adds namespace stripping for colon-prefixed
+/// names (`namespace:tool` -> `tool`). Dot characters are preserved because
+/// some callers use them in actual tool names; only `:` is treated as the
+/// namespace delimiter.
+pub(super) fn normalize_tool_name(raw: &str) -> String {
+    let mut name = raw.trim().trim_matches('"').trim_matches('\'').to_string();
+
+    if name.starts_with("name=") || name.starts_with("name =") {
+        name = name
+            .trim_start_matches("name")
+            .trim_start_matches('=')
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
+    }
+
+    if let Some(eq_pos) = name.find('=') {
+        name = name[..eq_pos].trim().to_string();
+    }
+
+    if let Some(colon) = name.rfind(':') {
+        let head = &name[..colon];
+        let tail = &name[colon + 1..];
+        let head_is_namespace =
+            !head.is_empty() && head.chars().all(is_tool_name_or_namespace_char);
+        if head_is_namespace && is_tool_name_component(tail) {
+            name = tail.to_string();
+        }
+    }
+
+    name
+}

--- a/crates/spark-server/src/tool_parser/helpers_b.rs
+++ b/crates/spark-server/src/tool_parser/helpers_b.rs
@@ -162,7 +162,7 @@ pub(super) fn gemma4_to_json(native: &str) -> String {
 }
 
 /// Shared tool_choice instruction appended to all system prompts.
-pub(super) fn append_tool_choice_instruction(prompt: &mut String, tool_choice: &ToolChoice) {
+pub(crate) fn append_tool_choice_instruction(prompt: &mut String, tool_choice: &ToolChoice) {
     match tool_choice {
         ToolChoice::Mode(s) if s == "required" => {
             prompt.push_str(

--- a/crates/spark-server/test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja
+++ b/crates/spark-server/test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}


### PR DESCRIPTION
## Summary

When the loaded checkpoint's **own** chat template renders tool instructions — every native Qwen 3.5/3.6 template does — Atlas injected a **second** copy from the tool parser. The request then carried two competing tool-format guidances, and the observed failure mode is the model emitting **literal `<tool_call><bash><command>` XML as content**, HTML-entity-escaped, which no parser recognises.

This resolves the ownership question once, in `prepare_chat_prompt`: if the template came from the checkpoint, the model type is a known native-Qwen one, and the template actually declares a `tools` variable, then the parser contributes **only** the tool-choice constraint (`required` / a named tool), not its schema block and not its behavioural Bash/Write/Edit guidance. Every other path — custom override template, ChatML fallback, Hermes, TSCG — keeps the parser prompt exactly as before.

**Base is `main`.** No stack. `crates/spark-server` only; no kernel, no model, no runtime change.

## What was wrong

Two comment blocks in the tree recorded the two halves of the oscillation, and neither fixed it:

- `api/chat/mod.rs` carried a 2026-05-25 note removing the parser prompt outright, because injecting it made the model emit free-form XML.
- `api/chat/prepare.rs` carried an ST-995 note restoring it, because **Hermes** needs the canonical NousResearch function-calling prompt to decline correctly on irrelevance prompts (hallucination ~96 with it, 30/64 without).

Both are right. They are about **different parsers**. The code had one global switch for a per-checkpoint question, so it kept getting flipped.

The concrete duplication: a native Qwen template renders the tool schema and the `<tool_call>` XML format from its `tools` argument. `qwen3_coder` / `qwen3_xml`'s `system_prompt` renders the same schema again, plus tool-agnostic behavioural text. The model receives two formats and picks a third.

## What the fix does

### The predicate is narrow, and each clause is there for a reason

`checkpoint_owns_qwen_tool_prompt(model_type, checkpoint, openai_override)` in `tokenizer/chat_impl.rs`:

| clause | why |
|---|---|
| `checkpoint` | the template came from the model dir's `config`/`tokenizer_config`, not from an override. `load_override_template` and the ChatML fallback both set this false — an operator's own template is not assumed to render tools. |
| `!openai_override` | an OpenAI-shaped jinja env is present, so the request is not going through the native path at all. |
| `model_type ∈ {qwen3_5, qwen3_5_moe, qwen3_6, qwen3_6_moe}` | an allow-list, not a heuristic. A new checkpoint family gets the old behaviour until someone adds it deliberately. |

and then, independently, the loaded template must actually declare `tools`:

```rust
&& jinja_env.get_template("chat")?.undeclared_variables(false).contains("tools")
```

A Qwen template that does *not* take `tools` keeps the parser prompt. So the suppression is a property of the template in hand, not of a name.

### What is still injected

`parser_tool_prompt` keeps `append_tool_choice_instruction` on the native path. `tool_choice: required` and named-tool choices are a **request-level constraint** the checkpoint template knows nothing about; dropping them would change behaviour, not just prose. `levers.tscg` also opts out of suppression entirely.

### Incidental

`normalize_tool_name` moves from `tool_parser.rs` to `tool_parser/helpers_a.rs` unchanged — `tool_parser.rs` was at the CI 500-LoC cap and the new code has to live somewhere. `api/chat/mod.rs` loses the two stale comment blocks and gains one line saying where the decision now lives.

## Oracle and evidence

`crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs` (207 lines, new), driven from `prepare.rs` via `#[path]` so it reaches the crate-private seam.

The fixture is the thing that makes this a real test: `crates/spark-server/test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja` is **the actual Qwen3.6 checkpoint template**, not a stub. The predicate's `undeclared_variables` clause is asserted against a template that really does render `tools`, so a change to how minijinja reports undeclared variables fails here rather than in production.

Covered: native Qwen + checkpoint template → schema suppressed, tool-choice retained; override template → parser prompt intact; ChatML fallback → intact; Hermes → intact (this is the ST-995 regression the 2026-05-25 removal caused); TSCG lever → intact; a Qwen template without `tools` → intact.

**No serving receipt is claimed.** The failure this fixes is a prompt-content defect observed in a live opencode session, not a number. The H100 box for this campaign is down and nothing here needed it.

## Test plan

Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, private `CARGO_TARGET_DIR`, isolated worktree against this branch fetched from the fork.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p spark-server --features cuda --all-targets --jobs 8 -- -D warnings` — **clean, rc=0**
- [x] `cargo test -p spark-server --bins --features cuda -- native_tool_prompt` — **5 passed, 0 failed** (2467 filtered)
- [x] `cargo test -p spark-server --bins --features cuda` — **2460 passed, 0 failed, 12 ignored** (`main`: 2455 → **+5**)
- [x] `cargo test -p spark-server --features cuda --lib` — **114 passed, 0 failed** (the thin library)
- [x] File-size cap — **0 violations** (`tool_parser.rs` comes back under the cap; that is why `normalize_tool_name` moved)
- [x] No `kernels/` change.

## GB10 perf-gate records

Touches `crates/` (a PERF_PATH), so committed `.benchmarks/` records are invalidated on landing. No perf path is altered; the re-measure is a formality. **But**: agentic/BFCL-style records taken against a native Qwen checkpoint were measured with the duplicated prompt in the context, so their prompt token counts and their tool-call accuracy are both taken under the old behaviour.

## What is NOT claimed

- **No perf claim.** The prompt gets shorter on the native path, which will move prompt token counts; nothing here measures that.
- **No accuracy claim.** The literal-XML failure is the motivation, and the fix removes its stated cause, but this PR presents no BFCL or agentic score.
- The allow-list is four model types. Other checkpoints whose templates render tools keep the duplication until they are added.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
