### PR TITLE
xgrammar: bound parallel cold mask preparation, and keep the serial default (#918)

### DIFF
--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -21,6 +21,11 @@ use super::extract_ordered_vocab;
 pub struct GrammarEngine {
     pub(super) compiler: GrammarCompiler,
     vocab_size: usize,
+    /// #918: the on-disk token-mask snapshot this engine loads at
+    /// startup and re-writes as the cross-grammar cache grows. `None`
+    /// until [`Self::attach_mask_cache`] runs, and when persistence is
+    /// switched off. See [`super::mask_cache`].
+    pub(super) snapshot: Option<super::mask_cache::MaskSnapshot>,
 }
 
 // SAFETY: GrammarEngine is initialized on the main thread and moved to the
@@ -152,6 +157,7 @@ impl GrammarEngine {
         Ok(Self {
             compiler,
             vocab_size,
+            snapshot: None,
         })
     }
 

--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -144,12 +144,9 @@ impl GrammarEngine {
 
     fn from_tokenizer_info(tokenizer_info: TokenizerInfo) -> Result<Self, GrammarError> {
         let vocab_size = tokenizer_info.vocab_size();
-        // Bound cold mask preparation without occupying the shared sampling
-        // pool. All workers join before prefill; warm masks remain cached.
-        let threads = std::thread::available_parallelism()
-            .map_err(|e| GrammarError::Compilation(format!("grammar CPU count: {e}")))?
-            .get()
-            .min(4) as i32;
+        // Restore the historical serial default: four-worker native-tool
+        // preparation has not improved cold latency in the measured workload.
+        // The compiler still supports bounded parallel preparation for callers.
         // Cache enabled with an explicit memory budget.
         // ★ NOT -1 (unlimited). `CacheKey::Schema` is keyed by the full tool
         // schema, so agentic traffic mints a distinct compiled grammar per
@@ -158,9 +155,8 @@ impl GrammarEngine {
         // above any realistic hot set (tens of schemas) while bounding the
         // tail. `-1` remains available as an explicit opt-in for callers that
         // genuinely want every grammar pinned.
-        let compiler =
-            GrammarCompiler::new(&tokenizer_info, threads, true, GRAMMAR_CACHE_BUDGET_BYTES)
-                .map_err(GrammarError::Compilation)?;
+        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, GRAMMAR_CACHE_BUDGET_BYTES)
+            .map_err(GrammarError::Compilation)?;
         Ok(Self {
             compiler,
             vocab_size,

--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -144,7 +144,13 @@ impl GrammarEngine {
 
     fn from_tokenizer_info(tokenizer_info: TokenizerInfo) -> Result<Self, GrammarError> {
         let vocab_size = tokenizer_info.vocab_size();
-        // Single compilation thread, cache enabled, no memory limit.
+        // Bound cold mask preparation without occupying the shared sampling
+        // pool. All workers join before prefill; warm masks remain cached.
+        let threads = std::thread::available_parallelism()
+            .map_err(|e| GrammarError::Compilation(format!("grammar CPU count: {e}")))?
+            .get()
+            .min(4) as i32;
+        // Cache enabled with an explicit memory budget.
         // ★ NOT -1 (unlimited). `CacheKey::Schema` is keyed by the full tool
         // schema, so agentic traffic mints a distinct compiled grammar per
         // request; unbounded, that grew host RSS ~100 MB/min under BFCL and is
@@ -152,8 +158,9 @@ impl GrammarEngine {
         // above any realistic hot set (tens of schemas) while bounding the
         // tail. `-1` remains available as an explicit opt-in for callers that
         // genuinely want every grammar pinned.
-        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, GRAMMAR_CACHE_BUDGET_BYTES)
-            .map_err(GrammarError::Compilation)?;
+        let compiler =
+            GrammarCompiler::new(&tokenizer_info, threads, true, GRAMMAR_CACHE_BUDGET_BYTES)
+                .map_err(GrammarError::Compilation)?;
         Ok(Self {
             compiler,
             vocab_size,

--- a/crates/spark-server/src/grammar/mask_cache.rs
+++ b/crates/spark-server/src/grammar/mask_cache.rs
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! On-disk persistence of the cross-grammar token-mask cache (#918).
+//!
+//! WHAT IS PERSISTED, AND WHY IT IS NOT KEYED BY SCHEMA
+//! ----------------------------------------------------
+//! #918 describes the cold cost as "per new tool schema". The CPU
+//! measurement behind this module says otherwise — it is per *process*.
+//! M5 Max, release, Qwen3 ByteLevel-BPE tokenizer (151,669 tokens), the
+//! coherency gate's `get_weather` schema through
+//! `compile_qwen3_coder_tool_grammar`, single-shot:
+//!
+//! ```text
+//! schema                                   construct   mask prewarm
+//! get_weather(city, days)                     5.5 ms       621.2 ms
+//! get_weather(city, days)  — again            0.1 ms         0.0 ms
+//! search_docs(query, limit) — NEW schema      4.9 ms        16.0 ms
+//! run_cmd(command, timeout) — NEW schema      4.9 ms        14.2 ms
+//! ```
+//!
+//! A second, entirely different schema costs ~2.5% of the first because
+//! xgrammar's Tier-2 `RuleLevelCache` keys masks *structurally*: every
+//! JSON tool schema reuses the same string / number / whitespace /
+//! punctuation sub-rules. So what has to survive a restart is the
+//! RULE-level cache, not a compiled grammar keyed by schema text — a
+//! schema-keyed file would only ever help an exact repeat and would
+//! miss the 97% that already transfers. The snapshot is therefore keyed
+//! by the TOKENIZER (fingerprint + vocab size); see
+//! `xgrammar::compiler::mask_snapshot`.
+//!
+//! WHEN IT IS WRITTEN
+//! ------------------
+//! From the background prewarm thread, after it has warmed a grammar —
+//! never from the request thread. The first grammar-bearing request of
+//! the first process still pays today's cost (minus whatever the
+//! prefill overlap hides); every process after that starts warm, for
+//! schemas it has never seen. Same harness, n=3: the whole cold path
+//! (schema in hand to first constrained mask filled) goes 624.8 ms ->
+//! 5.2-5.3 ms for the same schema and 5.0-19.1 ms for one this build
+//! has never compiled.
+//!
+//! Controls: `ATLAS_GRAMMAR_CACHE=0` disables persistence entirely;
+//! `ATLAS_GRAMMAR_CACHE_DIR` relocates the file (for a read-only model
+//! directory, or to share one warm cache across several model copies of
+//! the same tokenizer).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use xgrammar::compiler::{RuleLevelCache, SnapshotIdentity, mask_snapshot};
+
+use super::engine::GrammarEngine;
+
+/// Directory name created under the model directory.
+const CACHE_DIR_NAME: &str = ".atlas-grammar-cache";
+
+/// Upper bound on masks written to disk, most-recently-used first.
+///
+/// The in-memory rule cache is bounded by ~1/3 GiB, which is far more
+/// than belongs in a file next to a checkpoint. Measured mask footprint
+/// is ~19 KB at a 151,669-token vocabulary (2.36 MB for the 123 masks
+/// of one tool grammar), so 512 caps the snapshot around 10 MB there
+/// and ~16 MB at Qwen3.6's 248,320 — several distinct tool grammars'
+/// worth, which is all the reuse the structural key can deliver anyway.
+const MAX_PERSISTED_MASKS: usize = 512;
+
+/// Everything the background saver needs, with no reference to the
+/// (`!Sync`) compiler.
+pub(super) struct MaskSnapshot {
+    path: PathBuf,
+    identity: SnapshotIdentity,
+    cache: RuleLevelCache,
+    /// Entry count at the last successful write — the save is skipped
+    /// unless the cache has grown since.
+    saved_entries: Arc<AtomicUsize>,
+    /// One writer at a time; a second concurrent prewarm just skips.
+    writing: Arc<AtomicBool>,
+}
+
+/// A callback the background prewarm invokes once a grammar's masks are
+/// warm. Boxed so `state.rs` needs no knowledge of persistence.
+pub type PrewarmHook = Arc<dyn Fn(usize) + Send + Sync>;
+
+/// `ATLAS_GRAMMAR_CACHE=0` (or `false`/`off`/`no`) disables the on-disk
+/// mask cache. Anything else — including unset — enables it.
+pub(super) fn cache_enabled_from(value: Option<&str>) -> bool {
+    !matches!(
+        value
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "off" | "no"
+    )
+}
+
+/// Where the snapshot for `fingerprint` lives.
+///
+/// `ATLAS_GRAMMAR_CACHE_DIR` wins when set — a model directory pulled
+/// from a read-only mount cannot host the file, and one warm cache can
+/// legitimately serve several copies of the same checkpoint.
+pub(super) fn snapshot_path(
+    model_dir: &Path,
+    dir_override: Option<&str>,
+    fingerprint: u64,
+) -> PathBuf {
+    let dir = match dir_override.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(d) => PathBuf::from(d),
+        None => model_dir.join(CACHE_DIR_NAME),
+    };
+    dir.join(format!("masks-{fingerprint:016x}.bin"))
+}
+
+impl GrammarEngine {
+    /// Seed the cross-grammar mask cache from a snapshot written by an
+    /// earlier process, and arm the background saver (#918).
+    ///
+    /// Returns the number of masks imported; `0` is a miss (no file, a
+    /// different tokenizer, a different build, or a corrupt file) and is
+    /// not an error — the engine just compiles as it did before.
+    /// Called once, at server startup, off any request path.
+    pub fn attach_mask_cache(&mut self, model_dir: &Path) {
+        if !cache_enabled_from(std::env::var("ATLAS_GRAMMAR_CACHE").ok().as_deref()) {
+            tracing::info!("Grammar: on-disk mask cache disabled (ATLAS_GRAMMAR_CACHE)");
+            return;
+        }
+        let Some(cache) = self.compiler.rule_cache_handle() else {
+            return; // compiler built with caching off — nothing to persist
+        };
+        let identity = self.compiler.snapshot_identity();
+        let path = snapshot_path(
+            model_dir,
+            std::env::var("ATLAS_GRAMMAR_CACHE_DIR").ok().as_deref(),
+            identity.tokenizer_fingerprint,
+        );
+        let imported = match self.compiler.load_mask_snapshot(&path) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(
+                    "Grammar: mask snapshot unreadable at {}: {e}",
+                    path.display()
+                );
+                0
+            }
+        };
+        if imported > 0 {
+            tracing::info!(
+                "Grammar: warmed {imported} token masks from {} — the first tool-call \
+                 request skips the cold mask compile (#918)",
+                path.display(),
+            );
+        } else {
+            tracing::info!(
+                "Grammar: no usable mask snapshot at {}; the first grammar of this \
+                 process will compute and persist one (#918)",
+                path.display(),
+            );
+        }
+        self.snapshot = Some(MaskSnapshot {
+            path,
+            identity,
+            cache,
+            saved_entries: Arc::new(AtomicUsize::new(imported)),
+            writing: Arc::new(AtomicBool::new(false)),
+        });
+    }
+
+    /// The callback handed to a request's background prewarm, which
+    /// persists the grown mask cache once that prewarm finishes.
+    /// `None` when persistence is off or the engine was never attached.
+    pub(crate) fn mask_snapshot_hook(&self) -> Option<PrewarmHook> {
+        let snap = self.snapshot.as_ref()?;
+        let (path, identity) = (snap.path.clone(), snap.identity);
+        let cache = snap.cache.clone();
+        let saved = Arc::clone(&snap.saved_entries);
+        let writing = Arc::clone(&snap.writing);
+        Some(Arc::new(move |_warmed: usize| {
+            if cache.len() <= saved.load(Ordering::Relaxed) {
+                return; // nothing new to persist
+            }
+            if writing.swap(true, Ordering::AcqRel) {
+                return; // another prewarm is already writing
+            }
+            // The encode + fsync (~27 ms for 2.4 MB at a 151,669-token
+            // vocabulary) runs on a THIRD thread, not this one: the
+            // request's first constrained fill joins the prewarm
+            // thread, and it must wait for masks, never for I/O.
+            let (path, cache, saved) = (path.clone(), cache.clone(), Arc::clone(&saved));
+            let done = Arc::clone(&writing);
+            let spawned = std::thread::Builder::new()
+                .name("grammar-mask-save".to_string())
+                .spawn(move || {
+                    let written =
+                        mask_snapshot::save_to_file(&cache, identity, &path, MAX_PERSISTED_MASKS);
+                    match written {
+                        Ok(n) => {
+                            saved.store(n, Ordering::Relaxed);
+                            tracing::debug!(
+                                "Grammar: persisted {n} token masks to {}",
+                                path.display()
+                            );
+                        }
+                        // A read-only model directory is a normal
+                        // deployment, not a fault: the server keeps
+                        // working, just cold at boot.
+                        Err(e) => tracing::debug!(
+                            "Grammar: could not persist masks to {}: {e}",
+                            path.display()
+                        ),
+                    }
+                    done.store(false, Ordering::Release);
+                });
+            if let Err(e) = spawned {
+                tracing::debug!("Grammar: mask-snapshot writer not spawned: {e}");
+                writing.store(false, Ordering::Release);
+            }
+        }))
+    }
+}

--- a/crates/spark-server/src/grammar/mod.rs
+++ b/crates/spark-server/src/grammar/mod.rs
@@ -11,6 +11,8 @@
 mod compile_misc;
 mod compile_tools;
 mod engine;
+mod mask_cache;
+mod prewarm;
 mod schema;
 mod state;
 
@@ -18,6 +20,7 @@ mod state;
 pub(crate) mod tests;
 
 pub use engine::{GrammarEngine, GrammarError};
+pub use mask_cache::PrewarmHook;
 pub use schema::augment_schema_with_tafc_think;
 pub use state::{GrammarState, grammar_blocks_stop};
 

--- a/crates/spark-server/src/grammar/prewarm.rs
+++ b/crates/spark-server/src/grammar/prewarm.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Background token-mask prewarm, overlapped with prompt prefill (#918).
+//!
+//! WHAT THIS MOVES OFF THE CRITICAL PATH
+//! -------------------------------------
+//! [`xgrammar::CompiledGrammar::compile_top_k_masks`] is the dominant
+//! term of a cold grammar-constrained request. Measured on CPU (M5 Max,
+//! release, Qwen3 ByteLevel-BPE tokenizer, 151,669-token vocabulary, the
+//! coherency gate's `get_weather` schema through
+//! `compile_qwen3_coder_tool_grammar`, single-shot):
+//!
+//! ```text
+//! grammar construction      4.9-5.5 ms
+//! mask prewarm          596.7-621.2 ms   (123 reachable scanable states)
+//! matcher + first fill      0.1-0.3 ms
+//! ```
+//!
+//! #918 reports ~3.2 s for the same phase on the H100 host at 248,320
+//! tokens. `compile_grammar_state` runs BEFORE the prompt forward pass
+//! (`prefill_a_step.rs` / `prefill_b_step.rs`), so all of it lands in
+//! front of the first token even though the GPU is about to be busy for
+//! 370-1,400 ms with the prefill itself. Running the prewarm on its own
+//! thread hides that much of it; the first constrained sample joins.
+//! Measured on the same CPU harness, moving it off the request thread
+//! releases that thread after 4.9 ms instead of 624.8 ms (n=3), so the
+//! whole remainder is available to overlap the forward pass.
+//!
+//! WHY THIS IS NOT A PARALLEL PREWARM
+//! ----------------------------------
+//! An H100 experiment that made the prewarm loop itself four-way
+//! parallel was measured and abandoned: four workers contending on the
+//! shared `Arc<GrammarData>` made cold latency WORSE (5.28-6.57 s vs
+//! 4.82 s). This changes nothing about that loop — `compile_top_k_masks`
+//! stays the serial JIT walk it is in tree, and `GrammarCompiler`'s
+//! `max_threads` stays recorded-but-unused — it only moves the whole
+//! serial walk off the request thread. No two workers ever touch one
+//! grammar.
+//!
+//! Kill switch: `ATLAS_GRAMMAR_ASYNC_PREWARM=0` restores the synchronous
+//! prewarm.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use xgrammar::CompiledGrammar;
+
+use super::PrewarmHook;
+
+/// A rendezvous the background worker waits on before doing any work.
+///
+/// Always `None` in production. The ordering test passes one so it can
+/// hold the prewarm open and prove that (a) `GrammarState` construction
+/// did not block on it and (b) the first mask fill did. It is a plain
+/// field rather than a `#[cfg(test)]` global precisely so a gated state
+/// in one test can never stall a `GrammarState` built anywhere else.
+pub(super) type PrewarmGate = Arc<std::sync::Barrier>;
+
+/// A prewarm that is either still running on its own thread or finished.
+///
+/// Dropping a `Pending` prewarm — an abandoned or cancelled request —
+/// detaches the worker rather than cancelling it. That is deliberate:
+/// the work is bounded (one `compile_top_k_masks` pass), it holds only
+/// its own `CompiledGrammar` clone, and its result lands in the shared
+/// cross-grammar cache where the NEXT request benefits from it.
+pub(super) enum Prewarm {
+    /// Running. The `JoinHandle` yields the number of masks warmed; the
+    /// flag lets callers ask "done?" without joining.
+    Pending {
+        handle: std::thread::JoinHandle<usize>,
+        finished: Arc<AtomicBool>,
+    },
+    /// Joined, or never spawned (kill switch / thread-spawn failure).
+    Done(usize),
+}
+
+impl Prewarm {
+    /// Start warming the `k` costliest masks of `compiled`.
+    ///
+    /// Returns immediately when the async path is enabled and a thread
+    /// could be spawned; otherwise does the work inline, which is
+    /// exactly the pre-#918 behaviour.
+    pub(super) fn start(compiled: &CompiledGrammar, k: usize) -> Self {
+        Self::start_with(compiled, k, None, overlap_enabled(), None)
+    }
+
+    /// The whole policy, with the overlap decision passed in rather
+    /// than read from the environment — so a test can exercise BOTH
+    /// paths without mutating a process-wide variable other tests in
+    /// the same binary are concurrently reading.
+    pub(super) fn start_with(
+        compiled: &CompiledGrammar,
+        k: usize,
+        gate: Option<PrewarmGate>,
+        overlap: bool,
+        on_warm: Option<PrewarmHook>,
+    ) -> Self {
+        if !overlap {
+            // The pre-#918 behaviour: warm inline, on this thread. The
+            // gate is a background-worker rendezvous and has no meaning
+            // here, so it is dropped rather than waited on.
+            drop(gate);
+            let warmed = compiled.compile_top_k_masks(k);
+            if let Some(hook) = on_warm {
+                hook(warmed);
+            }
+            return Prewarm::Done(warmed);
+        }
+        let owned = compiled.clone();
+        let finished = Arc::new(AtomicBool::new(false));
+        let done_flag = Arc::clone(&finished);
+        let spawned = std::thread::Builder::new()
+            .name("grammar-prewarm".to_string())
+            .spawn(move || {
+                if let Some(gate) = gate {
+                    gate.wait();
+                }
+                let warmed = owned.compile_top_k_masks(k);
+                // Persist AFTER the masks are in the shared cache but
+                // BEFORE the finished flag: the request's first fill
+                // then never races the snapshot write, and the write
+                // still costs the request nothing — it is on this
+                // thread, which the prefill is already hiding.
+                if let Some(hook) = on_warm {
+                    hook(warmed);
+                }
+                done_flag.store(true, Ordering::Release);
+                warmed
+            });
+        match spawned {
+            Ok(handle) => Prewarm::Pending { handle, finished },
+            // Under thread pressure, do the work here rather than
+            // leaving the masks cold — a cold decode loop costs ~41 ms
+            // per token (see `FORCED_TOKEN_TOP_K`), far worse than a
+            // slow prefill.
+            Err(e) => {
+                tracing::debug!("Grammar: prewarm thread spawn failed ({e}); warming inline");
+                Prewarm::Done(compiled.compile_top_k_masks(k))
+            }
+        }
+    }
+
+    /// Block until the masks are warm. Idempotent; called at every site
+    /// that is about to read a token mask.
+    pub(super) fn wait(&mut self) -> usize {
+        match self {
+            Prewarm::Done(n) => *n,
+            Prewarm::Pending { .. } => {
+                let Prewarm::Pending { handle, .. } = std::mem::replace(self, Prewarm::Done(0))
+                else {
+                    unreachable!("just matched Pending");
+                };
+                // A panicked prewarm is not fatal: the mask cache is
+                // only a cache, and the matcher recomputes lazily.
+                let warmed = handle.join().unwrap_or_else(|_| {
+                    tracing::warn!("Grammar: background mask prewarm panicked; masks stay lazy");
+                    0
+                });
+                *self = Prewarm::Done(warmed);
+                warmed
+            }
+        }
+    }
+
+    /// Whether the worker has already finished, without joining it.
+    #[cfg(test)]
+    pub(super) fn is_finished(&self) -> bool {
+        match self {
+            Prewarm::Done(_) => true,
+            Prewarm::Pending { finished, .. } => finished.load(Ordering::Acquire),
+        }
+    }
+}
+
+/// The serve-path overlap decision. See [`overlap_enabled`].
+pub(super) fn overlap_enabled_for_serve() -> bool {
+    overlap_enabled()
+}
+
+/// Whether the prewarm overlaps prefill, read ONCE per process: the
+/// answer cannot change while a server runs, and a `getenv` per
+/// grammar-bearing request is pure overhead.
+fn overlap_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        overlap_from_env(std::env::var("ATLAS_GRAMMAR_ASYNC_PREWARM").ok().as_deref())
+    })
+}
+
+/// `ATLAS_GRAMMAR_ASYNC_PREWARM=0` (or `false`/`off`/`no`) restores the
+/// synchronous prewarm. Anything else — including unset — overlaps.
+pub(super) fn overlap_from_env(value: Option<&str>) -> bool {
+    !matches!(
+        value
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "off" | "no"
+    )
+}

--- a/crates/spark-server/src/grammar/state.rs
+++ b/crates/spark-server/src/grammar/state.rs
@@ -5,6 +5,7 @@
 use xgrammar::{CompiledGrammar, GrammarMatcher, allocate_token_bitmask, reset_token_bitmask};
 
 use super::engine::GrammarError;
+use super::prewarm::Prewarm;
 
 // ── GrammarState ───────────────────────────────────────────────────────
 
@@ -17,6 +18,13 @@ use super::engine::GrammarError;
 /// — which runs during the prefill phase of a grammar-constrained
 /// request, while the GPU is busy with the prompt — so the first decode
 /// steps never pay a cold mask-computation stall.
+///
+/// #918: this is ALSO the dominant cold-start cost — ~621 ms of a
+/// ~625 ms cold grammar preparation on CPU (M5 Max, release, Qwen3
+/// 151,669-token vocabulary, the coherency gate's `get_weather` schema,
+/// n=3; ~3.2 s at 248K vocab on the H100 host). It now runs on its own
+/// thread so it overlaps the prompt forward pass instead of preceding
+/// it; the first call that reads a mask joins. See [`super::prewarm`].
 ///
 /// `512`: measured on Qwen3.6-35B-A3B (248K vocab, qwen3_coder structural-tag
 /// grammar, GB10), the old `8` left the decode loop's resident states —
@@ -37,6 +45,12 @@ pub struct GrammarState {
     /// The run's verify-timing sink.
     timing: std::sync::Arc<crate::scheduler::mtp_timing::RunTiming>,
     matcher: GrammarMatcher,
+    /// #918: the top-k mask prewarm, running on its own thread so it
+    /// overlaps prefill. Joined by [`Self::await_masks`] before ANY
+    /// read of a token mask, so a constrained sample never observes a
+    /// half-warmed cache — the ordering the pre-#918 synchronous call
+    /// gave for free.
+    prewarm: Prewarm,
     /// Bitmask buffer: `Box<[i32]>` of shape `(1, ceil(vocab_size / 32))`.
     bitmask_data: Box<[i32]>,
     vocab_size: usize,
@@ -79,6 +93,24 @@ impl GrammarState {
         Self::with_timing(compiled, vocab_size, std::sync::Arc::default())
     }
 
+    /// Same as [`Self::new`], plus the #918 on-disk mask-cache hook the
+    /// background prewarm calls once this grammar's masks are warm.
+    /// The production creation site (`compile_grammar_state`) uses this;
+    /// unit tests of pure grammar structure keep the two-arg form.
+    pub fn new_with_hook(
+        compiled: &CompiledGrammar,
+        vocab_size: usize,
+        on_warm: Option<super::PrewarmHook>,
+    ) -> Result<Self, GrammarError> {
+        Self::build_with(
+            compiled,
+            vocab_size,
+            None,
+            super::prewarm::overlap_enabled_for_serve(),
+            on_warm,
+        )
+    }
+
     /// Same, with the run's timing sink. The grammar engine records two verify
     /// phases and has no scheduler context of its own — it is handed the sink
     /// rather than reaching for a global one.
@@ -93,6 +125,36 @@ impl GrammarState {
     }
 
     fn build(compiled: &CompiledGrammar, vocab_size: usize) -> Result<Self, GrammarError> {
+        Self::build_with(
+            compiled,
+            vocab_size,
+            None,
+            super::prewarm::overlap_enabled_for_serve(),
+            None,
+        )
+    }
+
+    /// Construction seam for the #918 ordering test: `gate`, when
+    /// `Some`, parks the background prewarm worker until the test
+    /// releases it. Production always passes `None` via [`Self::build`].
+    pub(super) fn build_gated(
+        compiled: &CompiledGrammar,
+        vocab_size: usize,
+        gate: Option<super::prewarm::PrewarmGate>,
+    ) -> Result<Self, GrammarError> {
+        Self::build_with(compiled, vocab_size, gate, true, None)
+    }
+
+    /// Same, with the overlap decision forced — the #918 tests drive
+    /// both the overlapped and the inline path without touching the
+    /// process environment.
+    pub(super) fn build_with(
+        compiled: &CompiledGrammar,
+        vocab_size: usize,
+        gate: Option<super::prewarm::PrewarmGate>,
+        overlap: bool,
+        on_warm: Option<super::PrewarmHook>,
+    ) -> Result<Self, GrammarError> {
         let matcher = GrammarMatcher::new(
             compiled, None,  // use stop tokens from compiled grammar
             false, // require stop token for proper termination
@@ -102,19 +164,17 @@ impl GrammarState {
 
         // Tier 2 (overlapped mask generation): eagerly compute the
         // costliest masks so they are warm before the first decode
-        // step. Pure cache population — no behavioral effect.
-        let warmed = compiled.compile_top_k_masks(FORCED_TOKEN_TOP_K);
-        tracing::debug!(
-            warmed,
-            requested = FORCED_TOKEN_TOP_K,
-            "Grammar: pre-warmed top-k token masks during prefill"
-        );
+        // step. Pure cache population — no behavioral effect, which is
+        // why it is safe to run concurrently with the prompt forward
+        // pass and join lazily (#918).
+        let prewarm = Prewarm::start_with(compiled, FORCED_TOKEN_TOP_K, gate, overlap, on_warm);
 
         let bitmask_data = allocate_token_bitmask(1, vocab_size);
 
         Ok(Self {
             timing: std::sync::Arc::default(),
             matcher,
+            prewarm,
             bitmask_data,
             vocab_size,
             stop_tokens: Box::new([]),
@@ -133,6 +193,30 @@ impl GrammarState {
     pub fn with_stop_tokens(mut self, stop_tokens: &[u32]) -> Self {
         self.stop_tokens = stop_tokens.to_vec().into_boxed_slice();
         self
+    }
+
+    /// Whether the background prewarm has completed, without joining
+    /// it — the ordering oracle for the #918 tests.
+    #[cfg(test)]
+    pub(super) fn prewarm_finished(&self) -> bool {
+        self.prewarm.is_finished()
+    }
+
+    /// Join the background top-k mask prewarm (#918).
+    ///
+    /// Called at the head of every path that reads a token mask. After
+    /// it returns, the mask cache holds exactly what the pre-#918
+    /// synchronous `compile_top_k_masks` left there, so nothing
+    /// downstream can observe the difference except the latency.
+    fn await_masks(&mut self) {
+        let warmed = self.prewarm.wait();
+        if warmed > 0 {
+            tracing::debug!(
+                warmed,
+                requested = FORCED_TOKEN_TOP_K,
+                "Grammar: pre-warmed top-k token masks overlapped with prefill"
+            );
+        }
     }
 
     /// Fill the allowed-token bitmask for the next decode step.
@@ -163,6 +247,9 @@ impl GrammarState {
         if self.bitmask_valid {
             return self.bitmask_fill_result;
         }
+        // The FIRST fill is the first constrained sample of the request:
+        // this is where the overlapped prewarm is collected (#918).
+        self.await_masks();
         let t_fill = std::time::Instant::now();
         reset_token_bitmask(&mut self.bitmask_data);
         let filled = self
@@ -315,6 +402,7 @@ impl GrammarState {
     /// `None` if no close is found within `max_bytes`. `Some(empty)` means
     /// the grammar can already stop. Leaves matcher state unchanged.
     pub fn completion_token_ids(&mut self, max_bytes: usize) -> Option<Vec<i32>> {
+        self.await_masks();
         self.matcher.find_completion_token_ids(max_bytes)
     }
 

--- a/crates/spark-server/src/grammar/tests/cold_compile.rs
+++ b/crates/spark-server/src/grammar/tests/cold_compile.rs
@@ -131,7 +131,20 @@ fn await_snapshot(dir: &std::path::Path) -> Option<u64> {
     while Instant::now() < deadline {
         if let Ok(entries) = std::fs::read_dir(dir.join(".atlas-grammar-cache")) {
             for entry in entries.filter_map(Result::ok) {
-                if entry.file_name().to_string_lossy().starts_with("masks-") {
+                // `.bin` is load-bearing, not decoration. `save_to_file`
+                // writes atomically as tmp + fsync + rename, and its temp
+                // name is `path.with_extension("tmp<pid>")` — i.e.
+                // `masks-<fp>.tmp12345`, which ALSO starts with "masks-".
+                // Waiting on the prefix alone returns while the writer is
+                // still filling the temp file, so "process 2" opens a
+                // `masks-<fp>.bin` that does not exist yet, recomputes every
+                // mask, and the test reads cold==warm. That is this test
+                // failing roughly half the time, and it is the wait
+                // predicate that is wrong — the persistence it checks is
+                // correct and genuinely atomic.
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("masks-") && name.ends_with(".bin") {
                     let len = entry.metadata().ok()?.len();
                     if len > 0 {
                         return Some(len);

--- a/crates/spark-server/src/grammar/tests/cold_compile.rs
+++ b/crates/spark-server/src/grammar/tests/cold_compile.rs
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! #918 — cold grammar preparation for a new tool schema.
+//!
+//! The phase split this module measures (M5 Max, `--release`, Qwen3
+//! ByteLevel-BPE tokenizer with 151,669 tokens, the coherency gate's
+//! `get_weather` schema through `compile_qwen3_coder_tool_grammar` —
+//! reproduce with
+//! `QWEN_TOKENIZER_JSON=... cargo test --release ... phase_timings -- --ignored --nocapture`):
+//!
+//! ```text
+//! engine build (TokenizerInfo)               101.9-128.0 ms   once per process
+//! grammar construction                           4.9-5.5 ms   per schema
+//! top-k mask prewarm, first grammar         596.7-621.2 ms   <-- the cold cost
+//! top-k mask prewarm, same schema again              0.0 ms
+//! top-k mask prewarm, a DIFFERENT schema       14.2-16.2 ms
+//! matcher construction + first mask fill         0.1-0.3 ms
+//! ```
+//!
+//! End to end, "tool schema in hand" to "first constrained mask filled",
+//! same box and build, n=3 (`cold_vs_snapshot_warm_with_a_real_tokenizer`):
+//!
+//! ```text
+//! cold, nothing on disk                            624.8 ms
+//!   of which the request thread is held               4.9 ms
+//! warm from an on-disk snapshot, same schema     5.2-5.3 ms
+//! warm from an on-disk snapshot, unseen schema  5.0-19.1 ms
+//! ```
+//!
+//! Two facts drive the fix: the prewarm is ~99% of the cold path, and it
+//! is paid once per PROCESS, not once per schema — a second, unrelated
+//! schema costs ~2.5% of the first because xgrammar's Tier-2 rule cache
+//! keys masks structurally. So: persist that cache across processes
+//! (`super::super::mask_cache`) and overlap what is left with prefill
+//! (`super::super::prewarm`).
+
+use std::time::{Duration, Instant};
+
+use super::*;
+use crate::grammar::GrammarState;
+
+/// A deterministic synthetic vocabulary: single printable ASCII plus
+/// three-character combinations, then the tool-call control tokens the
+/// qwen3_coder grammar needs. Wide enough that mask generation dominates
+/// (so the ratios below mean something), narrow enough to stay fast in a
+/// debug `cargo test`. Production vocabularies are 100-250x wider, which
+/// is why every assertion here is a RATIO and never a time.
+fn wide_vocab(n: usize) -> Vec<String> {
+    let alphabet: Vec<char> = (b' '..=b'~').map(|c| c as char).collect();
+    let mut vocab: Vec<String> = alphabet.iter().map(|c| c.to_string()).collect();
+    let mut i = 0usize;
+    while vocab.len() < n {
+        let a = alphabet[i % alphabet.len()];
+        let b = alphabet[(i / alphabet.len()) % alphabet.len()];
+        let c = alphabet[(i / (alphabet.len() * alphabet.len())) % alphabet.len()];
+        vocab.push(format!("{a}{b}{c}"));
+        i += 1;
+    }
+    vocab.truncate(n);
+    vocab.extend(["<tool_call>", "</tool_call>", "<eos>"].map(String::from));
+    vocab
+}
+
+const VOCAB: usize = 1024;
+
+fn engine() -> GrammarEngine {
+    let vocab = wide_vocab(VOCAB);
+    let eos = (vocab.len() - 1) as i32;
+    GrammarEngine::new(&vocab, &[eos]).expect("engine builds")
+}
+
+/// The coherency gate's tool, and a second tool that shares no name.
+fn tool(name: &str, a: &str, b: &str) -> Vec<ToolDefinition> {
+    serde_json::from_value(serde_json::json!([{
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": "Look up the current weather for a city.",
+            "parameters": {"type": "object", "properties": {
+                a: {"type": "string", "description": "City name."},
+                b: {"type": "integer", "description": "Forecast horizon in days."}},
+                "required": [a, b]},
+        }
+    }]))
+    .unwrap()
+}
+
+/// Compile a tool grammar and warm its masks, returning the wall time of
+/// the whole cold path a request pays before its first constrained
+/// token, plus the state (so callers can compare the resulting masks).
+fn prepare(engine: &mut GrammarEngine, tools: &[ToolDefinition]) -> (Duration, GrammarState) {
+    let started = Instant::now();
+    let compiled = engine
+        .compile_qwen3_coder_tool_grammar(tools, true, "</parameter>")
+        .expect("tool grammar compiles");
+    let hook = engine.mask_snapshot_hook();
+    let mut state =
+        GrammarState::new_with_hook(&compiled, engine.vocab_size(), hook).expect("grammar state");
+    // The first constrained sample — this is what joins the overlapped
+    // prewarm, so it is the honest end of the cold path.
+    state.fill_bitmask();
+    (started.elapsed(), state)
+}
+
+/// Size of the snapshot file under `dir`, once it appears.
+///
+/// The write runs on its own thread (so a request's first constrained
+/// fill never waits for I/O — see `mask_cache::mask_snapshot_hook`), so
+/// the test polls instead of assuming the file is already there.
+fn await_snapshot(dir: &std::path::Path) -> Option<u64> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if let Ok(entries) = std::fs::read_dir(dir.join(".atlas-grammar-cache")) {
+            for entry in entries.filter_map(Result::ok) {
+                if entry.file_name().to_string_lossy().starts_with("masks-") {
+                    let len = entry.metadata().ok()?.len();
+                    if len > 0 {
+                        return Some(len);
+                    }
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    None
+}
+
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "atlas-918-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    dir
+}
+
+#[test]
+fn a_second_distinct_schema_reuses_the_first_schemas_masks() {
+    // The measurement that redirects #918 from "per schema" to "per
+    // process": on the real Qwen3 vocabulary an unrelated second schema
+    // cost 16.2 ms against the first's 596.7 ms, because xgrammar's
+    // Tier-2 rule cache keys masks STRUCTURALLY and every JSON tool
+    // schema shares its string / number / whitespace / punctuation
+    // sub-rules.
+    //
+    // Asserted on the cache's hit/miss COUNTERS, not on wall clock. The
+    // size of the saving is cost-weighted, not count-weighted: the
+    // shared rules are the broad free-form value scanners (one mask
+    // each, most of the time), while the misses are cheap per-schema
+    // literal keys. Observed here: 31 hits / 94 misses yet 1.5x faster
+    // at a 1,027-token vocabulary; 37x faster at 151,669, where those
+    // value scanners are almost the whole bill. The invariant worth
+    // gating is therefore "a schema this engine never saw still reuses
+    // masks at all" — which goes to zero the moment the cross-grammar
+    // cache is keyed per schema, disabled, or its FSM hashing breaks.
+    let mut engine = engine();
+    let cache = engine
+        .compiler
+        .rule_cache_handle()
+        .expect("serve compilers enable the rule cache");
+
+    prepare(&mut engine, &tool("get_weather", "city", "days"));
+    let (hits_after_first, misses_after_first) = cache.hit_miss();
+    assert!(
+        misses_after_first > 0,
+        "the first schema should have computed masks, not found them"
+    );
+
+    prepare(&mut engine, &tool("search_docs", "query", "limit"));
+    let (hits, misses) = cache.hit_miss();
+    let (new_hits, new_misses) = (hits - hits_after_first, misses - misses_after_first);
+    assert!(
+        new_hits > 0,
+        "cross-schema mask reuse lost: the second schema hit {new_hits} / missed {new_misses}"
+    );
+}
+
+#[test]
+fn a_persisted_snapshot_removes_the_cold_prewarm_for_the_next_process() {
+    let dir = scratch("hit");
+    let tools = tool("get_weather", "city", "days");
+
+    // "Process" 1: nothing on disk. Pays the cold path, then the
+    // background prewarm persists the cross-grammar masks.
+    let mut first = engine();
+    first.attach_mask_cache(&dir);
+    let (cold, cold_state) = prepare(&mut first, &tools);
+    let snapshot = await_snapshot(&dir).expect("snapshot written by the background prewarm");
+    assert!(snapshot > 0, "snapshot file is empty");
+
+    // "Process" 2: same model directory, fresh engine.
+    let mut second = engine();
+    second.attach_mask_cache(&dir);
+    let (warm, warm_state) = prepare(&mut second, &tools);
+
+    // Correctness before speed: the warm path must produce the same
+    // first-token mask, bit for bit.
+    assert_eq!(
+        cold_state.bitmask_data(),
+        warm_state.bitmask_data(),
+        "snapshot-warmed grammar admits a different first token set"
+    );
+    assert!(
+        cold > warm * 3,
+        "the snapshot did not remove the cold prewarm: cold={cold:?} warm={warm:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_snapshot_from_a_different_tokenizer_is_a_miss() {
+    let dir = scratch("miss");
+    let tools = tool("get_weather", "city", "days");
+
+    let mut writer = engine();
+    writer.attach_mask_cache(&dir);
+    prepare(&mut writer, &tools);
+    await_snapshot(&dir).expect("the writing engine persisted its masks");
+
+    // A different vocabulary: same count, different bytes. Its
+    // fingerprint differs, so it must not adopt the other's masks —
+    // it looks for (and finds) no file of its own.
+    let other_vocab: Vec<String> = wide_vocab(VOCAB).iter().map(|t| format!("z{t}")).collect();
+    let eos = (other_vocab.len() - 1) as i32;
+    let mut reader = GrammarEngine::new(&other_vocab, &[eos]).expect("engine builds");
+    reader.attach_mask_cache(&dir);
+    let names: Vec<String> = std::fs::read_dir(dir.join(".atlas-grammar-cache"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        names.len(),
+        1,
+        "a second tokenizer must not reuse the first's file: {names:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The benchmark-style harness that produced the phase table above.
+/// Ignored by default: it needs a real 100K+ tokenizer on disk and is a
+/// diagnostic, not a gate.
+#[test]
+#[ignore = "CPU diagnostic: set QWEN_TOKENIZER_JSON to an existing tokenizer.json"]
+fn phase_timings_with_a_real_tokenizer() {
+    let path = std::env::var("QWEN_TOKENIZER_JSON").expect("QWEN_TOKENIZER_JSON");
+    let tokenizer = tokenizers::Tokenizer::from_file(path).expect("tokenizer loads");
+    let stop = tokenizer.token_to_id("<|im_end|>").expect("<|im_end|>") as i32;
+    let started = Instant::now();
+    let mut engine =
+        GrammarEngine::from_tokenizer(&tokenizer, None, &[stop]).expect("engine builds");
+    println!(
+        "vocab={} engine_build_ms={:.1}",
+        engine.vocab_size(),
+        started.elapsed().as_secs_f64() * 1000.0
+    );
+    let cases = [
+        (
+            "get_weather(city, days)",
+            tool("get_weather", "city", "days"),
+        ),
+        (
+            "get_weather(city, days) again",
+            tool("get_weather", "city", "days"),
+        ),
+        (
+            "search_docs(query, limit) NEW",
+            tool("search_docs", "query", "limit"),
+        ),
+        (
+            "run_cmd(command, timeout) NEW",
+            tool("run_cmd", "command", "timeout"),
+        ),
+    ];
+    for (label, tools) in cases {
+        let t = Instant::now();
+        let compiled = engine
+            .compile_qwen3_coder_tool_grammar(&tools, true, "</parameter>")
+            .expect("tool grammar compiles");
+        let construct = t.elapsed().as_secs_f64() * 1000.0;
+        let t = Instant::now();
+        let masks = compiled.compile_top_k_masks(512);
+        let prewarm = t.elapsed().as_secs_f64() * 1000.0;
+        let t = Instant::now();
+        let mut state = GrammarState::new(&compiled, engine.vocab_size()).expect("grammar state");
+        state.fill_bitmask();
+        let first_fill = t.elapsed().as_secs_f64() * 1000.0;
+        println!(
+            "[{label}] construct_ms={construct:.1} masks={masks} prewarm_ms={prewarm:.1} \
+             matcher_and_first_fill_ms={first_fill:.1} mask_bytes={}",
+            compiled.memory_size_bytes(),
+        );
+    }
+}
+
+/// End-to-end cold path on a real tokenizer: what a request pays from
+/// "tool schema in hand" to "first constrained mask filled", with and
+/// without a snapshot on disk. Ignored for the same reason as
+/// [`phase_timings_with_a_real_tokenizer`].
+#[test]
+#[ignore = "CPU diagnostic: set QWEN_TOKENIZER_JSON to an existing tokenizer.json"]
+fn cold_vs_snapshot_warm_with_a_real_tokenizer() {
+    let path = std::env::var("QWEN_TOKENIZER_JSON").expect("QWEN_TOKENIZER_JSON");
+    let tokenizer = tokenizers::Tokenizer::from_file(path).expect("tokenizer loads");
+    let stop = tokenizer.token_to_id("<|im_end|>").expect("<|im_end|>") as i32;
+    let dir = scratch("real");
+    let tools = tool("get_weather", "city", "days");
+    let build = || GrammarEngine::from_tokenizer(&tokenizer, None, &[stop]).expect("engine");
+
+    let mut cold_engine = build();
+    cold_engine.attach_mask_cache(&dir);
+    let (cold, _) = prepare(&mut cold_engine, &tools);
+    await_snapshot(&dir).expect("snapshot persisted");
+
+    for rep in 0..3 {
+        let mut warm_engine = build();
+        warm_engine.attach_mask_cache(&dir);
+        let (warm, _) = prepare(&mut warm_engine, &tools);
+        let mut unseen_engine = build();
+        unseen_engine.attach_mask_cache(&dir);
+        let (unseen, _) = prepare(&mut unseen_engine, &tool("run_cmd", "command", "timeout"));
+        await_snapshot(&dir);
+        // How long the REQUEST thread itself is held before prefill can
+        // start — the part candidate (4) moves behind the forward pass.
+        let mut admit_engine = build();
+        let admitted = Instant::now();
+        let compiled = admit_engine
+            .compile_qwen3_coder_tool_grammar(&tool("ping", "host", "count"), true, "</parameter>")
+            .unwrap();
+        let mut state =
+            GrammarState::new_with_hook(&compiled, admit_engine.vocab_size(), None).unwrap();
+        let admit_ms = admitted.elapsed().as_secs_f64() * 1000.0;
+        state.fill_bitmask();
+        let joined_ms = admitted.elapsed().as_secs_f64() * 1000.0;
+        println!(
+            "rep={rep} cold_ms={:.1} warm_same_schema_ms={:.1} warm_unseen_schema_ms={:.1} \
+             cold_admit_ms={admit_ms:.1} cold_admit_to_first_fill_ms={joined_ms:.1}",
+            cold.as_secs_f64() * 1000.0,
+            warm.as_secs_f64() * 1000.0,
+            unseen.as_secs_f64() * 1000.0,
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/spark-server/src/grammar/tests/cold_compile.rs
+++ b/crates/spark-server/src/grammar/tests/cold_compile.rs
@@ -85,21 +85,40 @@ fn tool(name: &str, a: &str, b: &str) -> Vec<ToolDefinition> {
     .unwrap()
 }
 
-/// Compile a tool grammar and warm its masks, returning the wall time of
-/// the whole cold path a request pays before its first constrained
-/// token, plus the state (so callers can compare the resulting masks).
-fn prepare(engine: &mut GrammarEngine, tools: &[ToolDefinition]) -> (Duration, GrammarState) {
+/// What one request pays before its first constrained token, split at
+/// the boundary the fix acts on.
+struct Prepared {
+    /// Schema -> EBNF -> parse -> normalize -> optimize -> decompose.
+    /// Unaffected by #918 and, on a narrow synthetic vocabulary in a
+    /// debug build, large enough to swamp the phase under test — which
+    /// is why the ratios below are asserted on `masks`, not on the sum.
+    construct: Duration,
+    /// Matcher construction + the top-k mask prewarm + the first
+    /// constrained fill (which joins the overlapped prewarm). This is
+    /// the ~99% of the cold path #918 is about.
+    masks: Duration,
+    state: GrammarState,
+}
+
+fn prepare(engine: &mut GrammarEngine, tools: &[ToolDefinition]) -> Prepared {
     let started = Instant::now();
     let compiled = engine
         .compile_qwen3_coder_tool_grammar(tools, true, "</parameter>")
         .expect("tool grammar compiles");
+    let construct = started.elapsed();
+
+    let started = Instant::now();
     let hook = engine.mask_snapshot_hook();
     let mut state =
         GrammarState::new_with_hook(&compiled, engine.vocab_size(), hook).expect("grammar state");
     // The first constrained sample — this is what joins the overlapped
-    // prewarm, so it is the honest end of the cold path.
+    // prewarm, so it is the honest end of the mask phase.
     state.fill_bitmask();
-    (started.elapsed(), state)
+    Prepared {
+        construct,
+        masks: started.elapsed(),
+        state,
+    }
 }
 
 /// Size of the snapshot file under `dir`, once it appears.
@@ -186,25 +205,33 @@ fn a_persisted_snapshot_removes_the_cold_prewarm_for_the_next_process() {
     // background prewarm persists the cross-grammar masks.
     let mut first = engine();
     first.attach_mask_cache(&dir);
-    let (cold, cold_state) = prepare(&mut first, &tools);
+    let cold = prepare(&mut first, &tools);
     let snapshot = await_snapshot(&dir).expect("snapshot written by the background prewarm");
     assert!(snapshot > 0, "snapshot file is empty");
 
     // "Process" 2: same model directory, fresh engine.
     let mut second = engine();
     second.attach_mask_cache(&dir);
-    let (warm, warm_state) = prepare(&mut second, &tools);
+    let warm = prepare(&mut second, &tools);
 
     // Correctness before speed: the warm path must produce the same
     // first-token mask, bit for bit.
     assert_eq!(
-        cold_state.bitmask_data(),
-        warm_state.bitmask_data(),
+        cold.state.bitmask_data(),
+        warm.state.bitmask_data(),
         "snapshot-warmed grammar admits a different first token set"
     );
+    // Measured 621.2 ms -> ~0.3 ms on the real Qwen3 vocabulary; a 3x
+    // floor is the loose version for a 1,027-token synthetic vocabulary
+    // in a debug build on a contended box.
     assert!(
-        cold > warm * 3,
-        "the snapshot did not remove the cold prewarm: cold={cold:?} warm={warm:?}"
+        cold.masks > warm.masks * 3,
+        "the snapshot did not remove the cold prewarm: cold={:?} warm={:?} \
+         (construct {:?} / {:?})",
+        cold.masks,
+        warm.masks,
+        cold.construct,
+        warm.construct,
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -311,16 +338,16 @@ fn cold_vs_snapshot_warm_with_a_real_tokenizer() {
 
     let mut cold_engine = build();
     cold_engine.attach_mask_cache(&dir);
-    let (cold, _) = prepare(&mut cold_engine, &tools);
+    let cold = prepare(&mut cold_engine, &tools);
     await_snapshot(&dir).expect("snapshot persisted");
 
     for rep in 0..3 {
         let mut warm_engine = build();
         warm_engine.attach_mask_cache(&dir);
-        let (warm, _) = prepare(&mut warm_engine, &tools);
+        let warm = prepare(&mut warm_engine, &tools);
         let mut unseen_engine = build();
         unseen_engine.attach_mask_cache(&dir);
-        let (unseen, _) = prepare(&mut unseen_engine, &tool("run_cmd", "command", "timeout"));
+        let unseen = prepare(&mut unseen_engine, &tool("run_cmd", "command", "timeout"));
         await_snapshot(&dir);
         // How long the REQUEST thread itself is held before prefill can
         // start — the part candidate (4) moves behind the forward pass.
@@ -337,9 +364,9 @@ fn cold_vs_snapshot_warm_with_a_real_tokenizer() {
         println!(
             "rep={rep} cold_ms={:.1} warm_same_schema_ms={:.1} warm_unseen_schema_ms={:.1} \
              cold_admit_ms={admit_ms:.1} cold_admit_to_first_fill_ms={joined_ms:.1}",
-            cold.as_secs_f64() * 1000.0,
-            warm.as_secs_f64() * 1000.0,
-            unseen.as_secs_f64() * 1000.0,
+            (cold.construct + cold.masks).as_secs_f64() * 1000.0,
+            (warm.construct + warm.masks).as_secs_f64() * 1000.0,
+            (unseen.construct + unseen.masks).as_secs_f64() * 1000.0,
         );
     }
     let _ = std::fs::remove_dir_all(&dir);

--- a/crates/spark-server/src/grammar/tests/mod.rs
+++ b/crates/spark-server/src/grammar/tests/mod.rs
@@ -10,6 +10,7 @@ mod engine_state;
 mod gemma4_required;
 mod minimax;
 mod misc;
+mod native_prewarm;
 mod parallel_calls;
 mod param_key_constraint;
 mod poolside;

--- a/crates/spark-server/src/grammar/tests/mod.rs
+++ b/crates/spark-server/src/grammar/tests/mod.rs
@@ -5,6 +5,7 @@
 use super::*;
 use crate::tool_parser::ToolDefinition;
 
+mod cold_compile;
 mod engine_state;
 mod gemma4_required;
 mod minimax;
@@ -12,6 +13,7 @@ mod misc;
 mod parallel_calls;
 mod param_key_constraint;
 mod poolside;
+mod prewarm_ordering;
 mod qwen3_coder_required;
 mod sanitize;
 mod tools_basic;

--- a/crates/spark-server/src/grammar/tests/native_prewarm.rs
+++ b/crates/spark-server/src/grammar/tests/native_prewarm.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Explicit CPU diagnostic using an already-present Qwen tokenizer. Never downloads.
+
+use super::*;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use xgrammar::compiler::{CompiledGrammar, CompiledGrammarImpl, RuleLevelCache};
+use xgrammar::matcher::GrammarMatcher;
+
+fn fresh(source: &CompiledGrammar, threads: usize) -> CompiledGrammar {
+    let s = source.inner();
+    CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: threads,
+        grammar: Arc::clone(&s.grammar),
+        tokenizer_info: s.tokenizer_info.clone(),
+        mask_cache: Mutex::new(Default::default()),
+        tag_slice: Arc::clone(&s.tag_slice),
+        rule_cache: Some(RuleLevelCache::new(1024 * 1024 * 1024 / 3)),
+        decomposition: s.decomposition.clone(),
+    }))
+}
+
+#[test]
+#[ignore = "CPU diagnostic: requires QWEN_TOKENIZER_JSON pointing to existing pinned tokenizer"]
+fn native_qwen_prewarm_exactness_and_cpu_timing() {
+    let path = std::env::var("QWEN_TOKENIZER_JSON").expect("explicit existing tokenizer path");
+    let tokenizer = tokenizers::Tokenizer::from_file(path).unwrap();
+    let stop = tokenizer.token_to_id("<|im_end|>").unwrap() as i32;
+    let end = tokenizer.token_to_id("<|endoftext|>").unwrap() as i32;
+    assert_eq!([stop, end], [248046, 248044]);
+    let mut engine = GrammarEngine::from_tokenizer(&tokenizer, Some(248320), &[stop, end]).unwrap();
+    let tools: Vec<ToolDefinition> = serde_json::from_value(serde_json::json!([{
+        "type":"function", "function": {"name":"get_weather",
+        "description":"Look up the current weather for a city.",
+        "parameters":{"type":"object","properties":{
+            "city":{"type":"string","description":"City name."},
+            "days":{"type":"integer","description":"Forecast horizon in days."}},
+            "required":["city","days"]}}
+    }]))
+    .unwrap();
+    let output = "<tool_call>\n<function=get_weather>\n<parameter=city>\nReykjavik\n</parameter>\n<parameter=days>\n3\n</parameter>\n</function>\n</tool_call>";
+    let ids = tokenizer.encode(output, false).unwrap().get_ids().to_vec();
+    for auto in [true, false] {
+        let started = Instant::now();
+        let source = engine
+            .compile_qwen3_coder_tool_grammar(&tools, auto, "</parameter>")
+            .unwrap();
+        println!(
+            "native compile auto={auto} ms={:.3}",
+            started.elapsed().as_secs_f64() * 1000.0
+        );
+        if let Ok(dir) = std::env::var("QWEN_GRAMMAR_EXPORT_DIR") {
+            std::fs::write(
+                format!("{dir}/native-{auto}.ebnf"),
+                xgrammar::grammar::print_grammar(source.grammar()),
+            )
+            .unwrap();
+            std::fs::write(
+                format!("{dir}/output-ids.json"),
+                serde_json::to_string(&ids).unwrap(),
+            )
+            .unwrap();
+        }
+        for rep in 0..1 {
+            let serial = fresh(&source, 1);
+            let parallel = fresh(&source, 4);
+            let start = Instant::now();
+            let n_serial = serial.compile_top_k_masks(512);
+            let serial_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let start = Instant::now();
+            let n_parallel = parallel.compile_top_k_masks(512);
+            let parallel_ms = start.elapsed().as_secs_f64() * 1000.0;
+            assert_eq!(n_serial, n_parallel);
+            assert_eq!(
+                *serial.inner().mask_cache.lock().unwrap(),
+                *parallel.inner().mask_cache.lock().unwrap(),
+                "adaptive masks differ before sampling"
+            );
+            let mut a = GrammarMatcher::new(serial, None, false, -1);
+            let mut b = GrammarMatcher::new(parallel, None, false, -1);
+            let mut am = vec![0; 248320usize.div_ceil(32)];
+            let mut bm = am.clone();
+            let mut fill_seconds = 0.0;
+            for &id in &ids {
+                am.fill(0);
+                bm.fill(0);
+                let start = Instant::now();
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                fill_seconds += start.elapsed().as_secs_f64();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert_eq!(am, bm, "next-token masks differ");
+                assert_ne!(
+                    am[id as usize / 32] & (1 << (id % 32)),
+                    0,
+                    "native continuation rejected"
+                );
+                assert!(a.accept_token(id as i32, false));
+                assert!(b.accept_token(id as i32, false));
+                a.rollback(1);
+                b.rollback(1);
+                am.fill(0);
+                bm.fill(0);
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert_eq!(am, bm, "rollback masks differ");
+                assert!(a.accept_token(id as i32, false));
+                assert!(b.accept_token(id as i32, false));
+            }
+            println!(
+                "native auto={auto} rep={rep} masks={n_serial} serial_ms={serial_ms:.3} parallel_ms={parallel_ms:.3} fill_ms_per_token={:.3} tokens={}",
+                fill_seconds * 1000.0 / ids.len() as f64,
+                ids.len()
+            );
+            // Both paths reject the same malformed function name in required mode.
+            if !auto {
+                a.reset();
+                b.reset();
+                assert!(!a.accept_string("<tool_call>\n<function=unknown>", false));
+                assert!(!b.accept_string("<tool_call>\n<function=unknown>", false));
+            }
+        }
+    }
+}

--- a/crates/spark-server/src/grammar/tests/prewarm_ordering.rs
+++ b/crates/spark-server/src/grammar/tests/prewarm_ordering.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! #918 candidate (4): the top-k mask prewarm runs concurrently with
+//! prefill, and the FIRST constrained sample waits for it.
+//!
+//! Both halves are asserted deterministically with a two-party
+//! `Barrier` the test controls: the background worker parks on it
+//! before doing any work, so "construction returned while the prewarm
+//! was still parked" and "the first fill did not return until the
+//! worker had run" are facts, not races.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+
+use super::{test_tool_defs, test_vocab};
+use crate::grammar::{GrammarEngine, GrammarState};
+use crate::tool_parser::ToolDefinition;
+
+fn engine_and_grammar() -> (GrammarEngine, xgrammar::CompiledGrammar) {
+    let mut engine = GrammarEngine::new(&test_vocab(), &[130]).expect("engine");
+    let tools: Vec<ToolDefinition> = test_tool_defs();
+    let compiled = engine
+        .compile_hermes_tool_grammar(&tools, false)
+        .expect("tool grammar compiles");
+    (engine, compiled)
+}
+
+#[test]
+fn construction_does_not_block_on_the_prewarm_but_the_first_fill_does() {
+    let (engine, compiled) = engine_and_grammar();
+    let gate = Arc::new(Barrier::new(2));
+
+    // The worker parks on the barrier before computing a single mask.
+    let mut state =
+        GrammarState::build_gated(&compiled, engine.vocab_size(), Some(Arc::clone(&gate)))
+            .expect("grammar state");
+    assert!(
+        !state.prewarm_finished(),
+        "construction returned only after the prewarm ran — the compile is \
+         still on the request's critical path"
+    );
+
+    // Release the worker from another thread, recording that the
+    // release happened BEFORE the fill below is allowed to return.
+    let released = Arc::new(AtomicBool::new(false));
+    let releaser = {
+        let (gate, released) = (Arc::clone(&gate), Arc::clone(&released));
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            released.store(true, Ordering::Release);
+            gate.wait();
+        })
+    };
+
+    state.fill_bitmask();
+    assert!(
+        released.load(Ordering::Acquire),
+        "the first constrained fill did not wait for the prewarm"
+    );
+    assert!(
+        state.prewarm_finished(),
+        "the first constrained fill returned with the prewarm still running"
+    );
+    releaser.join().unwrap();
+}
+
+#[test]
+fn awaiting_the_prewarm_is_idempotent_across_every_mask_reading_path() {
+    let (engine, compiled) = engine_and_grammar();
+    let mut state = GrammarState::new(&compiled, engine.vocab_size()).expect("grammar state");
+    state.fill_bitmask();
+    assert!(state.prewarm_finished());
+    // Joining again must not panic or hang; `Prewarm::wait` is called
+    // from fill_bitmask, forced_token, stop_legal and
+    // completion_token_ids, which run many times per request.
+    state.fill_bitmask();
+    state.forced_token();
+    state.stop_legal(&[130]);
+    state.completion_token_ids(64);
+    assert!(state.prewarm_finished());
+}
+
+#[test]
+fn the_kill_switch_restores_the_synchronous_prewarm() {
+    use crate::grammar::prewarm::overlap_from_env;
+    assert!(overlap_from_env(None), "unset must overlap");
+    assert!(overlap_from_env(Some("1")));
+    assert!(overlap_from_env(Some("")), "empty must overlap");
+    for off in ["0", "false", "OFF", " no "] {
+        assert!(!overlap_from_env(Some(off)), "{off} must disable overlap");
+    }
+
+    // The inline path is exercised directly rather than by mutating a
+    // process-wide env var other tests in this binary read concurrently.
+    let (engine, compiled) = engine_and_grammar();
+    let state = GrammarState::build_with(&compiled, engine.vocab_size(), None, false, None)
+        .expect("grammar state");
+    assert!(
+        state.prewarm_finished(),
+        "with overlap disabled, construction must warm inline"
+    );
+}

--- a/crates/spark-server/src/main_modules/serve_load.rs
+++ b/crates/spark-server/src/main_modules/serve_load.rs
@@ -844,6 +844,7 @@ pub(crate) fn load_model(
         &tokenizer,
         &mut eos_tokens,
         supports_thinking,
+        &model_dir,
     );
 
     // 7. Create scheduler channel + spawn scheduler

--- a/crates/spark-server/src/main_modules/serve_phases/tokenizer_runtime.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/tokenizer_runtime.rs
@@ -40,6 +40,10 @@ pub(crate) fn resolve_tokenizer_runtime(
     tokenizer: &crate::tokenizer::ChatTokenizer,
     eos_tokens: &mut Vec<u32>,
     supports_thinking: bool,
+    // #918: where the cross-grammar token-mask snapshot lives, so a
+    // restart (or a second server on the same checkpoint) does not pay
+    // the cold mask compile again. See `grammar::mask_cache`.
+    model_dir: &std::path::Path,
 ) -> TokenizerRuntime {
     use crate::{grammar, reasoning_parser};
 
@@ -273,11 +277,14 @@ pub(crate) fn resolve_tokenizer_runtime(
         let model_vocab_size = Some(config.vocab_size);
         match grammar::GrammarEngine::from_tokenizer(tokenizer.inner(), model_vocab_size, &stop_ids)
         {
-            Ok(engine) => {
+            Ok(mut engine) => {
                 tracing::info!(
                     "Grammar engine initialized (vocab_size={}, vocab_type=auto-detected from tokenizer)",
                     engine.vocab_size()
                 );
+                // #918: seed the cross-grammar mask cache from disk and
+                // arm the background saver. Startup, never a request.
+                engine.attach_mask_cache(model_dir);
                 Some(engine)
             }
             Err(e) => {

--- a/crates/spark-server/src/scheduler/emit_step.rs
+++ b/crates/spark-server/src/scheduler/emit_step.rs
@@ -591,7 +591,11 @@ pub fn compile_grammar_state(
     match compiled {
         Ok(grammar) => {
             let vocab_size = engine.vocab_size();
-            match GrammarState::new(&grammar, vocab_size) {
+            // #918: `on_warm` persists the cross-grammar mask cache from
+            // the background prewarm thread, so the NEXT process starts
+            // warm. `None` when the on-disk cache is off.
+            let on_warm = engine.mask_snapshot_hook();
+            match GrammarState::new_with_hook(&grammar, vocab_size, on_warm) {
                 Ok(state) => {
                     tracing::info!("Grammar constrained decoding active: {label}");
                     // Exempt the model's stop/EOS tokens from grammar refusal

--- a/crates/xgrammar/examples/native_prewarm_profile.rs
+++ b/crates/xgrammar/examples/native_prewarm_profile.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! CPU-only timing of grammar exported from Atlas's native tool compiler.
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use xgrammar::compiler::{CompiledGrammar, CompiledGrammarImpl, GrammarCompiler, RuleLevelCache};
+use xgrammar::matcher::GrammarMatcher;
+use xgrammar::tokenizer::TokenizerInfo;
+
+fn fresh(source: &CompiledGrammar, threads: usize) -> CompiledGrammar {
+    let s = source.inner();
+    CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: threads,
+        grammar: Arc::clone(&s.grammar),
+        tokenizer_info: s.tokenizer_info.clone(),
+        mask_cache: Mutex::new(Default::default()),
+        tag_slice: Arc::clone(&s.tag_slice),
+        rule_cache: Some(RuleLevelCache::new(1024 * 1024 * 1024 / 3)),
+        decomposition: s.decomposition.clone(),
+    }))
+}
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("existing CPU fixture directory");
+    let raw = std::fs::read_to_string(format!("{dir}/qwen-tokenizer.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let mut vocab = vec![String::new(); 248320];
+    for (tok, id) in json["model"]["vocab"].as_object().unwrap() {
+        vocab[id.as_u64().unwrap() as usize] = tok.clone();
+    }
+    for tok in json["added_tokens"].as_array().unwrap() {
+        vocab[tok["id"].as_u64().unwrap() as usize] = tok["content"].as_str().unwrap().to_owned();
+    }
+    let stop = vocab.iter().position(|t| t == "<|im_end|>").unwrap() as i32;
+    let end = vocab.iter().position(|t| t == "<|endoftext|>").unwrap() as i32;
+    assert_eq!([stop, end], [248046, 248044]);
+    let meta = xgrammar::detect_metadata_from_hf(&raw).unwrap();
+    let info = TokenizerInfo::new(
+        &vocab,
+        meta.vocab_type,
+        None,
+        Some(vec![stop, end]),
+        meta.add_prefix_space,
+    );
+    let ids: Vec<i32> =
+        serde_json::from_str(&std::fs::read_to_string(format!("{dir}/output-ids.json")).unwrap())
+            .unwrap();
+    for auto in [true, false] {
+        let ebnf = std::fs::read_to_string(format!("{dir}/native-{auto}.ebnf")).unwrap();
+        let compiler = GrammarCompiler::new(info.clone(), 1, true, -1);
+        let start = Instant::now();
+        let source = compiler.compile_grammar_from_ebnf(&ebnf, "root").unwrap();
+        println!(
+            "compile auto={auto} ms={:.3}",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+        if std::env::args().nth(2).as_deref() == Some("--warm-only") {
+            let warmed = fresh(&source, 4);
+            let count = warmed.compile_top_k_masks(512);
+            let started = Instant::now();
+            for _ in 0..100 {
+                assert_eq!(warmed.compile_top_k_masks(512), count);
+            }
+            println!(
+                "warm auto={auto} selected={count} us_per_call={:.3}",
+                started.elapsed().as_secs_f64() * 1e6 / 100.0
+            );
+            continue;
+        }
+        for rep in 0..3 {
+            let serial = fresh(&source, 1);
+            let parallel = fresh(&source, 4);
+            let start = Instant::now();
+            let n_serial = serial.compile_top_k_masks(512);
+            let serial_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let start = Instant::now();
+            let n_parallel = parallel.compile_top_k_masks(512);
+            let parallel_ms = start.elapsed().as_secs_f64() * 1000.0;
+            assert_eq!(n_serial, n_parallel);
+            assert!(
+                *serial.inner().mask_cache.lock().unwrap()
+                    == *parallel.inner().mask_cache.lock().unwrap(),
+                "adaptive mask/state sets differ"
+            );
+            let mut a = GrammarMatcher::new(serial, None, false, -1);
+            let mut b = GrammarMatcher::new(parallel, None, false, -1);
+            let mut am = vec![0; 248320usize.div_ceil(32)];
+            let mut bm = am.clone();
+            let mut fill_seconds = 0.0;
+            let mut positions = Vec::new();
+            for (position, &id) in ids.iter().enumerate() {
+                am.fill(0);
+                bm.fill(0);
+                let start = Instant::now();
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                let fill_us = start.elapsed().as_secs_f64() * 1e6;
+                fill_seconds += fill_us / 1e6;
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert!(am == bm, "next-token masks differ");
+                assert_ne!(am[id as usize / 32] & (1 << (id % 32)), 0);
+                let start = Instant::now();
+                assert!(a.accept_token(id, false));
+                let accept_us = start.elapsed().as_secs_f64() * 1e6;
+                positions.push(serde_json::json!({"position":position,"token_id":id,"token":String::from_utf8_lossy(&info.decoded_vocab()[id as usize]),"fill_us":fill_us,"accept_us":accept_us}));
+                assert!(b.accept_token(id, false));
+                a.rollback(1);
+                b.rollback(1);
+                am.fill(0);
+                bm.fill(0);
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert!(am == bm, "rollback masks differ");
+                assert!(a.accept_token(id, false));
+                assert!(b.accept_token(id, false));
+            }
+            println!(
+                "auto={auto} rep={rep} masks={n_serial} serial_ms={serial_ms:.3} parallel_ms={parallel_ms:.3} fill_ms_per_token={:.3} tokens={}",
+                fill_seconds * 1000.0 / ids.len() as f64,
+                ids.len()
+            );
+            println!(
+                "positions {}",
+                serde_json::json!({"auto":auto,"rep":rep,"positions":positions})
+            );
+            if !auto {
+                a.reset();
+                b.reset();
+                assert!(!a.accept_string("<tool_call>\n<function=unknown>", false));
+                assert!(!b.accept_string("<tool_call>\n<function=unknown>", false));
+            }
+        }
+    }
+}

--- a/crates/xgrammar/src/api/compiler.rs
+++ b/crates/xgrammar/src/api/compiler.rs
@@ -132,6 +132,47 @@ impl GrammarCompiler {
         self.inner.cache_size_bytes()
     }
 
+    /// Seed the cross-grammar rule-level mask cache from a snapshot a
+    /// previous process wrote (#918). Returns masks imported; `0` is a
+    /// miss (absent / stale / corrupt file), never an error.
+    pub fn load_mask_snapshot(&self, path: &std::path::Path) -> Result<usize, String> {
+        self.inner
+            .load_mask_snapshot(path)
+            .map_err(|e| e.to_string())
+    }
+
+    /// Persist the cross-grammar rule-level mask cache so the next
+    /// process starts warm (#918). Returns masks written.
+    pub fn save_mask_snapshot(
+        &self,
+        path: &std::path::Path,
+        max_entries: usize,
+    ) -> Result<usize, String> {
+        self.inner
+            .save_mask_snapshot(path, max_entries)
+            .map_err(|e| e.to_string())
+    }
+
+    /// A CLONE of the cross-grammar rule-level cache handle (`Arc`
+    /// inside — this shares the cache, it does not copy it).
+    ///
+    /// #918: lets a caller hand the cache to a background thread that
+    /// persists it, without holding the compiler (which is `!Sync`).
+    pub fn rule_cache_handle(&self) -> Option<crate::compiler::RuleLevelCache> {
+        self.inner.rule_cache().cloned()
+    }
+
+    /// The identity an on-disk mask snapshot must match to be usable
+    /// with this compiler's tokenizer (#918).
+    pub fn snapshot_identity(&self) -> crate::compiler::SnapshotIdentity {
+        self.inner.snapshot_identity()
+    }
+
+    /// Number of masks held by the cross-grammar rule-level cache.
+    pub fn rule_cache_len(&self) -> usize {
+        self.inner.rule_cache_len()
+    }
+
     /// The configured cache memory limit (`-1` = unlimited). Port of
     /// the vendored `GrammarCompiler::cache_limit_bytes`.
     pub fn cache_limit_bytes(&self) -> i64 {

--- a/crates/xgrammar/src/compiler/compile.rs
+++ b/crates/xgrammar/src/compiler/compile.rs
@@ -38,9 +38,8 @@ use super::rule_cache::RuleLevelCache;
 /// `GrammarCompiler` entry points guarantee this.
 ///
 /// Adaptive token masks are NOT computed here — they are compiled
-/// lazily on first matcher lookup (XGrammar-2 JIT). `_max_threads` is
-/// retained for API parity but is now unused: there is no eager
-/// per-state mask loop left to parallelize.
+/// lazily on first matcher lookup (XGrammar-2 JIT). `max_threads` is
+/// retained on the result to bound explicit `compile_top_k_masks` prewarming.
 ///
 /// `rule_cache` is the optional cross-grammar [`RuleLevelCache`] (passed
 /// from the [`super::GrammarCompiler`] so it is shared across every
@@ -49,7 +48,7 @@ use super::rule_cache::RuleLevelCache;
 pub(super) fn compile_optimized_grammar(
     mut grammar: GrammarData,
     tokenizer_info: &TokenizerInfo,
-    _max_threads: usize,
+    max_threads: usize,
     rule_cache: Option<RuleLevelCache>,
 ) -> CompiledGrammar {
     debug_assert!(
@@ -64,6 +63,7 @@ pub(super) fn compile_optimized_grammar(
     if tokenizer_info.vocab_size() == 0 {
         let decomposition = decompose_static_regions(&grammar);
         return CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+            prewarm_max_threads: max_threads,
             grammar: Arc::new(grammar),
             tokenizer_info: tokenizer_info.clone(),
             mask_cache: Mutex::new(AHashMap::new()),
@@ -101,6 +101,7 @@ pub(super) fn compile_optimized_grammar(
     // The mask cache starts empty and is populated lazily; on a miss the
     // lazy path consults `rule_cache` before recomputing.
     CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: max_threads,
         grammar: Arc::new(grammar),
         tokenizer_info: tokenizer_info.clone(),
         mask_cache: Mutex::new(AHashMap::new()),

--- a/crates/xgrammar/src/compiler/compiled_grammar.rs
+++ b/crates/xgrammar/src/compiler/compiled_grammar.rs
@@ -36,6 +36,8 @@ use super::rule_cache::{RuleLevelCache, RuleMaskKey};
 /// `CompiledGrammar::Impl`.
 #[derive(Debug)]
 pub struct CompiledGrammarImpl {
+    /// Maximum synchronous prewarm workers, inherited from the compiler.
+    pub prewarm_max_threads: usize,
     /// The optimized, FSM-accelerated grammar (shared — the lazy
     /// `MaskGenerator` needs an `Arc<GrammarData>`).
     pub grammar: Arc<GrammarData>,
@@ -302,10 +304,10 @@ impl CompiledGrammar {
     /// OVERLAPPED MASK GENERATION (Tier 2, "configurable JIT").
     ///
     /// Eagerly compute the `k` most-expensive adaptive-token masks,
-    /// populating the lazy JIT cache so they are already warm before
-    /// the matcher needs them. Atlas's scheduler calls this during
-    /// prefill — while the GPU is busy with the prompt — so the first
-    /// decode steps never pay a cold mask-computation stall.
+    /// populating the lazy JIT cache before the matcher needs them. Uses
+    /// at most the compiler's `max_threads`, including the caller, and
+    /// joins all workers before returning. Atlas calls this synchronously
+    /// before prompt prefill; no GPU overlap is implied.
     ///
     /// COST RANKING. A state's mask cost is dominated by the breadth of
     /// its first-character scan: every distinct first byte the state can
@@ -360,10 +362,31 @@ impl CompiledGrammar {
         // the list is small (one entry per scanable FSM state).
         ranked.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.0));
         let take = k.min(ranked.len());
-        for &(_, canonical, is_root) in &ranked[..take] {
+        let pending = self.uncached_masks(&ranked[..take]);
+        super::prewarm::for_each_bounded(&pending, self.pimpl.prewarm_max_threads, &|&(
+            _,
+            canonical,
+            is_root,
+        )| {
             self.get_or_compute_mask(canonical, is_root);
-        }
+        });
         take
+    }
+
+    pub(super) fn uncached_masks(
+        &self,
+        selected: &[(usize, ParserState, bool)],
+    ) -> Vec<(usize, ParserState, bool)> {
+        let cache = self
+            .pimpl
+            .mask_cache
+            .lock()
+            .expect("mask_cache mutex poisoned");
+        selected
+            .iter()
+            .copied()
+            .filter(|(_, state, _)| !cache.contains_key(state))
+            .collect()
     }
 
     /// Shared-pointer access to the inner state — used by the matcher.

--- a/crates/xgrammar/src/compiler/compiler.rs
+++ b/crates/xgrammar/src/compiler/compiler.rs
@@ -81,9 +81,8 @@ pub struct GrammarCompiler {
 impl GrammarCompiler {
     /// Construct a compiler bound to `tokenizer_info`.
     ///
-    /// * `max_threads` — retained for API parity. Mask computation is
-    ///   now lazy (XGrammar-2 JIT), so there is no eager parallel loop
-    ///   to bound; the value is recorded but unused. Must be >= 1.
+    /// * `max_threads` — bounds explicit top-k mask prewarming. Lazy
+    ///   matcher lookups still compute only the requested mask. Must be >= 1.
     /// * `cache_enabled` — whether to cache compiled grammars.
     /// * `cache_limit_bytes` — memory budget, ENFORCED by LRU eviction on
     ///   both tiers. `-1` means unlimited, which is now an explicit opt-in

--- a/crates/xgrammar/src/compiler/compiler.rs
+++ b/crates/xgrammar/src/compiler/compiler.rs
@@ -15,6 +15,7 @@ use crate::tokenizer::TokenizerInfo;
 use super::compile::compile_optimized_grammar;
 use super::compiled_grammar::CompiledGrammar;
 use super::grammar_cache::{GrammarCache, UNLIMITED_BYTES};
+use super::mask_snapshot::{self, SnapshotError, SnapshotIdentity};
 use super::rule_cache::{RuleLevelCache, UNLIMITED_SIZE};
 
 /// An error produced while compiling a grammar, schema or tag.
@@ -277,5 +278,57 @@ impl GrammarCompiler {
     /// The tokenizer this compiler is bound to.
     pub fn tokenizer_info(&self) -> &TokenizerInfo {
         &self.tokenizer_info
+    }
+
+    /// The identity an on-disk mask snapshot must match to be usable
+    /// with this compiler (#918).
+    pub fn snapshot_identity(&self) -> SnapshotIdentity {
+        SnapshotIdentity {
+            tokenizer_fingerprint: self.tokenizer_info.fingerprint(),
+            vocab_size: self.tokenizer_info.vocab_size(),
+        }
+    }
+
+    /// Seed the cross-grammar [`RuleLevelCache`] from a snapshot written
+    /// by an earlier process (#918).
+    ///
+    /// Returns the number of masks imported. `0` means a miss — no file,
+    /// a snapshot from a different tokenizer or build, or a corrupt one —
+    /// and the compiler simply computes as before. A compiler constructed
+    /// with `cache_enabled == false` has no rule cache and always
+    /// returns `0`.
+    pub fn load_mask_snapshot(&self, path: &std::path::Path) -> Result<usize, SnapshotError> {
+        let Some(cache) = &self.rule_cache else {
+            return Ok(0);
+        };
+        mask_snapshot::load_from_file(cache, self.snapshot_identity(), path)
+    }
+
+    /// Persist the cross-grammar [`RuleLevelCache`] so the NEXT process
+    /// starts warm (#918). Returns the number of masks written; at most
+    /// `max_entries`, most-recently-used first.
+    pub fn save_mask_snapshot(
+        &self,
+        path: &std::path::Path,
+        max_entries: usize,
+    ) -> Result<usize, SnapshotError> {
+        let Some(cache) = &self.rule_cache else {
+            return Ok(0);
+        };
+        mask_snapshot::save_to_file(cache, self.snapshot_identity(), path, max_entries)
+    }
+
+    /// The cross-grammar rule-level cache itself, when caching is on.
+    /// Exposed for the #918 snapshot tests and for callers that want to
+    /// share one cache across compilers.
+    pub fn rule_cache(&self) -> Option<&RuleLevelCache> {
+        self.rule_cache.as_ref()
+    }
+
+    /// Entries currently held by the cross-grammar rule-level cache —
+    /// `0` when caching is disabled. Used by the #918 tests and by the
+    /// serve path's warm-up logging.
+    pub fn rule_cache_len(&self) -> usize {
+        self.rule_cache.as_ref().map_or(0, |c| c.len())
     }
 }

--- a/crates/xgrammar/src/compiler/mask_snapshot.rs
+++ b/crates/xgrammar/src/compiler/mask_snapshot.rs
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Cross-process persistence for the Tier-2 [`RuleLevelCache`] — issue #918.
+//
+// WHY THE *RULE*-LEVEL CACHE AND NOT THE COMPILED GRAMMAR
+// -------------------------------------------------------
+// #918 reports "~3.4 s cold grammar compile per new tool schema". The
+// CPU measurement that motivated this module (M5 Max, release, Qwen3
+// ByteLevel-BPE tokenizer, 151,669-token vocabulary, the coherency
+// gate's `get_weather` schema through `compile_qwen3_coder_tool_grammar`)
+// shows the cost is per *process*, not per schema:
+//
+//   grammar construction (EBNF + parse + normalize + optimize)   5.5 ms
+//   mask prewarm, first grammar in the process (123 masks)     621.2 ms
+//   mask prewarm, same schema again                              0.0 ms
+//   mask prewarm, a DIFFERENT schema (new tool + field names)    16.0 ms
+//
+// The second distinct schema costs ~2.5% of the first because
+// [`RuleLevelCache`] keys masks *structurally* — every JSON tool schema
+// reuses the same string/number/whitespace/punctuation sub-rules. So a
+// disk cache keyed by (tokenizer, schema) would only ever help a repeat
+// of the *same* schema, and would miss the reuse that already carries
+// 97% of the load. Persisting the rule-level entries instead makes a
+// fresh process warm for schemas it has never seen.
+//
+// Scaling that ~600 ms to the H100 host in the #918 report (248,320
+// tokens, ~1.64x the vocabulary, a slower host core than the M5) lands
+// on the ~3.2 s of cold mask generation the issue still has open.
+//
+// FORMAT
+// ------
+// A single little-endian binary file. The header pins everything a
+// cached mask depends on — format version, `usize` width (the accepted
+// bitset is written as raw `BitVec` words), the tokenizer fingerprint
+// and the vocabulary size — and a trailing FNV-1a digest covers the
+// whole body, so a truncated or corrupt file is a cache MISS rather
+// than a wrong mask. Any mismatch returns `Ok(0)`: the caller recomputes.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use bitvec::order::Lsb0;
+use bitvec::vec::BitVec;
+
+use super::mask::{AdaptiveTokenMask, StoreType};
+use super::rule_cache::{RuleLevelCache, RuleMaskKey};
+
+/// File magic — `ATLAS` + "grammar masks", version 1.
+const MAGIC: &[u8; 8] = b"ATLASGM1";
+/// Bumped whenever the encoding or the mask semantics change, so a
+/// snapshot written by an older build is a miss, never a mis-decode.
+const FORMAT_VERSION: u32 = 1;
+
+/// Errors from reading or writing a mask snapshot. A *stale* or
+/// corrupt snapshot is NOT an error — it is a miss (`Ok(0)`); only
+/// genuine I/O failures surface here.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("mask snapshot I/O failed: {0}")]
+    Io(String),
+}
+
+impl From<std::io::Error> for SnapshotError {
+    fn from(e: std::io::Error) -> Self {
+        SnapshotError::Io(e.to_string())
+    }
+}
+
+/// The identity a snapshot is only valid for: the tokenizer it was
+/// computed against, plus that tokenizer's vocabulary size.
+///
+/// A mask is a partition of the sorted decoded vocabulary, so a
+/// different tokenizer (or a different `vocab_size` cap over the same
+/// tokenizer) invalidates every entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotIdentity {
+    /// [`crate::tokenizer::TokenizerInfo::fingerprint`].
+    pub tokenizer_fingerprint: u64,
+    /// [`crate::tokenizer::TokenizerInfo::vocab_size`].
+    pub vocab_size: usize,
+}
+
+/// Bits per `usize` on this target — part of the header because the
+/// accepted bitset is written as raw `BitVec<usize, Lsb0>` words.
+const fn usize_bits() -> u32 {
+    usize::BITS
+}
+
+// ── FNV-1a (64-bit) ────────────────────────────────────────────────
+//
+// A fixed-seed, dependency-free digest. `ahash`'s default state is
+// randomized per process, which is exactly wrong for a value that has
+// to be stable across restarts.
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Fold `bytes` into an FNV-1a accumulator.
+pub fn fnv1a(mut hash: u64, bytes: &[u8]) -> u64 {
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// FNV-1a over `bytes`, starting from the standard offset basis.
+pub fn fnv1a_of(bytes: &[u8]) -> u64 {
+    fnv1a(FNV_OFFSET, bytes)
+}
+
+// ── Encoding ───────────────────────────────────────────────────────
+
+/// A byte sink that digests everything it is handed, so the trailing
+/// checksum never needs a second pass over the buffer.
+struct Writer {
+    buf: Vec<u8>,
+    digest: u64,
+}
+
+impl Writer {
+    fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            digest: FNV_OFFSET,
+        }
+    }
+    fn bytes(&mut self, b: &[u8]) {
+        self.digest = fnv1a(self.digest, b);
+        self.buf.extend_from_slice(b);
+    }
+    fn u8(&mut self, v: u8) {
+        self.bytes(&[v]);
+    }
+    fn u32(&mut self, v: u32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn u64(&mut self, v: u64) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn i32(&mut self, v: i32) {
+        self.bytes(&v.to_le_bytes());
+    }
+    fn i32_slice(&mut self, v: &[i32]) {
+        self.u32(v.len() as u32);
+        for &x in v {
+            self.i32(x);
+        }
+    }
+}
+
+/// A checked byte source. Every read is bounds-guarded; a short read
+/// yields `None`, which the caller turns into a cache miss.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let out = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(out)
+    }
+    fn u8(&mut self) -> Option<u8> {
+        Some(self.take(1)?[0])
+    }
+    fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.take(4)?.try_into().ok()?))
+    }
+    fn u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.take(8)?.try_into().ok()?))
+    }
+    fn i32(&mut self) -> Option<i32> {
+        Some(i32::from_le_bytes(self.take(4)?.try_into().ok()?))
+    }
+    fn i32_vec(&mut self) -> Option<Vec<i32>> {
+        let n = self.u32()? as usize;
+        let mut out = Vec::with_capacity(n.min(1 << 20));
+        for _ in 0..n {
+            out.push(self.i32()?);
+        }
+        Some(out)
+    }
+}
+
+fn store_tag(t: StoreType) -> u8 {
+    match t {
+        StoreType::Accepted => 0,
+        StoreType::Rejected => 1,
+        StoreType::AcceptedBitset => 2,
+    }
+}
+
+fn store_from_tag(tag: u8) -> Option<StoreType> {
+    match tag {
+        0 => Some(StoreType::Accepted),
+        1 => Some(StoreType::Rejected),
+        2 => Some(StoreType::AcceptedBitset),
+        _ => None,
+    }
+}
+
+/// Serialize `entries` into the snapshot byte format.
+pub fn encode(
+    identity: SnapshotIdentity,
+    entries: &[(RuleMaskKey, Arc<AdaptiveTokenMask>)],
+) -> Vec<u8> {
+    let mut w = Writer::new();
+    w.bytes(MAGIC);
+    w.u32(FORMAT_VERSION);
+    w.u32(usize_bits());
+    w.u64(identity.tokenizer_fingerprint);
+    w.u64(identity.vocab_size as u64);
+    w.u64(entries.len() as u64);
+    for (key, mask) in entries {
+        w.u64(key.fsm_hash);
+        w.i32(key.fsm_new_node_id);
+        w.i32(key.state_cnt);
+        w.i32(key.edge_cnt);
+        w.u8(store_tag(mask.store_type));
+        w.i32_slice(&mask.accepted_indices);
+        w.i32_slice(&mask.rejected_indices);
+        w.i32_slice(&mask.uncertain_indices);
+        let words = mask.accepted_bitset.as_raw_slice();
+        w.u64(mask.accepted_bitset.len() as u64);
+        w.u64(words.len() as u64);
+        for &word in words {
+            w.u64(word as u64);
+        }
+    }
+    let digest = w.digest;
+    w.buf.extend_from_slice(&digest.to_le_bytes());
+    w.buf
+}
+
+/// Parse a snapshot. Returns `None` for ANY reason the bytes are not
+/// usable under `identity` — wrong magic, older format, different
+/// `usize` width, different tokenizer, truncation, checksum mismatch.
+/// Those are cache misses, not failures.
+pub fn decode(
+    bytes: &[u8],
+    identity: SnapshotIdentity,
+) -> Option<Vec<(RuleMaskKey, Arc<AdaptiveTokenMask>)>> {
+    let body_len = bytes.len().checked_sub(8)?;
+    let (body, tail) = bytes.split_at(body_len);
+    if fnv1a_of(body) != u64::from_le_bytes(tail.try_into().ok()?) {
+        return None;
+    }
+    let mut r = Reader::new(body);
+    if r.take(8)? != MAGIC
+        || r.u32()? != FORMAT_VERSION
+        || r.u32()? != usize_bits()
+        || r.u64()? != identity.tokenizer_fingerprint
+        || r.u64()? != identity.vocab_size as u64
+    {
+        return None;
+    }
+    let count = r.u64()? as usize;
+    let mut out = Vec::with_capacity(count.min(1 << 16));
+    for _ in 0..count {
+        let key = RuleMaskKey {
+            fsm_hash: r.u64()?,
+            fsm_new_node_id: r.i32()?,
+            state_cnt: r.i32()?,
+            edge_cnt: r.i32()?,
+        };
+        let store_type = store_from_tag(r.u8()?)?;
+        let accepted_indices = r.i32_vec()?;
+        let rejected_indices = r.i32_vec()?;
+        let uncertain_indices = r.i32_vec()?;
+        let bit_len = r.u64()? as usize;
+        let word_count = r.u64()? as usize;
+        let mut words: Vec<usize> = Vec::with_capacity(word_count.min(1 << 20));
+        for _ in 0..word_count {
+            words.push(r.u64()? as usize);
+        }
+        let mut accepted_bitset: BitVec<usize, Lsb0> = BitVec::from_vec(words);
+        if accepted_bitset.len() < bit_len {
+            return None;
+        }
+        accepted_bitset.truncate(bit_len);
+        out.push((
+            key,
+            Arc::new(AdaptiveTokenMask {
+                store_type,
+                accepted_indices,
+                rejected_indices,
+                accepted_bitset,
+                uncertain_indices,
+            }),
+        ));
+    }
+    // Trailing bytes mean the writer and reader disagree about the
+    // format; refuse rather than half-trust it.
+    if r.pos != body.len() {
+        return None;
+    }
+    Some(out)
+}
+
+// ── File-level helpers ─────────────────────────────────────────────
+
+/// Write `cache`'s entries to `path`, atomically (temp file + rename)
+/// so a concurrent reader never observes a half-written snapshot.
+///
+/// At most `max_entries` are written, taken from the MOST-recently-used
+/// end of the cache's LRU order. The rule cache is bounded by a memory
+/// budget (~1/3 of a GiB by default), and a snapshot that large has no
+/// business sitting next to a checkpoint: measured mask footprint is
+/// ~19 KB/mask at a 151,669-token vocabulary, so the cap is what keeps
+/// the file in the tens of megabytes.
+///
+/// Returns the number of entries written.
+pub fn save_to_file(
+    cache: &RuleLevelCache,
+    identity: SnapshotIdentity,
+    path: &Path,
+    max_entries: usize,
+) -> Result<usize, SnapshotError> {
+    let all = cache.entries();
+    let entries = &all[all.len().saturating_sub(max_entries)..];
+    let bytes = encode(identity, entries);
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    // The pid keeps two servers starting at once from colliding on the
+    // temp name; the rename is what makes the visible file atomic.
+    let tmp = path.with_extension(format!("tmp{}", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(entries.len())
+}
+
+/// Load `path` into `cache`. Returns the number of entries imported —
+/// `0` when the file is absent, stale, or corrupt (a miss).
+///
+/// Entries already present in `cache` win: [`RuleLevelCache::add`]
+/// rejects a duplicate key, so loading never overwrites a mask this
+/// process computed itself.
+pub fn load_from_file(
+    cache: &RuleLevelCache,
+    identity: SnapshotIdentity,
+    path: &Path,
+) -> Result<usize, SnapshotError> {
+    let mut bytes = Vec::new();
+    match std::fs::File::open(path) {
+        Ok(mut f) => f.read_to_end(&mut bytes)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e.into()),
+    };
+    let Some(entries) = decode(&bytes, identity) else {
+        return Ok(0);
+    };
+    let mut imported = 0usize;
+    for (key, mask) in entries {
+        if cache.add(key, mask) {
+            imported += 1;
+        }
+    }
+    Ok(imported)
+}
+
+#[cfg(test)]
+#[path = "mask_snapshot_tests.rs"]
+mod tests;

--- a/crates/xgrammar/src/compiler/mask_snapshot_tests.rs
+++ b/crates/xgrammar/src/compiler/mask_snapshot_tests.rs
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// #918 — cross-process persistence of the Tier-2 rule-level mask cache.
+
+use std::time::{Duration, Instant};
+
+use super::*;
+use crate::compiler::GrammarCompiler;
+use crate::tokenizer::{TokenizerInfo, VocabType};
+
+/// A deterministic synthetic vocabulary big enough that mask generation
+/// is the dominant cost (so the cold/warm ratio below is meaningful),
+/// small enough that the cold leg stays well under a second even in a
+/// debug `cargo test`. Real deployments are 30-60x wider — Qwen3.6-35B
+/// is 248,320 tokens — so this test asserts a RATIO, never a time.
+fn synthetic_vocab(n: usize) -> Vec<String> {
+    let alphabet: Vec<char> = (b' '..=b'~').map(|c| c as char).collect();
+    let mut vocab: Vec<String> = alphabet.iter().map(|c| c.to_string()).collect();
+    let mut i = 0usize;
+    while vocab.len() < n {
+        let a = alphabet[i % alphabet.len()];
+        let b = alphabet[(i / alphabet.len()) % alphabet.len()];
+        let c = alphabet[(i / (alphabet.len() * alphabet.len())) % alphabet.len()];
+        vocab.push(format!("{a}{b}{c}"));
+        i += 1;
+    }
+    vocab.truncate(n);
+    vocab
+}
+
+fn tokenizer(n: usize) -> TokenizerInfo {
+    TokenizerInfo::new(&synthetic_vocab(n), VocabType::Raw, None, None, false)
+}
+
+/// No cap in the unit tests — every warmed mask is persisted.
+const MAX: usize = usize::MAX;
+
+fn compiler(info: &TokenizerInfo) -> GrammarCompiler {
+    // 1 worker + caching on — the serve default restored by `37228e85`.
+    GrammarCompiler::new(info.clone(), 1, true, 1024 * 1024 * 1024)
+}
+
+/// The coherency gate's `get_weather` arguments (#918), as a bare JSON
+/// schema so this test needs nothing from `spark-server`.
+const WEATHER_SCHEMA: &str = r#"{"type":"object","properties":{
+    "city":{"type":"string"},"days":{"type":"integer"}},
+    "required":["city","days"]}"#;
+
+/// A schema this process has never compiled: different field names,
+/// different types, one extra property.
+const SEARCH_SCHEMA: &str = r#"{"type":"object","properties":{
+    "query":{"type":"string"},"limit":{"type":"integer"},
+    "fuzzy":{"type":"boolean"}},
+    "required":["query","limit"]}"#;
+
+fn compile_and_prewarm(c: &GrammarCompiler, schema: &str) -> (Duration, usize) {
+    let started = Instant::now();
+    let compiled = c
+        .compile_json_schema(schema, true, None, None, true, Some(8))
+        .expect("schema compiles");
+    let masks = compiled.compile_top_k_masks(512);
+    (started.elapsed(), masks)
+}
+
+/// Take the best of `reps` — the cheapest run is the one least polluted
+/// by scheduler noise on a shared CI box, and the claim ("the warm leg
+/// is much cheaper") is one-sided.
+fn best_of<F: FnMut() -> Duration>(reps: usize, mut f: F) -> Duration {
+    (0..reps).map(|_| f()).min().expect("reps > 0")
+}
+
+#[test]
+fn a_snapshot_round_trips_every_mask_byte_for_byte() {
+    let info = tokenizer(2048);
+    let c = compiler(&info);
+    compile_and_prewarm(&c, WEATHER_SCHEMA);
+    let identity = c.snapshot_identity();
+    let original = c.rule_cache().expect("cache enabled").entries();
+    assert!(!original.is_empty(), "prewarm populated no rule masks");
+
+    let decoded = decode(&encode(identity, &original), identity).expect("round trip decodes");
+    assert_eq!(decoded.len(), original.len());
+    for ((k_a, m_a), (k_b, m_b)) in original.iter().zip(decoded.iter()) {
+        assert_eq!(k_a, k_b, "rule key changed across the snapshot");
+        assert_eq!(**m_a, **m_b, "mask changed across the snapshot");
+    }
+}
+
+#[test]
+fn a_snapshot_written_for_another_tokenizer_is_a_miss() {
+    let info = tokenizer(1024);
+    let c = compiler(&info);
+    compile_and_prewarm(&c, WEATHER_SCHEMA);
+    let entries = c.rule_cache().unwrap().entries();
+    let bytes = encode(c.snapshot_identity(), &entries);
+
+    // Same vocabulary size, different contents.
+    let other = TokenizerInfo::new(
+        &synthetic_vocab(1024)
+            .iter()
+            .map(|t| format!("x{t}"))
+            .collect::<Vec<_>>(),
+        VocabType::Raw,
+        None,
+        None,
+        false,
+    );
+    assert_ne!(info.fingerprint(), other.fingerprint());
+    let foreign = SnapshotIdentity {
+        tokenizer_fingerprint: other.fingerprint(),
+        vocab_size: other.vocab_size(),
+    };
+    assert!(
+        decode(&bytes, foreign).is_none(),
+        "a snapshot from a different tokenizer must not be reused"
+    );
+    // ...and the same tokenizer with a different vocab_size cap is also
+    // a miss: mask indices are positions in the sorted decoded vocab.
+    assert!(
+        decode(
+            &bytes,
+            SnapshotIdentity {
+                vocab_size: info.vocab_size() + 1,
+                ..c.snapshot_identity()
+            }
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn a_corrupt_or_truncated_snapshot_is_a_miss_not_a_wrong_mask() {
+    let info = tokenizer(1024);
+    let c = compiler(&info);
+    compile_and_prewarm(&c, WEATHER_SCHEMA);
+    let identity = c.snapshot_identity();
+    let bytes = encode(identity, &c.rule_cache().unwrap().entries());
+
+    assert!(
+        decode(&bytes, identity).is_some(),
+        "control: intact decodes"
+    );
+    for cut in [0usize, 1, 9, bytes.len() / 2, bytes.len() - 1] {
+        assert!(
+            decode(&bytes[..cut], identity).is_none(),
+            "truncation at {cut} must be a miss"
+        );
+    }
+    let mut flipped = bytes.clone();
+    let mid = flipped.len() / 2;
+    flipped[mid] ^= 0x01;
+    assert!(
+        decode(&flipped, identity).is_none(),
+        "a single flipped body byte must fail the checksum"
+    );
+}
+
+#[test]
+fn loading_a_snapshot_removes_the_cold_mask_prewarm() {
+    let dir = std::env::temp_dir().join(format!("xgrammar-918-{}", std::process::id()));
+    let path = dir.join("masks.bin");
+    let _ = std::fs::remove_file(&path);
+    let info = tokenizer(2048);
+
+    // COLD: a fresh compiler with an empty rule cache.
+    let cold = best_of(3, || {
+        let c = compiler(&info);
+        compile_and_prewarm(&c, WEATHER_SCHEMA).0
+    });
+    let source = compiler(&info);
+    let (_, masks) = compile_and_prewarm(&source, WEATHER_SCHEMA);
+    assert!(masks > 0);
+    let written = source
+        .save_mask_snapshot(&path, MAX)
+        .expect("snapshot writes");
+    assert!(written > 0, "nothing persisted");
+
+    // WARM: a fresh compiler seeded from the snapshot only.
+    let mut imported = 0;
+    let warm = best_of(3, || {
+        let c = compiler(&info);
+        imported = c.load_mask_snapshot(&path).expect("snapshot loads");
+        compile_and_prewarm(&c, WEATHER_SCHEMA).0
+    });
+    assert_eq!(imported, written, "every persisted mask should import");
+
+    // Byte-exactness first — a fast wrong answer is not a fix.
+    let fresh = compiler(&info);
+    let (fresh_masks, warm_masks) = (
+        {
+            compile_and_prewarm(&fresh, WEATHER_SCHEMA);
+            fresh
+                .compile_json_schema(WEATHER_SCHEMA, true, None, None, true, Some(8))
+                .unwrap()
+        },
+        {
+            let c = compiler(&info);
+            c.load_mask_snapshot(&path).unwrap();
+            compile_and_prewarm(&c, WEATHER_SCHEMA);
+            c.compile_json_schema(WEATHER_SCHEMA, true, None, None, true, Some(8))
+                .unwrap()
+        },
+    );
+    assert_eq!(
+        *fresh_masks.inner().mask_cache.lock().unwrap(),
+        *warm_masks.inner().mask_cache.lock().unwrap(),
+        "snapshot-warmed masks differ from freshly computed ones"
+    );
+
+    // Hit/miss oracle alongside the ratio: the warm compiler must have
+    // served its masks from the imported snapshot, not recomputed them.
+    let seeded = compiler(&info);
+    assert_eq!(seeded.rule_cache().unwrap().hit_miss(), (0, 0));
+    seeded.load_mask_snapshot(&path).unwrap();
+    compile_and_prewarm(&seeded, WEATHER_SCHEMA);
+    let (hits, misses) = seeded.rule_cache().unwrap().hit_miss();
+    assert!(
+        hits > 0 && hits > misses,
+        "snapshot hits={hits} misses={misses}"
+    );
+
+    // The measured M5 Max ratio on the real Qwen3 vocabulary was
+    // 596.7 ms cold vs 0.0-16.2 ms warm (issue #918). A 4x floor is a
+    // deliberately loose gate for a 2,048-token synthetic vocabulary on
+    // a contended CI box; it still fails outright if the snapshot stops
+    // being consulted.
+    assert!(
+        cold > warm * 4,
+        "snapshot did not cut cold prewarm: cold={cold:?} warm={warm:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_snapshot_also_warms_a_schema_it_was_never_compiled_for() {
+    // The finding behind #918: the rule cache is keyed STRUCTURALLY, so
+    // a schema the snapshot never saw still reuses its string / number /
+    // whitespace / punctuation sub-rule masks. A snapshot keyed by
+    // (tokenizer, schema) — the shape #918 suggests — would miss exactly
+    // this. Asserted on the HIT/MISS counters rather than wall clock:
+    // the effect size varies with how much structure two schemas share
+    // (observed 2.7% of the cold cost on the qwen3_coder tool-grammar
+    // path, ~70% here on a bare JSON schema with renamed properties and
+    // an extra type), but "the snapshot was consulted and hit" is exact.
+    let dir = std::env::temp_dir().join(format!("xgrammar-918x-{}", std::process::id()));
+    let path = dir.join("masks.bin");
+    let _ = std::fs::remove_file(&path);
+    let info = tokenizer(1024);
+
+    let cold = compiler(&info);
+    compile_and_prewarm(&cold, SEARCH_SCHEMA);
+    let (cold_hits, _) = cold.rule_cache().unwrap().hit_miss();
+
+    let source = compiler(&info);
+    compile_and_prewarm(&source, WEATHER_SCHEMA); // a DIFFERENT schema
+    source
+        .save_mask_snapshot(&path, MAX)
+        .expect("snapshot writes");
+
+    let warm = compiler(&info);
+    assert!(warm.load_mask_snapshot(&path).unwrap() > 0);
+    compile_and_prewarm(&warm, SEARCH_SCHEMA);
+    let (warm_hits, warm_misses) = warm.rule_cache().unwrap().hit_miss();
+
+    assert!(
+        warm_hits > cold_hits,
+        "the imported snapshot was never hit for the unseen schema: \
+         warm={warm_hits} hits / {warm_misses} misses, cold={cold_hits} hits"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_cache_disabled_compiler_neither_loads_nor_saves() {
+    let info = tokenizer(256);
+    let c = GrammarCompiler::new(info.clone(), 1, false, 1024 * 1024);
+    let path = std::env::temp_dir().join("xgrammar-918-never-written.bin");
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(c.save_mask_snapshot(&path, MAX).unwrap(), 0);
+    assert_eq!(c.load_mask_snapshot(&path).unwrap(), 0);
+    assert!(!path.exists(), "a disabled cache must not write a file");
+    assert_eq!(c.rule_cache_len(), 0);
+}
+
+#[test]
+fn a_missing_snapshot_file_is_a_miss_not_an_error() {
+    let info = tokenizer(256);
+    let c = compiler(&info);
+    let path = std::env::temp_dir().join("xgrammar-918-absent-file.bin");
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(c.load_mask_snapshot(&path).unwrap(), 0);
+}
+
+#[test]
+fn a_compiled_grammar_can_cross_a_thread_boundary() {
+    // #918 candidate (4) moves `compile_top_k_masks` onto a background
+    // thread so it overlaps prefill; that needs `CompiledGrammar: Send`.
+    fn assert_send<T: Send + 'static>() {}
+    assert_send::<crate::compiler::CompiledGrammar>();
+}

--- a/crates/xgrammar/src/compiler/mod.rs
+++ b/crates/xgrammar/src/compiler/mod.rs
@@ -12,6 +12,7 @@
 // Module map:
 //   mask             — AdaptiveTokenMask (accept/reject/uncertain set)
 //   mask_gen         — per-state mask computation (EarleyParser scan)
+//   mask_snapshot    — cross-process persistence of the rule cache (#918)
 //   compiled_grammar — CompiledGrammar / CompiledGrammarImpl
 //   compile          — no-cache compilation core (XGrammar-2 JIT)
 //   compiler         — GrammarCompiler with the dashmap-backed cache
@@ -68,6 +69,7 @@ mod decompose;
 mod grammar_cache;
 mod mask;
 mod mask_gen;
+pub mod mask_snapshot;
 mod rule_cache;
 
 pub use coalesce::{Forced, analyze_bitmask};
@@ -75,6 +77,7 @@ pub use compiled_grammar::{CompiledGrammar, CompiledGrammarImpl};
 pub use compiler::{CompileError, GrammarCompiler};
 pub use decompose::{GrammarDecomposition, RuleDecomposition, Segment, decompose_static_regions};
 pub use mask::{AdaptiveTokenMask, StoreType, USE_BITSET_THRESHOLD};
+pub use mask_snapshot::{SnapshotError, SnapshotIdentity};
 pub use rule_cache::{RuleLevelCache, RuleMaskKey, UNLIMITED_SIZE};
 
 #[cfg(test)]

--- a/crates/xgrammar/src/compiler/mod.rs
+++ b/crates/xgrammar/src/compiler/mod.rs
@@ -70,6 +70,7 @@ mod grammar_cache;
 mod mask;
 mod mask_gen;
 pub mod mask_snapshot;
+mod prewarm;
 mod rule_cache;
 
 pub use coalesce::{Forced, analyze_bitmask};

--- a/crates/xgrammar/src/compiler/prewarm.rs
+++ b/crates/xgrammar/src/compiler/prewarm.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Bounded synchronous work dispatch for selected grammar masks.
+
+pub(super) fn for_each_bounded<T: Sync>(
+    items: &[T],
+    max_threads: usize,
+    work: &(impl Fn(&T) + Sync),
+) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    assert!(max_threads > 0);
+    let workers = max_threads.min(items.len());
+    if workers <= 1 {
+        items.iter().for_each(work);
+        return;
+    }
+    let next = AtomicUsize::new(0);
+    let run = || {
+        while let Some(item) = items.get(next.fetch_add(1, Ordering::Relaxed)) {
+            work(item);
+        }
+    };
+    std::thread::scope(|scope| {
+        for _ in 1..workers {
+            // Under host thread pressure, finish the same work with fewer
+            // workers. The caller also drains the queue; no job is dropped.
+            if std::thread::Builder::new()
+                .spawn_scoped(scope, &run)
+                .is_err()
+            {
+                break;
+            }
+        }
+        run();
+    }); // All selected masks are complete before the caller can sample.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
+
+    #[test]
+    fn bounded_workers_overlap_and_complete_each_job_once() {
+        let seen: Vec<_> = (0..16).map(|_| AtomicUsize::new(0)).collect();
+        let entered = (Mutex::new(0usize), Condvar::new());
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        for_each_bounded(&(0..16).collect::<Vec<_>>(), 4, &|&index| {
+            let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+            peak.fetch_max(now, Ordering::SeqCst);
+            let mut count = entered.0.lock().unwrap();
+            *count += 1;
+            entered.1.notify_all();
+            // Only the first wave waits. A serial implementation times out
+            // and fails the overlap oracle rather than hanging the suite.
+            if *count < 4 {
+                let _ = entered
+                    .1
+                    .wait_timeout_while(count, Duration::from_secs(1), |n| *n < 4)
+                    .unwrap();
+            }
+            seen[index].fetch_add(1, Ordering::SeqCst);
+            active.fetch_sub(1, Ordering::SeqCst);
+        });
+        assert!(
+            peak.load(Ordering::SeqCst) > 1,
+            "selected masks are still computed serially"
+        );
+        assert!(peak.load(Ordering::SeqCst) <= 4, "worker bound exceeded");
+        assert_eq!(
+            active.load(Ordering::SeqCst),
+            0,
+            "returned before joining workers"
+        );
+        assert!(seen.iter().all(|n| n.load(Ordering::SeqCst) == 1));
+    }
+
+    #[test]
+    fn one_worker_keeps_serial_order_and_empty_work_does_nothing() {
+        let seen = Mutex::new(Vec::new());
+        for_each_bounded(&[3, 2, 1], 1, &|n| seen.lock().unwrap().push(*n));
+        assert_eq!(*seen.lock().unwrap(), [3, 2, 1]);
+        for_each_bounded::<usize>(&[], 4, &|_| panic!("empty work executed"));
+    }
+}

--- a/crates/xgrammar/src/compiler/prewarm.rs
+++ b/crates/xgrammar/src/compiler/prewarm.rs
@@ -25,7 +25,7 @@ pub(super) fn for_each_bounded<T: Sync>(
             // Under host thread pressure, finish the same work with fewer
             // workers. The caller also drains the queue; no job is dropped.
             if std::thread::Builder::new()
-                .spawn_scoped(scope, &run)
+                .spawn_scoped(scope, run)
                 .is_err()
             {
                 break;

--- a/crates/xgrammar/src/compiler/rule_cache.rs
+++ b/crates/xgrammar/src/compiler/rule_cache.rs
@@ -44,6 +44,7 @@
 // keeps the LRU list — which is inherently shared — trivially correct.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::mask::AdaptiveTokenMask;
@@ -101,6 +102,11 @@ struct Inner {
 pub struct RuleLevelCache {
     max_size: usize,
     inner: Arc<Mutex<Inner>>,
+    /// Lifetime lookup outcomes, for the #918 warm-up logging and for
+    /// tests that need a DETERMINISTIC hit/miss oracle rather than a
+    /// wall-clock ratio. `(hits, misses)`.
+    hits: Arc<AtomicU64>,
+    misses: Arc<AtomicU64>,
 }
 
 impl std::fmt::Debug for RuleLevelCache {
@@ -126,6 +132,8 @@ impl RuleLevelCache {
                 lru: Vec::new(),
                 current_size: 0,
             })),
+            hits: Arc::new(AtomicU64::new(0)),
+            misses: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -133,7 +141,11 @@ impl RuleLevelCache {
     /// on a hit. Port of `RuleLevelCache::GetCache`.
     pub fn get(&self, key: &RuleMaskKey) -> Option<Arc<AdaptiveTokenMask>> {
         let mut inner = self.inner.lock().expect("rule cache mutex poisoned");
-        let idx = *inner.index.get(key)?;
+        let Some(&idx) = inner.index.get(key) else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return None;
+        };
+        self.hits.fetch_add(1, Ordering::Relaxed);
         Self::touch(&mut inner, idx);
         // After `touch`, the entry is at the back.
         Some(Arc::clone(&inner.lru[inner.lru.len() - 1].mask))
@@ -194,6 +206,21 @@ impl RuleLevelCache {
         computed
     }
 
+    /// Snapshot every cached entry in LRU order (least-recently-used
+    /// first), for cross-process persistence — see #918 and
+    /// [`super::mask_snapshot`].
+    ///
+    /// Returns clones of the `Arc`s, so the caller can encode the
+    /// masks without holding the cache lock.
+    pub fn entries(&self) -> Vec<(RuleMaskKey, Arc<AdaptiveTokenMask>)> {
+        let inner = self.inner.lock().expect("rule cache mutex poisoned");
+        inner
+            .lru
+            .iter()
+            .map(|e| (e.key, Arc::clone(&e.mask)))
+            .collect()
+    }
+
     /// Drop every cached entry. Port of `RuleLevelCache::ClearCache`.
     pub fn clear(&self) {
         let mut inner = self.inner.lock().expect("rule cache mutex poisoned");
@@ -215,6 +242,16 @@ impl RuleLevelCache {
             .lock()
             .expect("rule cache mutex poisoned")
             .current_size
+    }
+
+    /// Lifetime `(hits, misses)` over [`Self::get`] — the deterministic
+    /// oracle behind the #918 snapshot hit/miss tests. Not reset by
+    /// [`Self::clear`]: they count lookups, not residency.
+    pub fn hit_miss(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
     }
 
     /// Number of cached entries — for tests / introspection.

--- a/crates/xgrammar/src/compiler/tests/tier2_tests.rs
+++ b/crates/xgrammar/src/compiler/tests/tier2_tests.rs
@@ -181,3 +181,49 @@ fn compile_top_k_masks_empty_vocab_warms_nothing() {
         .unwrap();
     assert_eq!(cg.compile_top_k_masks(5), 0);
 }
+
+#[test]
+fn parallel_prewarm_preserves_every_selected_mask() {
+    // One optimized grammar fixes FSM numbering; both compiles have fresh
+    // caches, so equality cannot pass by reusing the reference's masks.
+    let grammar = optimized("root ::= \"yes\" | \"no\" | \"abc\"\n");
+    let info = small_tokenizer();
+    let serial = compile_optimized_grammar(grammar.clone(), &info, 1, None);
+    let parallel = compile_optimized_grammar(grammar, &info, 4, None);
+    assert_eq!(
+        serial.compile_top_k_masks(512),
+        parallel.compile_top_k_masks(512)
+    );
+    assert_eq!(
+        *serial.inner().mask_cache.lock().unwrap(),
+        *parallel.inner().mask_cache.lock().unwrap(),
+        "parallel preparation changed a selected state or adaptive mask"
+    );
+}
+
+#[test]
+fn already_warm_masks_schedule_no_worker_jobs() {
+    let c = compiler(4);
+    let cg = c
+        .compile_grammar_from_ebnf("root ::= \"yes\" | \"no\"\n", "root")
+        .unwrap();
+    let selected_count = cg.compile_top_k_masks(512);
+    let selected: Vec<_> = cg
+        .inner()
+        .mask_cache
+        .lock()
+        .unwrap()
+        .keys()
+        .map(|state| (1, *state, state.rule_id == cg.grammar().root_rule_id()))
+        .collect();
+    assert!(!selected.is_empty());
+    assert!(
+        cg.uncached_masks(&selected).is_empty(),
+        "warm masks would still spawn worker jobs"
+    );
+    assert_eq!(
+        cg.compile_top_k_masks(512),
+        selected_count,
+        "selected count changed on a warm request"
+    );
+}

--- a/crates/xgrammar/src/tokenizer/info.rs
+++ b/crates/xgrammar/src/tokenizer/info.rs
@@ -192,6 +192,39 @@ impl TokenizerInfo {
         &self.trie_subtree_nodes_range
     }
 
+    /// A PROCESS-STABLE digest of everything an adaptive token mask
+    /// depends on: the vocab type / size / prefix-space flag, the
+    /// sorted decoded vocabulary (ids *and* bytes, in order), and the
+    /// stop / special id sets.
+    ///
+    /// #918: the on-disk mask snapshot
+    /// ([`crate::compiler::mask_snapshot`]) is only valid for the exact
+    /// tokenizer it was computed against — a mask is a partition of
+    /// [`Self::sorted_decoded_vocab`] by index. This is the key that
+    /// decides hit vs miss across processes, so it is FNV-1a with a
+    /// fixed basis rather than `ahash`/`DefaultHasher`, whose seeds are
+    /// randomized per process.
+    pub fn fingerprint(&self) -> u64 {
+        use crate::compiler::mask_snapshot::{fnv1a, fnv1a_of};
+        let mut h = fnv1a_of(b"xgrammar.TokenizerInfo.v1");
+        h = fnv1a(h, &(self.vocab_type as u8).to_le_bytes());
+        h = fnv1a(h, &(self.vocab_size as u64).to_le_bytes());
+        h = fnv1a(h, &[self.add_prefix_space as u8]);
+        h = fnv1a(h, &(self.sorted_decoded_vocab.len() as u64).to_le_bytes());
+        for (id, token) in &self.sorted_decoded_vocab {
+            h = fnv1a(h, &id.to_le_bytes());
+            h = fnv1a(h, &(token.len() as u32).to_le_bytes());
+            h = fnv1a(h, token);
+        }
+        for ids in [&self.stop_token_ids, &self.special_token_ids] {
+            h = fnv1a(h, &(ids.len() as u64).to_le_bytes());
+            for id in ids {
+                h = fnv1a(h, &id.to_le_bytes());
+            }
+        }
+        h
+    }
+
     /// Serialize the metadata to the compact JSON form C++
     /// `DumpMetadata` emits:
     /// `{"vocab_type":N,"vocab_size":N,"add_prefix_space":b,"stop_token_ids":[...]}`.


### PR DESCRIPTION
## Summary

`CompiledGrammar::compile_top_k_masks` prepared its selected masks **one at a time, on the calling thread**. Cold tool-call latency is dominated by that walk, and there was no way to measure what a wider walk would buy — the shape was not a parameter.

This makes the walk a **bounded** parallel one: `prewarm::for_each_bounded`, with the worker count carried on the compiler (`prewarm_max_threads`) and inherited by every grammar it compiles. It ships an `xgrammar` example that drives the knob so the trade can be measured on a real vocabulary.

**The default is unchanged — and that is deliberate, not an oversight.** `GrammarEngine` sets one thread. Four-worker preparation did **not** improve cold latency on the measured workload: the cold cost is the compile and the top-k mask build, not the walk over pending masks, and the workers contend on the same rule cache. The capability stays on the compiler because it is the caller's choice and because the profiling example needs it to re-run the experiment on a different vocabulary.

Refs #918.

### Stack

```
main
 └─ #999  pr/918-grammar-mask-cache   (grammar mask cache, Fixes #918)
     └─ THIS PR  pr/xgrammar-cold-mask-prewarm
```

**Base branch is `main`, so the GitHub diff includes #999.** This PR's three commits are at the tip. It stacks because both touch `compiler/mod.rs`, `compiler/compiler.rs`, `compiled_grammar.rs` and `grammar/engine.rs`, and because #999's mask cache is what makes "already warm" a state worth testing for.

## What was wrong

`compile_top_k_masks` selected its states and then walked them serially. Two consequences:

1. **No knob, so no measurement.** "Would parallel mask preparation help the 3.4 s cold tool-call?" could not be answered without writing the dispatch first. The honest way to answer it is to build the bounded dispatch, measure, and then *report the result* — including when the result is "no".
2. **Nothing asserted that a parallel walk is order-independent.** Mask preparation mutates a shared cache keyed by FSM state. That it is safe to do out of order is a real property and it was untested, because there was no parallel path.

## What the fix does

### `compiler/prewarm.rs` — `for_each_bounded`

A scoped work-stealing walk over a slice, bounded by `max_threads`:

- `workers = max_threads.min(items.len())`, and `workers <= 1` takes the plain serial `for_each` — no thread, no atomic, no scope, for the case that is now the default.
- Jobs are claimed with one `AtomicUsize::fetch_add`, so no item runs twice.
- **`spawn_scoped` failure is not an error.** Under host thread pressure it breaks out of the spawn loop and the calling thread drains the queue itself. Fewer workers, same work, no job dropped — a prewarm that fails because the host is busy would be a worse outcome than a slow one.
- `thread::scope` returns only when every worker has finished, so **all selected masks are complete before the caller can sample**.

### Wiring

`Compiler::new` takes `max_threads`; `compile.rs` stamps it onto each `CompiledGrammar` as `prewarm_max_threads`; `compiled_grammar.rs` hands it to `for_each_bounded`. One value, set at compiler construction, inherited — not a second global.

### The default goes back to serial

`GrammarEngine::from_tokenizer_info` sets one compilation thread, with the comment recording *why*: the measurement did not support four. That is the third commit, and it is the point of the PR as much as the dispatch is.

## Oracle and evidence

`crates/xgrammar/src/compiler/tests/tier2_tests.rs`:

- **`parallel_prewarm_preserves_every_selected_mask`** — the correctness pin. It compiles **one** optimized grammar (so FSM state numbering is fixed) twice, with 1 and 4 workers, **both with fresh caches**, then asserts both the selected count *and* the full `mask_cache` contents are equal. Compiling twice from fresh is what stops the equality passing by the parallel run reusing the serial run's masks.
- **`already_warm_masks_schedule_no_worker_jobs`** — `uncached_masks` must be empty on a warm grammar, so a repeat request spawns nothing. This is the interaction with #999's cache.

`crates/xgrammar/src/compiler/prewarm.rs` tests: jobs overlap when workers are available (a condvar rendezvous, not a sleep), every job runs exactly once, and the serial path is taken at `workers <= 1`.

`crates/xgrammar/examples/native_prewarm_profile.rs` is the measurement harness that produced the "no improvement" verdict, kept in-tree so the verdict can be re-tested rather than believed.

**No new latency number is claimed here.** The #918 cold/warm tool-call timings belong to #999's mask cache, which is the change that actually moved them. This PR's own measured result is negative and is reflected in the default.

## Test plan

Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, private `CARGO_TARGET_DIR`, isolated worktree against this branch fetched from the fork.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p xgrammar -p spark-server --features cuda --all-targets --jobs 8 -- -D warnings` — **clean, rc=0**
- [x] `cargo test -p xgrammar` — **834 + 2 + 1 passed, 0 failed** (#999 base: 830 + 2 + 1 → **+4**)
- [x] `cargo test -p spark-server --bins --features cuda -- prewarm` — **4 passed, 0 failed, 1 ignored** (2471 filtered). The ignored one is `native_qwen_prewarm_exactness_and_cpu_timing`, a CPU diagnostic gated on `QWEN_TOKENIZER_JSON` pointing at a pinned tokenizer — it is `#[ignore]` on purpose and adds no pass to the count.
- [x] `cargo test -p spark-server --bins --features cuda` — **2461 passed, 0 failed, 13 ignored** (#999 base: 2461 passed / 12 ignored → **+0 passing, +1 ignored diagnostic**)
- [x] File-size cap — **0 violations**
- [x] No `kernels/` change, no `crates/spark-model` change.

## GB10 perf-gate records

Touches `crates/` (a PERF_PATH), so committed `.benchmarks/` records are invalidated on landing. The default path is **unchanged** (one worker → the serial `for_each`), so this is a formality rather than a re-measure with a new shape.

## What is NOT claimed

- **Parallel prewarm is not claimed to be faster.** It was measured and it was not, on the workload that motivated it. The default is serial. The dispatch ships because the knob is what makes the question answerable again on a different vocabulary, and it ships with its own correctness pin.
- No claim about a vocabulary other than the measured one.
- `for_each_bounded` bounds worker *count*, not wall time. It has no deadline and no cancellation.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
