### PR TITLE
ci: one certification campaign per STACK, not per layer

### DIFF
--- a/.github/scripts/certification-selftest.sh
+++ b/.github/scripts/certification-selftest.sh
@@ -503,6 +503,33 @@ if [ -s "$TMP/alias.sh" ]; then
   # ever passed, any diff could skip certification by breaking classify-diff.
   want_rc 1 "control: a broken classifier (empty web_only) stays red" \
     env RESULT=skipped WEB_ONLY= STAMPED=true EXPEDITED=false bash "$TMP/alias.sh"
+
+  # ── ONE CAMPAIGN PER STACK (2026-09-12) ───────────────────────────────────
+  # A stack LAYER skips certification because the top carries it: merging a
+  # registered stack's top lands every layer below it in one operation, so the
+  # tree reaching `main` is the top's tree. These rows are the whole safety
+  # argument for that skip, so each failure mode gets its own control.
+  want_rc 0 "alias: a stack layer passes on a deliberate skip" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=true EXPEDITED=false IS_STACK_LAYER=true bash "$TMP/alias.sh"
+  # A layer's OWN stamp is not what releases the stack's certification, so an
+  # unstamped layer must still pass -- otherwise a 26-layer stack needs 26
+  # stamps and one forgotten comment wedges the whole thing.
+  want_rc 0 "alias: an UNSTAMPED stack layer still passes" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=false EXPEDITED=false IS_STACK_LAYER=true bash "$TMP/alias.sh"
+  # THE TOP ALWAYS CERTIFIES. `is_stack_layer` is false for a PR with nothing
+  # above it, and that PR is the one whose merge lands the stack. If this ever
+  # passed, a whole stack could merge with no records at all.
+  want_rc 1 "control: the TOP of a stack (not a layer) stays red on a skip" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=true EXPEDITED=false IS_STACK_LAYER=false bash "$TMP/alias.sh"
+  # A BROKEN classifier leaves it EMPTY. Same shape and same reason as the
+  # empty-web_only control above: fail closed, or breaking the classifier
+  # becomes a way to skip certification.
+  want_rc 1 "control: an empty is_stack_layer stays red" \
+    env RESULT=skipped WEB_ONLY=false STAMPED=true EXPEDITED=false IS_STACK_LAYER= bash "$TMP/alias.sh"
+  # Being a layer excuses a SKIP, never a FAILURE. A layer whose certification
+  # ran and said no is still no.
+  want_rc 1 "control: a stack layer does not excuse a FAILED certification" \
+    env RESULT=failure WEB_ONLY=false STAMPED=true EXPEDITED=false IS_STACK_LAYER=true bash "$TMP/alias.sh"
 else
   bad "could not extract the alias shell from ci.yml"
 fi
@@ -2426,6 +2453,39 @@ want_rc_msg 1 "same commit" "control: head == base is refused" \
 want_rc 2 "control: called with no arguments it refuses, it does not pass" \
   bash .github/scripts/assert-stack-layer-differs.sh
 
+echo "== one campaign per stack is WIRED =="
+# ★ The alias rows above prove a layer's SKIP is translated into a pass. They
+# cannot prove the certification job actually skips for a layer -- that lives
+# in `pr-benchmark-gate`'s own `if:`, and deleting it would silently restore
+# one campaign per layer (~120 GPU-hours for a 26-layer stack) with every
+# selftest row still green. So assert the condition structurally, and prove the
+# assertion itself can fail.
+assert_stack_skip_wired() {
+  python3 - "$1" <<'PYW'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+cond = " ".join((d["jobs"]["pr-benchmark-gate"].get("if") or "").split())
+need = "needs.changes.outputs.is_stack_layer != 'true'"
+if need not in cond:
+    print("pr-benchmark-gate's if: does not carry " + repr(need), file=sys.stderr)
+    print("  got: " + cond, file=sys.stderr)
+    raise SystemExit(1)
+# An EQUALITY here would be a hole: the classifier fails open, so an empty
+# output must RUN the gate. Only the negative test is acceptable.
+if "is_stack_layer ==" in cond:
+    print("the layer test must be `!= 'true'`, never an equality", file=sys.stderr)
+    raise SystemExit(1)
+PYW
+}
+want_rc 0 "the benchmark gate skips stack layers (one campaign per stack)" \
+  assert_stack_skip_wired .github/workflows/ci.yml
+mkdir -p "$TMP/sw"
+printf 'jobs:\n  pr-benchmark-gate:\n    if: notacondition\n' > "$TMP/sw/ci.yml"
+want_rc 1 "control: dropping the layer test from the gate is caught" \
+  assert_stack_skip_wired "$TMP/sw/ci.yml"
+printf "jobs:\n  pr-benchmark-gate:\n    if: needs.changes.outputs.is_stack_layer == 'false'\n" > "$TMP/sw/eq.yml"
+want_rc 1 "control: an EQUALITY layer test is caught (it fails the wrong way)" \
+  assert_stack_skip_wired "$TMP/sw/eq.yml"
 echo "== job outputs are exported =="
 # The guard that would have caught `is_stack_layer` being computed, logged and
 # never exported -- which told every lower stack layer it was not one and made

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1443,7 +1443,46 @@ jobs:
     # through.
     if: >-
       ${{ !cancelled() && needs.changes.outputs.web_only != 'true'
-          && needs.stamp.outputs.stamped != 'false' }}
+          && needs.stamp.outputs.stamped != 'false'
+          && needs.changes.outputs.is_stack_layer != 'true' }}
+    # ── `is_stack_layer != 'true'`: ONE CAMPAIGN PER STACK ────────────────────
+    #
+    # Maintainer decision, 2026-09-12 (tbraun96): "Just because multiple PRs in
+    # a stack affect the perf path does not mean to treat each one separately;
+    # no. Instead, we stack everything and run one certification gate to keep
+    # things fast."
+    #
+    # Before this line, a stack of N layers each touching PERF_PATHS owed N
+    # campaigns, because the gate judges every layer against `main` rather than
+    # against its own base, and a record pinned to the TOP's tree does not cover
+    # a lower layer's tree. Twenty-four layers at ~5 GPU-hours is ~120 GPU-hours
+    # for one merge, which is why the practice had been to compose instead — and
+    # composing loses per-PR review, authorship and the ability to drop one
+    # constituent.
+    #
+    # WHY SKIPPING A LAYER IS SOUND, and not a hole in branch protection:
+    #
+    #   * `is_stack_layer` is true only when the event is `pull_request`, the
+    #     head branch is in THIS repo, and `gh pr list --base <HEAD_REF>` finds
+    #     an OPEN pr above it. So it is true only while something above this PR
+    #     will carry it in.
+    #   * Merging a registered stack's top lands every layer below it in one
+    #     operation, so the tree that reaches `main` is the TOP's tree — which
+    #     is the tree the top's records were measured at.
+    #   * The `merge_group` certification below still runs on the MERGED tree,
+    #     so the thing actually landing is still gated.
+    #   * The moment a layer stops having an open PR above it — the stack is
+    #     broken up, or it becomes the top — this flips false and it certifies
+    #     on its own. A layer can never merge alone on someone else's records.
+    #
+    # `!= 'true'` and not `== 'false'` for the same reason as the two tests
+    # beside it: the classifier fails OPEN, so an empty or errored output must
+    # RUN the certification rather than wave it through.
+    #
+    # `.github/scripts/certification-selftest.sh` carries four controls for
+    # this: the top never skips, a fork head never skips, an errored signal
+    # runs the gate, and a genuine layer does skip.
+    #
     # `!= 'false'`, not `== 'true'`: the stamp job fails OPEN, so an empty output
     # must run the lane rather than hold it. Same shape and same reason as the
     # `web_only` test beside it — five workflows here carry the lesson that a
@@ -1649,6 +1688,7 @@ jobs:
           WEB_ONLY: ${{ needs.changes.outputs.web_only }}
           STAMPED: ${{ needs.stamp.outputs.stamped }}
           EXPEDITED: ${{ needs.stamp.outputs.expedited }}
+          IS_STACK_LAYER: ${{ needs.changes.outputs.is_stack_layer }}
         run: |
           echo "PR Benchmark Certifications => ${RESULT} (web_only=${WEB_ONLY:-unknown})"
           if [ "${RESULT}" = "success" ]; then exit 0; fi
@@ -1670,6 +1710,28 @@ jobs:
           # branch cannot become a hole in branch protection.
           if [ "${RESULT}" = "skipped" ] && [ "${WEB_ONLY}" = "true" ]; then
             echo "web-only diff: no record's measured inputs were touched — pass."
+            exit 0
+          fi
+          # THE SECOND SKIP THAT IS A PASS: this PR is a LAYER of a stack, so
+          # the certification it needs is the one at the stack's TOP. Merging a
+          # registered stack's top lands every layer below it in one operation,
+          # so the tree that reaches `main` is the top's tree, and that is the
+          # tree the top's records were measured at.
+          #
+          # Positive on IS_STACK_LAYER on purpose, exactly like WEB_ONLY above:
+          # a skip caused by a broken classifier leaves it EMPTY and falls
+          # through to red. And the classifier itself is narrow — it requires a
+          # `pull_request` event, a head branch IN THIS REPO, and an OPEN pr
+          # whose base is this PR's head. So this branch can only fire while
+          # something above this PR will carry it in; the moment that stops
+          # being true the layer certifies on its own.
+          #
+          # Placed ABOVE the stamp hold deliberately: a layer's own /stamp is
+          # not what releases the stack's certification, and holding a layer red
+          # for want of a stamp it does not need is how a 26-layer stack becomes
+          # unmergeable.
+          if [ "${RESULT}" = "skipped" ] && [ "${IS_STACK_LAYER}" = "true" ]; then
+            echo "stack layer: certification is carried by the top of this stack — pass."
             exit 0
           fi
           # HELD, not failed. Certification never ran because nobody has released


### PR DESCRIPTION
Per @tbraun96: *"Just because multiple PRs in a stack affect the perf path does not mean to treat each one separately; no. Instead, we stack everything and run one certification gate to keep things fast."*

## What was wrong

`pr-benchmark-gate` had **no stack condition**. The gate judges every layer against `main` rather than against its own base, and a record pinned to the TOP's tree does not cover a lower layer's tree — so a stack of N layers touching `PERF_PATHS` owed **N campaigns**. For the 26-layer stack being assembled from @TheTom's extracted PRs that is **~120 GPU-hours for one merge**.

The documented workaround was to **compose** instead: one aggregation branch, one tree, one campaign. That is how the 22-PR #934 landed — and it costs per-PR review, authorship, and the ability to drop a single constituent.

## What changes

One clause on the gate, and a matching branch in the alias:

```yaml
          && needs.changes.outputs.is_stack_layer != 'true' }}
```

The layers below the top no longer certify; **the top does**. Merging a registered stack's top lands every layer below it in one operation, so the tree that reaches `main` *is* the top's tree — the tree its records were measured at.

## Why this is not a hole in branch protection

| | |
|---|---|
| `is_stack_layer` is narrow | true only when the event is `pull_request`, the head branch is **in this repo**, and `gh pr list --base <HEAD_REF> --state open` finds a PR above it — i.e. only while something above will carry this PR in |
| the TOP always certifies | it has nothing above it, so it is never a layer |
| a fork head is never a layer | `HEAD_REPO == REPO`, so a fork cannot skip certification by naming its branch after a stack base |
| it fails **open** | `!= 'true'`, never an equality — an empty or errored output RUNS the certification. Same shape and same reason as the `web_only` and `stamped` tests beside it |
| a skip is excused, a FAILURE is not | a layer whose certification ran and said no is still no |
| `merge_group` is unchanged | still certifies the merged tree |

The alias gains a second *"skip that is a pass"*, placed **above** the stamp hold deliberately: a layer's own `/stamp` is not what releases the stack's certification, and holding 25 layers red for want of 25 stamps would make a stack unmergeable for a reason unrelated to evidence.

## Controls — both directions

This loosens a safety property, so it is tested as such. **Eight new rows**, each with a fixture that must go red:

```
alias: a stack layer passes on a deliberate skip
alias: an UNSTAMPED stack layer still passes
control: the TOP of a stack (not a layer) stays red on a skip
control: an empty is_stack_layer stays red
control: a stack layer does not excuse a FAILED certification
the benchmark gate skips stack layers (one campaign per stack)
control: dropping the layer test from the gate is caught
control: an EQUALITY layer test is caught (it fails the wrong way)
```

The last three are a **structural** guard. The alias rows prove a skip is translated into a pass, but they cannot prove the job actually skips — deleting the `if:` clause would silently restore per-layer campaigns with every other row still green. So the condition is asserted against `ci.yml` directly, and that assertion has its own two negative fixtures.

```
bash .github/scripts/certification-selftest.sh
234 passed, 0 failed        (was 226)

bash scripts/preflight.sh
PREFLIGHT CLEAN — 83 suites, 0 lints
```

**Negative control on the mechanism itself:** removing the alias branch turns exactly the two positive rows red and leaves the three RED controls green.

## Scope

`.github/` only — **no `PERF_PATHS`**, so no records move and this needs no campaign of its own.

The `automerger` skill's rule is updated to match (it is not tracked in this repo). The section formerly titled *"ONE CAMPAIGN PER STACK HOLDS ONLY IF ONE LAYER TOUCHES `PERF_PATHS`"* now reads *"MEASURED AT THE TOP"*, and rule 36 no longer says *"do not stack them, or compose"*. The #951/#948 incident is kept — it is the evidence for **why** the gate had to change, not a reason to avoid stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwKSBe469fPnngzCFzbWcp