### PR TITLE
Qwen3.8-Flash-Next: lookup drafts into the wide MTP verify (#974)

### DIFF
--- a/crates/spark-server/src/lookup_drafts.rs
+++ b/crates/spark-server/src/lookup_drafts.rs
@@ -144,30 +144,37 @@ impl LookupDrafter {
         self.tail.extend_from_slice(&tokens[len - n.min(len)..]);
     }
 
-    /// Propose exactly `width` tokens to follow `tokens`, or nothing.
+    /// Propose exactly `width` tokens to follow `tokens` + `next`, or nothing.
     ///
-    /// `tokens` is the committed sequence, prompt and generation together.
-    pub fn propose(&mut self, tokens: &[u32], width: usize) -> Vec<u32> {
+    /// `tokens` is the sequence the model has consumed, prompt and generation
+    /// together; `next` is the newest token, emitted but not yet fed (the
+    /// scheduler's `last_token`). The drafts are what followed the last
+    /// occurrence of `tokens[..] ++ [next]`'s tail, so draft 0 is the token
+    /// after `next`, never `next` itself.
+    pub fn propose(&mut self, tokens: &[u32], next: u32, width: usize) -> Vec<u32> {
         let len = tokens.len();
         let n = self.min_match;
-        if width == 0 || len < n + width {
+        if width == 0 || len + 1 < n + width {
             return Vec::new();
         }
         self.extend(tokens);
-        let suffix_start = len - n;
-        let suffix = &tokens[suffix_start..];
-        let Some(starts) = self.index.get(&Self::key(suffix)) else {
+        // The virtual sequence v = tokens ++ [next]; its last n-gram starts
+        // at v index len + 1 - n and ends with `next`.
+        let mut suffix: Vec<u32> = tokens[len + 1 - n..].to_vec();
+        suffix.push(next);
+        let suffix_start = len + 1 - n;
+        let Some(starts) = self.index.get(&Self::key(&suffix)) else {
             return Vec::new();
         };
         let mut best: Option<(usize, usize)> = None; // (match length, start)
         for &p in starts.iter().rev() {
             let p = p as usize;
-            // The hit needs `width` tokens after it that are not the suffix
-            // itself being proposed as its own continuation.
+            // The hit needs `width` tokens after it inside `tokens`, and it
+            // cannot be the suffix itself.
             if p + n + width > len || p == suffix_start {
                 continue;
             }
-            if tokens[p..p + n] != *suffix {
+            if tokens[p..p + n] != suffix[..] {
                 continue;
             }
             // Extend the match backwards; longer context, better draft.
@@ -175,7 +182,7 @@ impl LookupDrafter {
             while m < self.max_match
                 && p >= m + 1 - n
                 && suffix_start >= m + 1 - n
-                && tokens[p + n - 1 - m] == tokens[len - 1 - m]
+                && tokens[p + n - 1 - m] == tokens[len - m]
             {
                 m += 1;
             }
@@ -202,8 +209,8 @@ mod tests {
     fn repeats_the_continuation_of_the_latest_copy() {
         let mut d = LookupDrafter::new(3, 16);
         // [1 2 3] -> 4 5 the first time, [1 2 3] -> 7 8 the second time.
-        let t = vec![1, 2, 3, 4, 5, 9, 1, 2, 3, 7, 8, 9, 1, 2, 3];
-        assert_eq!(d.propose(&t, 2), vec![7, 8]);
+        let t = vec![1, 2, 3, 4, 5, 9, 1, 2, 3, 7, 8, 9, 1, 2];
+        assert_eq!(d.propose(&t, 3, 2), vec![7, 8]);
         assert_eq!(d.fired, 1);
     }
 
@@ -211,14 +218,14 @@ mod tests {
     fn longest_backward_match_beats_recency() {
         let mut d = LookupDrafter::new(3, 16);
         // Older copy shares 4 tokens of context, newer copy shares 3.
-        let t = vec![0, 1, 2, 3, 4, 5, 9, 9, 1, 2, 3, 6, 6, 9, 0, 1, 2, 3];
-        assert_eq!(d.propose(&t, 1), vec![4]);
+        let t = vec![0, 1, 2, 3, 4, 5, 9, 9, 1, 2, 3, 6, 6, 9, 0, 1, 2];
+        assert_eq!(d.propose(&t, 3, 1), vec![4]);
     }
 
     #[test]
     fn nothing_on_fresh_generation() {
         let mut d = LookupDrafter::new(3, 16);
-        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7, 8], 2).is_empty());
+        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7], 8, 2).is_empty());
         assert_eq!(d.fired, 0);
     }
 
@@ -227,35 +234,35 @@ mod tests {
         let mut d = LookupDrafter::new(3, 16);
         // The only earlier copy has four tokens after it; a width of five
         // cannot be filled, a width of four runs into the suffix itself.
-        let t = vec![1, 2, 3, 4, 1, 2, 3];
-        assert!(d.propose(&t, 5).is_empty());
-        assert_eq!(d.propose(&t, 4), vec![4, 1, 2, 3]);
+        let t = vec![1, 2, 3, 4, 1, 2];
+        assert!(d.propose(&t, 3, 4).is_empty());
+        assert_eq!(d.propose(&t, 3, 3), vec![4, 1, 2]);
     }
 
     #[test]
     fn the_suffix_is_not_its_own_continuation() {
         let mut d = LookupDrafter::new(2, 16);
-        let t = vec![5, 5, 5, 5];
+        let t = vec![5, 5, 5];
         // Hits at 0 and 1 continue with 5; the suffix start (2) is skipped.
-        assert_eq!(d.propose(&t, 1), vec![5]);
+        assert_eq!(d.propose(&t, 5, 1), vec![5]);
     }
 
     #[test]
     fn index_extends_incrementally_and_rebuilds_on_a_new_sequence() {
         let mut d = LookupDrafter::new(3, 16);
         let mut t = vec![1, 2, 3, 4, 5];
-        assert!(d.propose(&t, 1).is_empty());
+        assert!(d.propose(&t, 6, 1).is_empty());
         assert_eq!(d.indexed_len(), 5);
-        t.extend([1, 2, 3]);
-        assert_eq!(d.propose(&t, 1), vec![4]);
+        t.extend([6, 1, 2]);
+        assert_eq!(d.propose(&t, 3, 1), vec![4]);
         assert_eq!(d.indexed_len(), 8);
         // A different sequence of the same length: re-indexed, no stale hit.
-        let u = vec![9, 8, 7, 6, 5, 9, 8, 7];
-        assert_eq!(d.propose(&u, 1), vec![6]);
+        let u = vec![9, 8, 7, 6, 5, 4, 9, 8];
+        assert_eq!(d.propose(&u, 7, 1), vec![6]);
         assert_eq!(d.indexed_len(), 8);
         // A rollback shorter than the indexed prefix is re-indexed too.
-        let v = vec![9, 8, 7, 6, 9, 8, 7];
-        assert_eq!(d.propose(&v, 1), vec![6]);
+        let v = vec![9, 8, 7, 6, 5, 9, 8];
+        assert_eq!(d.propose(&v, 7, 1), vec![6]);
         assert_eq!(d.indexed_len(), 7);
     }
 
@@ -263,10 +270,10 @@ mod tests {
     fn matches_the_quadratic_proposer_on_its_own_cases() {
         // The cases `crate::ngram` tests, at the same minimum match.
         let mut d = LookupDrafter::new(2, 16);
-        assert_eq!(d.propose(&[1, 2, 3, 4, 5, 1, 2, 3], 1), vec![4]);
-        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7, 8], 1).is_empty());
-        assert!(d.propose(&[1, 2], 1).is_empty());
-        assert_eq!(d.propose(&[10, 20, 30, 10, 20, 30, 10, 20], 1), vec![30]);
+        assert_eq!(d.propose(&[1, 2, 3, 4, 5, 1, 2], 3, 1), vec![4]);
+        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7], 8, 1).is_empty());
+        assert!(d.propose(&[1], 2, 1).is_empty());
+        assert_eq!(d.propose(&[10, 20, 30, 10, 20, 30, 10], 20, 1), vec![30]);
     }
 
     #[test]
@@ -276,18 +283,20 @@ mod tests {
         let mut t: Vec<u32> = (0..100_000u32).map(|i| i.wrapping_mul(2_654_435_761) % 50_000 + 1_000).collect();
         let block: Vec<u32> = (0..64u32).map(|i| 60_000 + i).collect();
         t.extend(&block);
-        t.extend(&block[..8]);
+        t.extend(&block[..7]);
         let mut d = LookupDrafter::new(4, 16);
         let mut hits = 0;
+        // The newest token (block[7 + 2*step]) is `next`, not yet in `t`.
         for step in 0..28 {
-            let got = d.propose(&t, 2);
+            let next = block[7 + step * 2];
+            let got = d.propose(&t, next, 2);
             let want = block[8 + step * 2..8 + step * 2 + 2].to_vec();
             if got == want {
                 hits += 1;
             }
-            t.extend(&want);
+            t.push(next);
+            t.push(want[0]);
         }
         assert_eq!(hits, 28);
-        assert_eq!(d.indexed_len(), t.len() - 2);
     }
 }

--- a/crates/spark-server/src/lookup_drafts.rs
+++ b/crates/spark-server/src/lookup_drafts.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+//! Lookup drafts for the wide verify (#974).
+//!
+//! The draft for the next step is read out of the sequence itself: find the
+//! most recent earlier occurrence of the tokens just generated and propose the
+//! tokens that followed it. No draft model runs. On generation that repeats
+//! its context (a tool result echoed back, a file re-emitted with one edit,
+//! restated instructions, tool-call scaffolding) the continuation is the right
+//! one nearly every time, and the step costs the verify alone. On fresh
+//! reasoning nothing matches and the MTP head drafts as before.
+//!
+//! The hookup is [`crate::scheduler::lookup_gate`]: when the index fires, the
+//! drafts go into `pending_drafts` and the MTP propose is skipped for that
+//! step; the verify, accept and commit are unchanged.
+//!
+//! # The index
+//!
+//! [`crate::ngram::NgramProposer`] rescans the whole history for every match
+//! length on every step, which is quadratic in the context and proposes one
+//! token. This proposer keeps a hash index from every `min_match`-gram in the
+//! sequence to the positions it starts at, extended incrementally as tokens
+//! commit, so a step costs the candidates at one key. At 88K tokens of context
+//! that is the difference between a scan and a lookup.
+//!
+//! Candidates are tried most recent first and the longest backward match wins
+//! (ties keep the most recent), so a block that has been repeated several
+//! times follows its latest copy. The continuation is returned only when it
+//! fills the requested width: the wide verify dispatches on the number of
+//! drafts, and a short draft would change the step shape the MTP head was
+//! tuned at.
+
+use std::collections::HashMap;
+
+/// Prompt-lookup proposer with an incremental n-gram index over one sequence.
+pub struct LookupDrafter {
+    /// Match length the index is keyed on; shorter matches never fire.
+    min_match: usize,
+    /// Longest backward match considered when ranking candidates.
+    max_match: usize,
+    /// `hash(tokens[p..p + min_match])` to the start positions `p`, ascending.
+    index: HashMap<u64, Vec<u32>>,
+    /// How many tokens of the current sequence the index covers.
+    indexed_len: usize,
+    /// The last `min_match` indexed tokens, to notice a different sequence.
+    tail: Vec<u32>,
+    /// Armed by the MTP step for the run's single-sequence regime; the gate
+    /// never fires with two sequences active (one index, one sequence).
+    single_sequence: bool,
+    /// Steps where the index fired.
+    pub fired: u64,
+    /// Drafts proposed across those steps.
+    pub proposed: u64,
+    /// Drafts the verify accepted across those steps.
+    pub accepted: u64,
+}
+
+impl LookupDrafter {
+    pub fn new(min_match: usize, max_match: usize) -> Self {
+        let min_match = min_match.max(2);
+        Self {
+            min_match,
+            max_match: max_match.max(min_match),
+            index: HashMap::new(),
+            indexed_len: 0,
+            tail: Vec::new(),
+            single_sequence: false,
+            fired: 0,
+            proposed: 0,
+            accepted: 0,
+        }
+    }
+
+    pub fn set_single_sequence(&mut self, single: bool) {
+        self.single_sequence = single;
+    }
+
+    pub fn single_sequence(&self) -> bool {
+        self.single_sequence
+    }
+
+    pub fn min_match(&self) -> usize {
+        self.min_match
+    }
+
+    /// Positions indexed so far (tests and diagnostics).
+    pub fn indexed_len(&self) -> usize {
+        self.indexed_len
+    }
+
+    /// Forget the sequence; the next `propose` rebuilds from scratch.
+    pub fn reset(&mut self) {
+        self.index.clear();
+        self.indexed_len = 0;
+        self.tail.clear();
+    }
+
+    /// Count a verify of `proposed` lookup drafts that accepted `accepted`.
+    pub fn record(&mut self, proposed: usize, accepted: usize) {
+        self.proposed += proposed as u64;
+        self.accepted += accepted as u64;
+    }
+
+    fn key(gram: &[u32]) -> u64 {
+        // FNV-1a over the token ids; the index verifies every hit token by
+        // token, so a collision costs a compare, never a wrong draft.
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for &t in gram {
+            h ^= t as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        h
+    }
+
+    /// Bring the index up to `tokens.len()`. A sequence that does not extend
+    /// the indexed prefix (a new request, a watchdog rollback) is re-indexed.
+    fn extend(&mut self, tokens: &[u32]) {
+        let len = tokens.len();
+        let n = self.min_match;
+        let continues = len >= self.indexed_len
+            && self.indexed_len >= self.tail.len()
+            && tokens[self.indexed_len - self.tail.len()..self.indexed_len] == self.tail[..];
+        if !continues {
+            self.reset();
+        }
+        if len < n {
+            return;
+        }
+        // Grams already indexed start at p <= indexed_len - n.
+        let first = if self.indexed_len >= n {
+            self.indexed_len - n + 1
+        } else {
+            0
+        };
+        for p in first..=len - n {
+            self.index
+                .entry(Self::key(&tokens[p..p + n]))
+                .or_default()
+                .push(p as u32);
+        }
+        self.indexed_len = len;
+        self.tail.clear();
+        self.tail.extend_from_slice(&tokens[len - n.min(len)..]);
+    }
+
+    /// Propose exactly `width` tokens to follow `tokens`, or nothing.
+    ///
+    /// `tokens` is the committed sequence, prompt and generation together.
+    pub fn propose(&mut self, tokens: &[u32], width: usize) -> Vec<u32> {
+        let len = tokens.len();
+        let n = self.min_match;
+        if width == 0 || len < n + width {
+            return Vec::new();
+        }
+        self.extend(tokens);
+        let suffix_start = len - n;
+        let suffix = &tokens[suffix_start..];
+        let Some(starts) = self.index.get(&Self::key(suffix)) else {
+            return Vec::new();
+        };
+        let mut best: Option<(usize, usize)> = None; // (match length, start)
+        for &p in starts.iter().rev() {
+            let p = p as usize;
+            // The hit needs `width` tokens after it that are not the suffix
+            // itself being proposed as its own continuation.
+            if p + n + width > len || p == suffix_start {
+                continue;
+            }
+            if tokens[p..p + n] != *suffix {
+                continue;
+            }
+            // Extend the match backwards; longer context, better draft.
+            let mut m = n;
+            while m < self.max_match
+                && p >= m + 1 - n
+                && suffix_start >= m + 1 - n
+                && tokens[p + n - 1 - m] == tokens[len - 1 - m]
+            {
+                m += 1;
+            }
+            if best.is_none_or(|(bm, _)| m > bm) {
+                best = Some((m, p));
+                if m == self.max_match {
+                    break;
+                }
+            }
+        }
+        let Some((_, p)) = best else {
+            return Vec::new();
+        };
+        self.fired += 1;
+        tokens[p + n..p + n + width].to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeats_the_continuation_of_the_latest_copy() {
+        let mut d = LookupDrafter::new(3, 16);
+        // [1 2 3] -> 4 5 the first time, [1 2 3] -> 7 8 the second time.
+        let t = vec![1, 2, 3, 4, 5, 9, 1, 2, 3, 7, 8, 9, 1, 2, 3];
+        assert_eq!(d.propose(&t, 2), vec![7, 8]);
+        assert_eq!(d.fired, 1);
+    }
+
+    #[test]
+    fn longest_backward_match_beats_recency() {
+        let mut d = LookupDrafter::new(3, 16);
+        // Older copy shares 4 tokens of context, newer copy shares 3.
+        let t = vec![0, 1, 2, 3, 4, 5, 9, 9, 1, 2, 3, 6, 6, 9, 0, 1, 2, 3];
+        assert_eq!(d.propose(&t, 1), vec![4]);
+    }
+
+    #[test]
+    fn nothing_on_fresh_generation() {
+        let mut d = LookupDrafter::new(3, 16);
+        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7, 8], 2).is_empty());
+        assert_eq!(d.fired, 0);
+    }
+
+    #[test]
+    fn a_short_continuation_does_not_fire() {
+        let mut d = LookupDrafter::new(3, 16);
+        // The only earlier copy has four tokens after it; a width of five
+        // cannot be filled, a width of four runs into the suffix itself.
+        let t = vec![1, 2, 3, 4, 1, 2, 3];
+        assert!(d.propose(&t, 5).is_empty());
+        assert_eq!(d.propose(&t, 4), vec![4, 1, 2, 3]);
+    }
+
+    #[test]
+    fn the_suffix_is_not_its_own_continuation() {
+        let mut d = LookupDrafter::new(2, 16);
+        let t = vec![5, 5, 5, 5];
+        // Hits at 0 and 1 continue with 5; the suffix start (2) is skipped.
+        assert_eq!(d.propose(&t, 1), vec![5]);
+    }
+
+    #[test]
+    fn index_extends_incrementally_and_rebuilds_on_a_new_sequence() {
+        let mut d = LookupDrafter::new(3, 16);
+        let mut t = vec![1, 2, 3, 4, 5];
+        assert!(d.propose(&t, 1).is_empty());
+        assert_eq!(d.indexed_len(), 5);
+        t.extend([1, 2, 3]);
+        assert_eq!(d.propose(&t, 1), vec![4]);
+        assert_eq!(d.indexed_len(), 8);
+        // A different sequence of the same length: re-indexed, no stale hit.
+        let u = vec![9, 8, 7, 6, 5, 9, 8, 7];
+        assert_eq!(d.propose(&u, 1), vec![6]);
+        assert_eq!(d.indexed_len(), 8);
+        // A rollback shorter than the indexed prefix is re-indexed too.
+        let v = vec![9, 8, 7, 6, 9, 8, 7];
+        assert_eq!(d.propose(&v, 1), vec![6]);
+        assert_eq!(d.indexed_len(), 7);
+    }
+
+    #[test]
+    fn matches_the_quadratic_proposer_on_its_own_cases() {
+        // The cases `crate::ngram` tests, at the same minimum match.
+        let mut d = LookupDrafter::new(2, 16);
+        assert_eq!(d.propose(&[1, 2, 3, 4, 5, 1, 2, 3], 1), vec![4]);
+        assert!(d.propose(&[1, 2, 3, 4, 5, 6, 7, 8], 1).is_empty());
+        assert!(d.propose(&[1, 2], 1).is_empty());
+        assert_eq!(d.propose(&[10, 20, 30, 10, 20, 30, 10, 20], 1), vec![30]);
+    }
+
+    #[test]
+    fn a_long_context_is_one_lookup_per_step() {
+        // 100K tokens of noise, then a 64-token block repeated: the second
+        // copy drafts the first at every step.
+        let mut t: Vec<u32> = (0..100_000u32).map(|i| i.wrapping_mul(2_654_435_761) % 50_000 + 1_000).collect();
+        let block: Vec<u32> = (0..64u32).map(|i| 60_000 + i).collect();
+        t.extend(&block);
+        t.extend(&block[..8]);
+        let mut d = LookupDrafter::new(4, 16);
+        let mut hits = 0;
+        for step in 0..28 {
+            let got = d.propose(&t, 2);
+            let want = block[8 + step * 2..8 + step * 2 + 2].to_vec();
+            if got == want {
+                hits += 1;
+            }
+            t.extend(&want);
+        }
+        assert_eq!(hits, 28);
+        assert_eq!(d.indexed_len(), t.len() - 2);
+    }
+}

--- a/crates/spark-server/src/main.rs
+++ b/crates/spark-server/src/main.rs
@@ -47,6 +47,7 @@ pub mod metrics;
 mod model_download;
 mod model_resolver;
 mod moe_quality;
+mod lookup_drafts;
 mod ngram;
 mod openai;
 mod rate_limiter;

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -72,7 +72,11 @@ pub struct SchedLevers {
     /// `ATLAS_LOOKUP_DRAFTS=0` restores the MTP head on every step.
     pub lookup_drafts: bool,
     /// Match length the lookup index is keyed on (`ATLAS_LOOKUP_MIN_MATCH`,
-    /// default 4). Shorter matches never fire.
+    /// default 8). Shorter matches never fire. Measured 2026-09-12 on
+    /// Qwen3.8-Flash-Next: at 4 the index fires on fresh code and prose
+    /// (`self.`, `return`, `):` repeat every few lines), the verify rejects
+    /// the drafts, accept counts drop and every stream moves; at 8 all three
+    /// standard cells are byte-identical to the base at base tok/s.
     pub lookup_min_match: usize,
     /// Longest backward match the lookup ranks by (`ATLAS_LOOKUP_MAX_MATCH`,
     /// default 16).
@@ -226,7 +230,7 @@ impl SchedLevers {
             dflash_adaptive_reprobe: num("ATLAS_DFLASH_ADAPTIVE_REPROBE", 256),
             dflash_resume_guard: num("ATLAS_DFLASH_RESUME_GUARD", 0),
             lookup_drafts: on_unless_zero("ATLAS_LOOKUP_DRAFTS"),
-            lookup_min_match: num("ATLAS_LOOKUP_MIN_MATCH", 4),
+            lookup_min_match: num("ATLAS_LOOKUP_MIN_MATCH", 8),
             lookup_max_match: num("ATLAS_LOOKUP_MAX_MATCH", 16),
             shadow_topk: spark_model::speculative::shadow_topk(),
 
@@ -275,7 +279,7 @@ impl SchedLevers {
             dflash_adaptive_reprobe: 256,
             dflash_resume_guard: 0,
             lookup_drafts: true,
-            lookup_min_match: 4,
+            lookup_min_match: 8,
             lookup_max_match: 16,
             shadow_topk: 0,
             disable_watchdogs: false,

--- a/crates/spark-server/src/scheduler/levers.rs
+++ b/crates/spark-server/src/scheduler/levers.rs
@@ -66,6 +66,17 @@ pub struct SchedLevers {
     /// `ATLAS_DFLASH_RESUME_GUARD=N` (default 0 = off): keep the first N
     /// post-`</think>` tokens on plain serial decode.
     pub dflash_resume_guard: u32,
+    /// Lookup drafts into the wide verify (#974): when the sequence's own
+    /// history matches the tokens just generated, the continuation is the
+    /// draft and the MTP propose is skipped for that step. Ships ON;
+    /// `ATLAS_LOOKUP_DRAFTS=0` restores the MTP head on every step.
+    pub lookup_drafts: bool,
+    /// Match length the lookup index is keyed on (`ATLAS_LOOKUP_MIN_MATCH`,
+    /// default 4). Shorter matches never fire.
+    pub lookup_min_match: usize,
+    /// Longest backward match the lookup ranks by (`ATLAS_LOOKUP_MAX_MATCH`,
+    /// default 16).
+    pub lookup_max_match: usize,
     /// `ATLAS_MTP_SHADOW_TOPK` — the verify side of the drafter top-k probe.
     /// Parsed by `spark_model::speculative::shadow_topk`, the SSOT.
     pub shadow_topk: usize,
@@ -214,6 +225,9 @@ impl SchedLevers {
             dflash_adaptive_min: num("ATLAS_DFLASH_ADAPTIVE_MIN", 2.0),
             dflash_adaptive_reprobe: num("ATLAS_DFLASH_ADAPTIVE_REPROBE", 256),
             dflash_resume_guard: num("ATLAS_DFLASH_RESUME_GUARD", 0),
+            lookup_drafts: on_unless_zero("ATLAS_LOOKUP_DRAFTS"),
+            lookup_min_match: num("ATLAS_LOOKUP_MIN_MATCH", 4),
+            lookup_max_match: num("ATLAS_LOOKUP_MAX_MATCH", 16),
             shadow_topk: spark_model::speculative::shadow_topk(),
 
             // Reuses the tested parsers in `helpers` rather than re-deriving
@@ -260,6 +274,9 @@ impl SchedLevers {
             dflash_adaptive_min: 2.0,
             dflash_adaptive_reprobe: 256,
             dflash_resume_guard: 0,
+            lookup_drafts: true,
+            lookup_min_match: 4,
+            lookup_max_match: 16,
             shadow_topk: 0,
             disable_watchdogs: false,
             eos_suppressed_by_thinking: false,

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -485,6 +485,7 @@ pub fn resume_swapped_seq(
         grammar_state: None,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
+        pending_drafts_lookup: false,
         last_token_time: Instant::now(),
         request_start: s.request_start,
         decode_start: s.decode_start,

--- a/crates/spark-server/src/scheduler/lifecycle_tests.rs
+++ b/crates/spark-server/src/scheduler/lifecycle_tests.rs
@@ -406,6 +406,7 @@ fn test_seq(
         grammar_state: None,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
+        pending_drafts_lookup: false,
         last_token_time: now,
         request_start: now,
         decode_start: now,

--- a/crates/spark-server/src/scheduler/lookup_gate.rs
+++ b/crates/spark-server/src/scheduler/lookup_gate.rs
@@ -34,9 +34,15 @@ pub(super) fn take_lookup_drafts(
     sched: &SchedCtx,
     width: usize,
     dflash: bool,
+    ep: bool,
 ) -> bool {
+    // Off under expert parallelism: the drafter runs on rank 0 only, and a
+    // lookup step on rank 0 moved the Marconi prefix-cache anchors on both
+    // ranks of a TP=2 x EP=2 build (Richard's bisect, 2026-09-12). Until
+    // that is understood the gate stays single-rank.
     if !sched.levers.lookup_drafts
         || dflash
+        || ep
         || seq.grammar_state.is_some()
         || !WIDE_WIDTHS.contains(&width)
     {
@@ -46,7 +52,9 @@ pub(super) fn take_lookup_drafts(
     if !lookup.single_sequence() {
         return false;
     }
-    let drafts = lookup.propose(&seq.seq.tokens, width);
+    // `seq.tokens` holds the rows the model has consumed; the newest token
+    // is `last_token`, emitted and not yet fed. Drafts follow it.
+    let drafts = lookup.propose(&seq.seq.tokens, seq.last_token, width);
     if drafts.is_empty() {
         return false;
     }
@@ -88,8 +96,9 @@ mod tests {
     fn fires_at_the_wide_width_and_marks_the_sequence() {
         let sched = ctx_with(3);
         sched.lookup.borrow_mut().set_single_sequence(true);
-        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2, 3]);
-        assert!(take_lookup_drafts(&mut a, &sched, 2, false));
+        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2]);
+        a.last_token = 3;
+        assert!(take_lookup_drafts(&mut a, &sched, 2, false, false));
         assert_eq!(a.pending_drafts, vec![4, 5]);
         assert!(a.pending_drafts_lookup);
         assert!(a.pending_draft_conf.is_empty());
@@ -98,13 +107,15 @@ mod tests {
     #[test]
     fn stays_out_of_dflash_grammar_narrow_and_multi_sequence() {
         let sched = ctx_with(3);
-        let t = [1, 2, 3, 4, 5, 9, 1, 2, 3];
+        let t = [1, 2, 3, 4, 5, 9, 1, 2];
         let mut a = seq_with(&t);
-        assert!(!take_lookup_drafts(&mut a, &sched, 2, false), "not armed single");
+        a.last_token = 3;
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, false, false), "not armed single");
         sched.lookup.borrow_mut().set_single_sequence(true);
-        assert!(!take_lookup_drafts(&mut a, &sched, 2, true), "dflash");
-        assert!(!take_lookup_drafts(&mut a, &sched, 1, false), "K=2 lane");
-        assert!(!take_lookup_drafts(&mut a, &sched, 4, false), "past the wide verify");
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, true, false), "dflash");
+        assert!(!take_lookup_drafts(&mut a, &sched, 1, false, false), "K=2 lane");
+        assert!(!take_lookup_drafts(&mut a, &sched, 4, false, false), "past the wide verify");
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, false, true), "expert parallel");
         assert!(a.pending_drafts.is_empty() && !a.pending_drafts_lookup);
     }
 
@@ -121,7 +132,8 @@ mod tests {
             crate::scheduler::helpers::WatchdogParams::default(),
         );
         sched.lookup.borrow_mut().set_single_sequence(true);
-        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2, 3]);
-        assert!(!take_lookup_drafts(&mut a, &sched, 2, false));
+        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2]);
+        a.last_token = 3;
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, false, false));
     }
 }

--- a/crates/spark-server/src/scheduler/lookup_gate.rs
+++ b/crates/spark-server/src/scheduler/lookup_gate.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// provenance-id: 526f6e616c6420522e205374657369616b
+
+//! The draft gate for the wide verify (#974): lookup first, MTP head second.
+//!
+//! Both sites that hand the wide verify its drafts (the bootstrap propose in
+//! `mtp_step` and the re-propose at the end of `verify_mtp_wide::finish`) ask
+//! the lookup index before running the MTP head. A hit fills
+//! `pending_drafts` at the width the head would have drafted, marks the
+//! sequence, and the head does not run that step. The verify, accept, commit
+//! and rollback are the same code either way.
+//!
+//! What a lookup step does to the drafter: nothing. No drafter rows are
+//! written for lookup drafts, so `finish` skips the proposer trim for that
+//! step (the Flash-Next head rewinds `drafted - accepted`, and both are zero
+//! here). The drafter's own KV then lacks the positions the lookup step
+//! committed, the same gap a suspended step leaves today; the next MTP
+//! propose reads the target's highway for the row it drafts from, as always.
+//!
+//! Off under DFlash (its own drafter and seam), under a grammar (the wide
+//! path clamps drafts there), at widths the wide verify does not dispatch,
+//! and whenever more than one sequence is active.
+
+use super::sched_ctx::SchedCtx;
+use super::types::ActiveSeq;
+
+/// Widths the wide verify dispatches: K=3 and K=4 rows.
+const WIDE_WIDTHS: std::ops::RangeInclusive<usize> = 2..=3;
+
+/// Try the lookup index for `width` drafts. `true` means `pending_drafts` is
+/// set and the caller skips the MTP propose this step.
+pub(super) fn take_lookup_drafts(
+    seq: &mut ActiveSeq,
+    sched: &SchedCtx,
+    width: usize,
+    dflash: bool,
+) -> bool {
+    if !sched.levers.lookup_drafts
+        || dflash
+        || seq.grammar_state.is_some()
+        || !WIDE_WIDTHS.contains(&width)
+    {
+        return false;
+    }
+    let mut lookup = sched.lookup.borrow_mut();
+    if !lookup.single_sequence() {
+        return false;
+    }
+    let drafts = lookup.propose(&seq.seq.tokens, width);
+    if drafts.is_empty() {
+        return false;
+    }
+    tracing::debug!(
+        "lookup drafts: seq_len={} drafts={drafts:?} (fired {} steps)",
+        seq.seq.seq_len,
+        lookup.fired
+    );
+    seq.pending_drafts = drafts;
+    seq.pending_draft_conf.clear();
+    seq.pending_drafts_lookup = true;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_with(min_match: usize) -> SchedCtx {
+        let mut levers = crate::scheduler::levers::SchedLevers::defaults();
+        levers.lookup_min_match = min_match;
+        SchedCtx::new(
+            crate::scheduler::vocab_masks::VocabMasks::default(),
+            std::sync::Arc::new(levers),
+            std::sync::Arc::new(crate::scheduler::snapshot::SnapshotCell::default()),
+            crate::scheduler::limits::SchedLimits::NONE,
+            crate::scheduler::helpers::WatchdogParams::default(),
+        )
+    }
+
+    fn seq_with(tokens: &[u32]) -> ActiveSeq {
+        let (mut a, _rx) = crate::scheduler::test_support::active_seq(0, 0);
+        a.seq.tokens = tokens.to_vec();
+        a.seq.seq_len = tokens.len();
+        a
+    }
+
+    #[test]
+    fn fires_at_the_wide_width_and_marks_the_sequence() {
+        let sched = ctx_with(3);
+        sched.lookup.borrow_mut().set_single_sequence(true);
+        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2, 3]);
+        assert!(take_lookup_drafts(&mut a, &sched, 2, false));
+        assert_eq!(a.pending_drafts, vec![4, 5]);
+        assert!(a.pending_drafts_lookup);
+        assert!(a.pending_draft_conf.is_empty());
+    }
+
+    #[test]
+    fn stays_out_of_dflash_grammar_narrow_and_multi_sequence() {
+        let sched = ctx_with(3);
+        let t = [1, 2, 3, 4, 5, 9, 1, 2, 3];
+        let mut a = seq_with(&t);
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, false), "not armed single");
+        sched.lookup.borrow_mut().set_single_sequence(true);
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, true), "dflash");
+        assert!(!take_lookup_drafts(&mut a, &sched, 1, false), "K=2 lane");
+        assert!(!take_lookup_drafts(&mut a, &sched, 4, false), "past the wide verify");
+        assert!(a.pending_drafts.is_empty() && !a.pending_drafts_lookup);
+    }
+
+    #[test]
+    fn the_kill_switch_restores_the_mtp_head() {
+        let mut levers = crate::scheduler::levers::SchedLevers::defaults();
+        levers.lookup_drafts = false;
+        levers.lookup_min_match = 3;
+        let sched = SchedCtx::new(
+            crate::scheduler::vocab_masks::VocabMasks::default(),
+            std::sync::Arc::new(levers),
+            std::sync::Arc::new(crate::scheduler::snapshot::SnapshotCell::default()),
+            crate::scheduler::limits::SchedLimits::NONE,
+            crate::scheduler::helpers::WatchdogParams::default(),
+        );
+        sched.lookup.borrow_mut().set_single_sequence(true);
+        let mut a = seq_with(&[1, 2, 3, 4, 5, 9, 1, 2, 3]);
+        assert!(!take_lookup_drafts(&mut a, &sched, 2, false));
+    }
+}

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -37,6 +37,7 @@ pub use mod_helpers::capture_runtime_handle;
 pub mod dumps;
 pub mod levers;
 pub mod limits;
+mod lookup_gate;
 mod mtp_accept_debug;
 mod mtp_bootstrap_step;
 mod mtp_dcut;

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -303,6 +303,7 @@ pub fn step_mtp(
                 sched,
                 effective_num_drafts,
                 dflash_verify_raw_argmax,
+                model.is_ep(),
             )
         {
             tracing::debug!("lookup bootstrap: tok={tok} → drafts={:?}", a.pending_drafts);

--- a/crates/spark-server/src/scheduler/mtp_step.rs
+++ b/crates/spark-server/src/scheduler/mtp_step.rs
@@ -27,6 +27,7 @@ pub fn step_mtp(
     // GAP. One Instant::now() when disarmed, same cost note as StepTimer.
     let t_step_outer = std::time::Instant::now();
     let single_sequence = active.len() == 1;
+    sched.lookup.borrow_mut().set_single_sequence(single_sequence);
     let mut bootstrap_idxs: Vec<usize> = Vec::new();
     let mut verify_idxs: Vec<usize> = Vec::new();
     for (i, a) in active.iter().enumerate() {
@@ -295,7 +296,17 @@ pub fn step_mtp(
         // Adaptive speculation: a suspended seq skips proposing entirely and
         // stays on this serial bootstrap path until the re-probe fires.
         // (`will_propose` is the single spec_allowed evaluation above.)
-        if will_propose {
+        // Lookup first (#974): a hit fills the drafts and the head sits out.
+        if will_propose
+            && super::lookup_gate::take_lookup_drafts(
+                a,
+                sched,
+                effective_num_drafts,
+                dflash_verify_raw_argmax,
+            )
+        {
+            tracing::debug!("lookup bootstrap: tok={tok} → drafts={:?}", a.pending_drafts);
+        } else if will_propose {
             match model.run_mtp_propose_multi(
                 tok,
                 a.seq.seq_len,

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -181,6 +181,7 @@ fn build_active_seq_from_prefill(
         logit_bias: p.logit_bias,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
+        pending_drafts_lookup: false,
         inside_thinking: if immediate_finish {
             p.enable_thinking && think_end_token.is_some()
         } else {

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -220,6 +220,7 @@ pub fn start_chunked_prefill(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
+            pending_drafts_lookup: false,
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -566,6 +567,7 @@ pub fn start_chunked_prefill(
                 logit_bias: logit_bias.clone(),
                 pending_drafts: Vec::new(),
                 pending_draft_conf: Vec::new(),
+                pending_drafts_lookup: false,
                 inside_thinking: req_enable_thinking && think_end_token.is_some(),
                 enable_thinking: req_enable_thinking,
                 thinking_budget: req_thinking_budget,
@@ -654,6 +656,7 @@ pub fn start_chunked_prefill(
                 logit_bias: logit_bias.clone(),
                 pending_drafts: Vec::new(),
                 pending_draft_conf: Vec::new(),
+                pending_drafts_lookup: false,
                 inside_thinking: spontaneous_think
                     || (req_enable_thinking && think_end_token.is_some()),
                 enable_thinking: req_enable_thinking,

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -191,6 +191,7 @@ pub fn prefill_request(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
+            pending_drafts_lookup: false,
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -385,6 +386,7 @@ pub fn prefill_request(
             logit_bias: logit_bias.clone(),
             pending_drafts: Vec::new(),
             pending_draft_conf: Vec::new(),
+            pending_drafts_lookup: false,
             inside_thinking: req_enable_thinking && think_end_token.is_some(),
             enable_thinking: req_enable_thinking,
             thinking_budget: req_thinking_budget,
@@ -470,6 +472,7 @@ pub fn prefill_request(
         logit_bias,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
+        pending_drafts_lookup: false,
         inside_thinking: spontaneous_think || (req_enable_thinking && think_end_token.is_some()),
         enable_thinking: req_enable_thinking,
         thinking_budget: if spontaneous_think {

--- a/crates/spark-server/src/scheduler/sched_ctx.rs
+++ b/crates/spark-server/src/scheduler/sched_ctx.rs
@@ -74,6 +74,9 @@ pub struct SchedCtx {
     /// with; putting the seam in the right place now is cheaper than moving it
     /// once something depends on it.
     pub rom_head: Option<std::sync::Arc<dyn crate::scheduler::rollback::RomHead>>,
+    /// Lookup-draft index for this run (#974). One sequence at a time, like
+    /// every speculative path here; `RefCell` for the same reason `scratch` is.
+    pub lookup: std::cell::RefCell<crate::lookup_drafts::LookupDrafter>,
 }
 
 impl SchedCtx {
@@ -89,6 +92,10 @@ impl SchedCtx {
             snapshot,
             dumps: crate::scheduler::dumps::RunDumps::from_env(),
             scratch: DecodeScratch::default(),
+            lookup: std::cell::RefCell::new(crate::lookup_drafts::LookupDrafter::new(
+                levers.lookup_min_match,
+                levers.lookup_max_match,
+            )),
             levers,
             limits,
             watchdog,

--- a/crates/spark-server/src/scheduler/test_support.rs
+++ b/crates/spark-server/src/scheduler/test_support.rs
@@ -112,6 +112,7 @@ pub(super) fn test_seq(
         grammar_state: None,
         pending_drafts: Vec::new(),
         pending_draft_conf: Vec::new(),
+        pending_drafts_lookup: false,
         last_token_time: now,
         request_start: now,
         decode_start: now,

--- a/crates/spark-server/src/scheduler/types.rs
+++ b/crates/spark-server/src/scheduler/types.rs
@@ -381,6 +381,10 @@ pub(super) struct ActiveSeq {
     /// which case D-Cut leaves the sequence at full depth. Truncated in
     /// lock-step with `pending_drafts` so index `j` always describes draft `j`.
     pub pending_draft_conf: Vec<f32>,
+    /// [`Self::pending_drafts`] came from the lookup index, not the MTP head
+    /// (#974): no drafter rows were written for them, so the verify's
+    /// proposer trim is skipped for that step.
+    pub pending_drafts_lookup: bool,
     /// Timestamp of the last token emission (for TBT deadline tracking).
     pub last_token_time: Instant,
     /// Timestamp when the request entered prefill (for TTFT).

--- a/crates/spark-server/src/scheduler/verify_mtp_wide.rs
+++ b/crates/spark-server/src/scheduler/verify_mtp_wide.rs
@@ -137,7 +137,7 @@ pub(super) fn finish(
         seq.finished = true;
         return;
     }
-    if super::lookup_gate::take_lookup_drafts(seq, sched, num_drafts, false) {
+    if super::lookup_gate::take_lookup_drafts(seq, sched, num_drafts, false, model.is_ep()) {
         return;
     }
     let grammar_mask = super::mtp_grammar_mask_for(seq);

--- a/crates/spark-server/src/scheduler/verify_mtp_wide.rs
+++ b/crates/spark-server/src/scheduler/verify_mtp_wide.rs
@@ -51,6 +51,9 @@ pub(super) fn finish(
     ctx: &LogitsContext,
 ) {
     let k = drafts.len() + 1;
+    // Lookup drafts (#974) wrote no drafter rows: the trim below is skipped
+    // for them, and the index is scored on what the verify accepted.
+    let from_lookup = std::mem::take(&mut seq.pending_drafts_lookup);
     let vocab = model.vocab_size();
     // Borrow the run's staging buffer instead of allocating. `vec![0; ...]`
     // here was a fresh 1.49 MB (K=3, vocab 151936) allocation AND zero-fill on
@@ -114,7 +117,9 @@ pub(super) fn finish(
     if !super::verify_k2_step::commit_verify_aux_or_finish(model, seq, na + 1, k) {
         return;
     }
-    if let Err(e) = model.trim_proposer_state(&mut seq.seq, na, 0) {
+    if from_lookup {
+        sched.lookup.borrow_mut().record(drafts.len(), na);
+    } else if let Err(e) = model.trim_proposer_state(&mut seq.seq, na, 0) {
         tracing::error!("trim_proposer_state(K={k}): {e:#}");
         seq.finished = true;
         return;
@@ -130,6 +135,9 @@ pub(super) fn finish(
     if let Err(e) = model.save_hidden_for_mtp(na, 0) {
         tracing::error!("save_hidden_for_mtp({na}): {e:#}");
         seq.finished = true;
+        return;
+    }
+    if super::lookup_gate::take_lookup_drafts(seq, sched, num_drafts, false) {
         return;
     }
     let grammar_mask = super::mtp_grammar_mask_for(seq);


### PR DESCRIPTION
Claims the implementation of #974 on Qwen3.8-Flash-Next. Draft until the cells below are measured; the code is complete and wired, the tests are in the tree.

## What it does

The step reads its draft out of the sequence before it runs the MTP head. When the last `ATLAS_LOOKUP_MIN_MATCH` tokens (default 8) already occurred earlier in the prompt or the generation, the tokens that followed that occurrence become the drafts, at the width the head would have drafted (K=3 or K=4 rows), and the head does not run that step. With no match the head drafts as before. The verify, accept, commit and rollback paths are untouched.

Copy-heavy turns are where it pays: tool output echoed back, a file re-emitted with one edit, restated instructions, tool-call scaffolding. The class is real. llama.cpp posted 97.4 tok/s on one Spark on "reproduce a file with one change" at 94.7% acceptance against 22 on prose (NVIDIA forum, Flash-Next thread p.4, 26 Aug). Atlas MTP-2 on this pack stands at 62.0 on fresh generation (#973). Copy-task and fresh-generation numbers stay in separate tables.

## What changed

| file | change |
|---|---|
| `spark-server/src/lookup_drafts.rs` | new. A hash index from every min-match-gram to the positions it starts at, extended incrementally as tokens commit, rebuilt on a new sequence or a rollback. One lookup per step at 88K context, where the existing `ngram.rs` rescans the whole history per step. Most recent hit first, longest backward match wins. Fires only when the continuation fills the requested width, so the step shape stays the one the head was tuned at. |
| `scheduler/lookup_gate.rs` | new. The gate both draft sites call: off under DFlash, under a grammar, under expert parallelism, at one draft (the K=2 lane), and with more than one sequence active. At two drafts, K=3 rows, it is live. |
| `scheduler/verify_mtp_wide.rs` | `finish` asks the gate before the re-propose. A lookup step skips the proposer trim (no drafter rows were written for its drafts) and scores the index on what the verify accepted. |
| `scheduler/mtp_step.rs` | the bootstrap asks the gate before the propose, and arms the gate for the single-sequence regime. |
| `scheduler/levers.rs`, `sched_ctx.rs`, `types.rs` | `lookup_drafts`, `lookup_min_match`, `lookup_max_match`; the index lives on the run's context; `pending_drafts_lookup` on the sequence. |

Defaults ON. `ATLAS_LOOKUP_DRAFTS=0` restores the MTP head on every step, byte-identical to the base.

## Drafter state on a lookup step

The Flash-Next head rewinds `drafted - accepted` rows after each verify. A lookup step drafts nothing through the head, so there is nothing to rewind and `finish` skips the trim. The head's own KV then lacks the positions that step committed, the gap a suspended step already leaves today; the next propose reads the target's highway for the row it drafts from, as it does now. A wrong lookup draft costs what a wrong head draft costs: the rows the verify rejects.

## Not in this PR

The K=4+ small-M FFN arm. K=4 rows fall off the small-M FFN arms onto the prefill MoE path (LRU 14.9 tok/s during the #972 series), so this PR runs at the width #973 runs at. Wider lookup drafts on Flash-Next wait on that arm. The 27B's batched GDN verify (#844, #845) takes them today.

## Measured so far, my box, this branch

MTP-2, three standard cells, three runs each, against the same binary with `ATLAS_LOOKUP_DRAFTS=0`. At match length 4 the index fires on fresh code and prose, accept counts fall (LRU 310 to 303, MinHeap 178 to 169) and every stream moves. At match length 8 all nine runs are byte-identical to the base at base tok/s, so 8 is the default. Richard's bisect on a TP=2 x EP=2 build found the same firing cost at 4, plus prefix-cache anchor drift across ranks; the gate is now off under expert parallelism until that is understood. The copy-task cell and the agentic gate follow.

## Measurement plan, my box, before this leaves draft

1. Fixed-file "reproduce with one change" cell, its own table.
2. MinHeap x3 and Volvo x3, byte-identical streams against `ATLAS_LOOKUP_DRAFTS=0`, medians, completion tokens beside tok/s.
3. `spark benchmark run agentic-webserver` against the serve.

Environment: nvidia/Qwen3.8-Flash-Next-NVFP4 @ fc694b54, GB10, `bench/qwen4_exp/serve_nvidia_mtp.sh`, MTP_DRAFTS=2.

Tests: `cargo test -p spark-server lookup`.

Related: #974, #972, #973, #844, #845, #834.


