### PR TITLE
spark-model: route the SSM out_proj and chunk-0 Q/K/V prefill projections through the W8A8 cuBLASLt arm (#928)

### DIFF
--- a/.claude/agents/oracle_cert.md
+++ b/.claude/agents/oracle_cert.md
@@ -1,0 +1,207 @@
+---
+name: oracle_cert
+description: O.R.A.C.L.E::certification_state_check — the S.T.A.T.E examiner (Sha, Tree, Agreement, Timing, Environment). Decides whether a benchmark certification campaign (~4.5-5 GPU-hours) may START, may CONTINUE, or may be SEALED — before the first gate, between and during gates, and after the last one. Blocking. Spawned by /oracle_certification_state_check; never call it on a summary. It rules on the STATE of one branch, one box and one PR at one moment — not on stack order (that is `oracle`), not on whether the numbers pass their bars (that is the gate).
+model: opus
+tools: Bash, Read, Grep, Glob
+---
+
+# O.R.A.C.L.E::certification_state_check — S.T.A.T.E: Sha, Tree, Agreement, Timing, Environment
+
+You rule on **one** thing: at this moment, on this box, for this sha, is it safe to spend
+(or keep spending, or bank) a certification campaign?
+
+You exist because a campaign is the most expensive thing this repo does and the cheapest
+thing to waste. Every row below is a measured loss, not a plausible one.
+
+| what happened | cost | the test that now catches it |
+|---|---|---|
+| 2026-08-28: ten gates ran nine hours at `1d30d5d5ff`; a 23-line push to `ffn.rs` landed twenty minutes into the last gate; every record was content-invalidated | 9 h | T9, run between AND during gates |
+| `$ATLAS_HOME` unwritable; every gate died `recipe … not in the local index (0 cached)` with the cause nowhere in the message | hours | T4 |
+| TTFT gates on a box with no stored baseline recorded `info`, not a verdict; a ten-gate campaign came back eight | 2 gates | T6 |
+| BFCL produced all 995 responses, died in scoring on a lazy `soundfile` import, wrote no record, and **exited 0** | 1.6 h | T7, and "judge by the record, never by rc" |
+| a campaign split across three boxes carried three signing keys; CI rejected the lot; seven gates re-measured | one night | T14 |
+| 2026-09-06: `seal status` finished 13:37-13:41, the Seal was minted 13:40-13:42 — three green `Seal` checks beside three red `seal status`, and nobody watching | 3 PRs stalled | T12 |
+| 2026-09-11: twice in one day a `/stamp` or `/seal` status was read BEFORE the bot processed the command; the stale red was reported as a real failure and nearly triggered a re-campaign | two false alarms | T12, and the reason this file exists |
+| `pgrep -f 'spark serve'` matched the shell that ran it: one control hung in an infinite lane-wait; a `pkill -f` killed its own shell | a control, a session | T8's self-filter |
+
+Assume the same price for anything you wave through.
+
+## What you are given
+
+Demand these verbatim; refuse to rule on a summary. If any are missing, say which and
+return the negative verdict for the phase.
+
+- the **phase**: `pre`, `begin`, `during` or `post`
+- the **lockfile** `.oracle_should_begin_cert` as read by the caller, and the
+  `owner.session_id` the caller believes is its own
+- the PR number, head branch, the anchor sha to be certified, `$ATLAS_HOME`, and the
+  campaign driver's path if one exists
+- the caller's own PID and launcher command line, so T8 can exclude them
+- for `post`: the full text of `spark benchmark --pull-request-gate-check --pr <N>`
+- any **override** being claimed: test ids, reason, who
+
+You may — and should — run every read-only command yourself. **A claim you verified
+outranks a claim you were handed.** You write nothing: not the lockfile, not a temp file,
+not a comment. The skill owns the lockfile; you are its examiner, not its author.
+
+Read `PERF_PATHS` the way `campaign-guard.sh` does, never from memory:
+
+```bash
+paths=$(sed -n '/pub const PERF_PATHS/,/];/p' crates/atlas-plugin/src/gate/coverage.rs \
+        | grep -oE '"[^"]+"' | tr -d '"')
+```
+
+## The tests
+
+Answer every test the phase requires, in writing, each with the evidence that settles it
+and the mechanism that makes it matter. **"Looks fine" is not an answer** — paste the
+command and the line of output that decides it. A test whose command could not answer is
+`unknown`, and **`unknown` blocks exactly as `fail` does**: `campaign-guard.sh` exit 2 is
+the precedent, where "could not answer" is never "safe to continue".
+
+### T0 — Lock ownership (every phase, never overridable)
+Re-read `.oracle_should_begin_cert` yourself. `owner.session_id` must equal the one handed
+to you; `status` must match the phase (`evaluating` for `pre`, `evaluated` for `begin`,
+`running_certification` for `during`/`post`); `campaign.anchor_sha` must equal the sha you
+are ruling on. Any mismatch means another session took the lock or the caller is ruling on
+a sha it did not lock. Name whose session the file records.
+
+### Sha
+**T1 — clean perf tree** (not overridable). `git status --porcelain --untracked-files=all -- $paths`
+prints nothing. `gate/mod.rs::dirty_perf_paths` stamps the dirty list into the record and
+`check.rs` fails it — a campaign from a dirty tree is spent before it starts.
+
+**T2 — HEAD is the frozen sha, pushed, with main MERGED in.** `git rev-parse HEAD` == the
+anchor == `git rev-parse origin/<branch>`; `git merge-base --is-ancestor origin/main HEAD`
+true. If the branch already carries records, every record `git_sha` must still be reachable
+— a rebase orphans ancestry and the gate then says "git cannot diff that commit against
+this one". Overridable only for "not yet pushed, will push this exact sha"; never for a rebase.
+
+**T3 — the binary is built from this sha** (not overridable). No other check can see a stale
+binary. `stat -c %Y target/release/spark` must exceed both `git log -1 --format=%ct HEAD -- $paths`
+and the mtime of `$(git rev-parse --git-path HEAD)`. Say plainly that mtime-newer is
+**necessary, not sufficient** — the binary embeds no sha. The decisive proof is a
+`cargo build --release` that recompiles nothing; demand its `Finished` line.
+
+### Environment
+**T4 — the box can write and sign.** `./target/release/spark doctor` exits 0. It probes
+`$ATLAS_HOME` by writing and asks `git ls-files .github/record-signers/` — **not the
+filesystem** — whether this box's fingerprint is committed; an auto-registered untracked
+`.pub` does not count. Record the resolved `$ATLAS_HOME`: every Speed-class gate must run
+under that one home, because the key is per-home, not per-box. Overridable only for a
+signer whose `.pub` will be committed beside the records.
+
+**T5 — `.benchmarks/` carries nothing from another life.** No `bfcl-subset-[abcd]` or
+`bfcl-subset-echolp-[abcd]` dirs — one flips the gate onto the group path and it then
+demands all four. `git status --porcelain --untracked-files=all -- .benchmarks` empty: an
+untracked record from an aborted run at another sha is a `Disagreement::Commits` waiting to
+happen. Overridable for a deliberate sharded run.
+
+**T6 — subjects resolve and pins are complete.** For each required gate the
+`kernels/<hw>/<model>/BENCH.toml` entry marked `default = true` names a recipe present in
+the local index; any entry with `hermetic = "true"` pins every `gate/hermetic.rs::CLOSED_KEYS`
+pair — `gate::bench` refuses an under-pinned entry at parse time, after the serve has loaded.
+Then `ls $ATLAS_HOME/runs/ttft-{cold,warm}-gate/baseline-*.json`: absent means each TTFT gate
+needs TWO runs. State which case applies. Overridable only for the two-run question.
+
+**T7 — the BFCL scorer imports.** Run exactly what `score.py` performs:
+`$ATLAS_HOME/artifacts/bfcl/venv/bin/python -c "from bfcl_eval.constants.enums import Language; from bfcl_eval.eval_checker.ast_eval.ast_checker import ast_checker"`.
+Importing `bfcl_eval` alone proves nothing — the 1.6 h loss was a lazy transitive import.
+Overridable only if no BFCL gate is planned.
+
+**T8 — the box is free, and the tester is not counting itself.**
+`nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader` empty; `pgrep -x spark`
+empty; `pgrep -af 'release/spark serve|inference-endpoint|cargo|nvcc'` empty **after removing
+the caller's PID, its launcher line, and the pgrep itself** — `pgrep -f` matches its own argv
+and has hung a control here; prefer `-x`. `MemAvailable/MemTotal` at or above
+`bench_selfstart.rs::MIN_FREE_FRACTION`. `git worktree list` shows no other checkout of this
+branch. Overridable only for the memory fraction, with the holder named.
+
+### Timing
+**T9 — the branch has not moved where the gate looks** (not overridable).
+`scripts/campaign-guard.sh <anchor> <branch>` exits 0. Exit 1 = a perf path moved and whatever
+is running measures a dead tree; **exit 2 = could not answer, which is a stop, never a pass.**
+
+**T10 — no other PR is mid-certification.** For every other open PR whose diff touches
+`$paths`: it is mid-certification if it adds `.benchmarks/` records at a sha not on main, its
+bot comment carries `<!-- atlas-certification-state:` with `stage-2`, `stage-3` or `queued`,
+or `isInMergeQueue` is true. Two record-bearing PRs cannot share a queue group. Overridable
+when the owner is serialising by hand — name the other PR.
+
+**T11 — this PR is the top of its stack.** `gh pr list --base <head-branch> --state open`
+empty. A lower layer must not pay for certification. Overridable only when `oracle` ruled
+"one campaign per PERF_PATHS layer" — quote its verdict line.
+
+**T12 — stamp/seal sequencing.** `stamp status` and `seal status` are JOBS inside the `CI`
+run. They read the check-runs API when they execute, **a job's outputs are frozen for the
+life of its run, and a job inside an in-progress run cannot be re-run.** Therefore:
+- `/stamp` or `/seal` may be commented only when the newest `CI` run for the head sha is
+  `completed` (the handler re-runs it), OR it is in flight AND none of `stamp status`,
+  `seal status`, `PR Benchmark Certifications` has `status==completed` yet.
+- **A red `stamp status`/`seal status` is a REAL failure only if the `Stamp`/`Seal` check run
+  on the head sha was created BEFORE that job's `started_at`.** If the mark is newer than the
+  job, the red is stale; the remedy is a FULL `gh run rerun <id>` once the run completes —
+  `--failed` cannot work, because those jobs **succeeded while emitting `false`**.
+- If the bot has not yet posted "Stamp recorded." / "Seal recorded.", the state is `unknown`,
+  not red. Say "not yet processed" and how long ago the comment was posted. **Do not report a
+  failure you cannot date.**
+- `/seal` is voided by the next commit; `/stamp` survives.
+Overridable only in `pre`; never in `post`.
+
+### Agreement
+**T13 — one sha across everything the PR adds** (not overridable).
+`git diff --name-only --diff-filter=AM $(git merge-base origin/main HEAD)...HEAD -- .benchmarks`,
+then `jq -r .git_sha` on each: exactly one distinct value. `Disagreement::Commits` is "always
+fatal, every class". **`--pull-request-gate-check` does NOT ask this** — coverage and
+agreement are different questions, and it will report PASS on a set that CI rejects.
+
+**T14 — one signer per Speed class.** Same set, grouped by `registry::find(id).sensitivity`:
+Speed-class records share ONE fingerprint; Correctness-class may span boxes. Every fingerprint
+must be in `git ls-files .github/record-signers/`. The Speed split is not overridable.
+
+## Phases
+
+| phase | tests | verdicts |
+|---|---|---|
+| `pre` | T0, T1-T12 (+T13/T14 if the diff already adds records) | `CERT-GO` / `CERT-NO-GO` |
+| `begin` | T0, T1, T2, T8, T9 — the cheap re-check between verdict and launch | `CERT-GO` / `CERT-NO-GO` |
+| `during` | T0, T1, T2, T8, T9 | `CERT-CONTINUE` / `CERT-ABORT` |
+| `post` | T0, T1, T2, T9, T12, T13, T14 + the gate-check text (refuse on `NONE`, `FAIL`, `still need`) | `CERT-SEAL` / `CERT-HOLD` |
+
+## Override
+
+For tests marked overridable, with a reason and a name. You still **RUN** the test and record
+its true `observed` result; mark it `overridden` and exclude it from the verdict. State both
+verdicts on separate lines. An override claimed on a non-overridable test is refused and the
+verdict is negative — say which test, and that CI rejects the outcome regardless, so the
+override would only convert a refusal into wasted hours.
+
+## Verdict
+
+End with exactly one line:
+
+```
+CERT-GO
+CERT-NO-GO — T<n> <name>: <the one line of evidence>
+```
+
+(`CERT-CONTINUE`/`CERT-ABORT` for `during`; `CERT-SEAL`/`CERT-HOLD` for `post`.) With an
+override in force the positive line carries it — `CERT-GO (override: T10 — <reason>)` — and
+the line above reads `without override: CERT-NO-GO — T10 …`.
+
+**Anything hedged is the negative verdict.** "Probably idle", "the stamp should be processed
+by now", "the binary is likely current" — each is a test you did not finish. Saying so costs
+minutes; getting it wrong costs the campaign.
+
+## Output the caller reuses
+
+Before the verdict line, emit the JSON the skill writes into the lockfile, in a fenced
+```json block, conforming to the schema in the skill's "The JSON" section: one object per
+test in `tests`, evidence verbatim and trimmed to the deciding lines, `blocking` listing every
+failing or unknown non-overridden test. The skill copies it unchanged — make it valid JSON.
+
+## What you do not rule on
+
+Whether the stack is ordered correctly (`oracle`), whether the group is worth a campaign,
+whether the numbers pass their bars (the gate), whether a green re-run is evidence. If you
+notice one, note it in a single line under the verdict and move on.

--- a/.claude/agents/oracle_chki.md
+++ b/.claude/agents/oracle_chki.md
@@ -1,0 +1,131 @@
+---
+name: oracle_chki
+description: O.R.A.C.L.E::pre_commit_cross_hardware_check — Ownership Reach And Cross-hardware Leakage Examiner. Rules, BEFORE a commit is pushed, on whether a kernel change meant for one hardware (gb10, strix, strix-hip, metal) alters what ANOTHER hardware compiles — through a symlink, a common/ fan-out, a kernel_source redirect, or a shared KERNEL.toml / MODEL.toml / HARDWARE.toml. That is cross-hardware kernel interference, CHKI. Blocking. Use whenever scripts/check_cross_hardware.py reports CHKI or a structural violation, whenever a diff touches kernels/gb10/common/, a __SCALE__ / __HIP / __CUDA_ARCH__ arm, or cfg!(atlas_scale) host dispatch, and before writing a Hardware: or CHKI-Verdict: trailer. It rules on REMEDY — benign, parameterize in HARDWARE.toml, or a separate kernel with no symlink. Ordering is `oracle`'s question; whether the numbers pass is the gate's.
+model: opus
+tools: Bash, Read, Grep, Glob
+---
+
+# O.R.A.C.L.E::pre_commit_cross_hardware_check — Ownership Reach And Cross-hardware Leakage Examiner
+
+You rule on **one** thing: does this change alter what another hardware compiles, and if so,
+which of the three remedies is right?
+
+You exist because the tree shares kernels across hardware by three mechanisms that no path
+prefix reveals — symlinks (strix: 105 into gb10, strix-hip: 86), `common/` fan-out, and
+`[model] kernel_source` redirects — and the only signal that a gb10 edit changed AMD's compile
+has ever been a compile failure. A performance-only effect has never been visible.
+
+| incident | what happened | how it was caught |
+|---|---|---|
+| `d584c0c50` | `__syncwarp()` added to `gb10/common/w4a16_gemv.cu`, symlinked into strix and strix-hip; hipcc rejects it | ONLY because the windows-hip release leg failed. Author: "the convention was already there and I broke it." |
+| `17fe989ec` | a Strix workaround left inside gb10 common device code | invalidated 27 targets' benchmark records; full GPU re-measurement demanded |
+| 109 `__SCALE__` guards in 32 gb10-owned files | AMD branches living inside NVIDIA files — the state this check exists to unwind | never caught; it accreted |
+| `taxon.rs` comment | states the OPPOSITE policy ("kernels are shared, so an AMD port must pass both hardwares' benches in one PR") | being replaced |
+
+A wrong `CHKI-OK` costs a silent regression on a hardware with **no benchmark records, no CI
+box, and a PR compile leg for one model only**. Nobody will measure it.
+
+## What you are given
+
+Demand these verbatim; refuse to rule on a summary. If any are missing, say which and return
+`CHKI-FAIL`.
+
+- `python3 scripts/check_cross_hardware.py --base <base> --worktree --json`, in full — the
+  per-path `reach_hw`, `via` symlink chains, and `structural` findings
+- `git diff <base>...HEAD -- kernels/` — the actual hunks, not a description
+- for every reached shared file: `unifdef -k -D__SCALE__=1` (and `-U__SCALE__`) of the BEFORE
+  and AFTER file, with each reached hardware's `extra_nvcc_flags` `-D`s applied, and the diff
+- the intended hardware and the evidence for it: the `Hardware:` trailer if any, the branch,
+  the measurement in the commit body
+- `grep -rn 'atlas_scale\|atlas_hip' crates/ --include=*.rs` restricted to files in the diff
+- if a de-share is proposed: `git show <base>:<target> | sha256sum` and `sha256sum <new file>`
+
+Run read-only commands yourself. **A claim you verified outranks a claim you were handed.**
+
+## The eight questions
+
+Answer each in writing with the evidence that settles it. "Looks fine" is not an answer — name
+the file, the line, the symlink, the macro, or the sha.
+
+1. **Reach.** For every changed kernel path, which targets on which hardware consume its bytes?
+   Re-derive it: `readlink` the chain, then confirm membership **after stem-shadowing** — a real
+   file with the same stem in the consuming hardware's dir means the gb10 copy is NOT consumed
+   there (`strix-hip/qwen3.6-27b/nvfp4/w4a16_gemm.cu` is the standing example). Include headers:
+   quoted includes resolve against the **symlink's** directory, which is why strix-hip's real
+   `prefill_paged_compute.cuh` shadows gb10's even though the including `.cu` is a symlink.
+
+2. **Intent versus ownership.** Which hardware was this change made FOR, and which owns the
+   bytes? If they differ — a Strix fix written into a gb10 file — say so: that is CHKI in the
+   other direction, and the remedy is never (a).
+
+3. **Arm classification.** For each hunk in each reached shared file: inside which preprocessor
+   arm does it sit — `#if defined(__SCALE__)` / `__HIP*` (AMD-only), its `#else` (NVIDIA-only), a
+   `__CUDA_ARCH__` band, or unguarded (both)? Evidence is the `unifdef` diff per hardware, not a
+   reading of the source. `extra_nvcc_flags` differ per hardware (`-DTQ_PLUS_SIGNS` is gb10-only):
+   apply them.
+
+4. **Host dispatch.** Does any `cfg!(atlas_scale)` / `cfg(atlas_hip)` site pair with a device
+   constant this change moved? The standing pair is `BR64` (gb10 `prefill_paged_compute.cuh` = 64,
+   strix-hip's = 32) with `prefill_attn_main_a.rs`. A pairing broken on one side is interference
+   that touches no `kernels/strix*` path at all.
+
+5. **Config fan-out.** Did a symlinked `KERNEL.toml` (`strix/common/` → gb10) or `MODEL.toml`
+   (`strix-hip/qwen3.6-35b-a3b/` → gb10) carry the change? `[modules]`, `[shadow_exempt]`,
+   `[build] extra_nvcc_flags` and every behaviour key now differ for that hardware. Name the keys.
+
+6. **Performance relevance on the OTHER hardware.** For anything reaching an arm that hardware
+   compiles: does it change register use, shared memory (RDNA3.5 caps LDS at 64 KB/workgroup),
+   unroll factors, tile shapes, or intrinsics? Produce byte-identical compiled output for that
+   hardware, an empty `unifdef` diff for it, or a measurement. **"Unmeasured" is not "benign".**
+
+7. **Remedy.** Choose exactly one:
+   - **benign** — state which proof from Q6 you hold, per hardware.
+   - **parameterize** — name the `kernels/<hw>/HARDWARE.toml` key AND the reader that the SAME
+     change adds in `crates/atlas-kernels/build.rs`. **Only `vendor` and `arch` are read today**;
+     `compute_capability`, `memory_bandwidth_gbps` and `memory_gb` have no reader at all. A key
+     without a reader is decoration, and `kernels/strix/HARDWARE.toml` already forbids it in
+     writing: *"Do not re-add either key without adding a reader in the same change."*
+   - **separate** — name the file that becomes a real file in the intended tree, the file in the
+     other tree pinned at the base revision's bytes (sha256 both sides), and confirm **no symlink
+     is created**.
+
+8. **Cost of being wrong.** For THIS change: is a mistake a compile break (visible — the strix
+   release legs compile `qwen3.6-27b` only) or a performance change (invisible — no strix record
+   exists)? Say which, and whether the evidence in front of you is enough to spend it.
+
+## Verdict
+
+Exactly one line:
+
+```
+CHKI-OK — benign: <proof, per reached hardware>
+CHKI-OK — parameterize: kernels/<hw>/HARDWARE.toml <KEY>, reader crates/atlas-kernels/build.rs
+CHKI-OK — separate: <path> de-shared, <other-hw path> pinned at <base sha> bytes, no symlink
+CHKI-FAIL — <what is missing, or which question has no evidence>
+```
+
+**Anything hedged is `CHKI-FAIL`.** "Probably only NVIDIA sees it", "AMD is not a priority",
+"the guard should cover it" — each means the reach was not checked. Saying so costs a de-share
+or a define; getting it wrong costs a regression nobody will measure.
+
+## Output the caller reuses
+
+The trailer block the commit must carry:
+
+```
+Hardware: gb10, strix, strix-hip
+CHKI-Verdict: benign — unifdef -D__SCALE__ diff empty for strix and strix-hip; gb10 PTX sha256 unchanged
+```
+
+And the reach table, reproduced in the PR description:
+
+```
+| path | owner | reaches | via | remedy |
+```
+
+## What you do not rule on
+
+Whether the change is correct or fast on its OWN hardware; stack order; whether a benchmark
+threshold moves; whether the 192 grandfathered symlinks should be de-shared wholesale; anything
+under `kernels/metal/` unless a symlink into it appears (none exist). Note it in one line under
+your verdict and move on — do not let it change your remedy call.

--- a/.claude/skills/oracle_certification_state_check/SKILL.md
+++ b/.claude/skills/oracle_certification_state_check/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: oracle_certification_state_check
+description: "O.R.A.C.L.E::certification_state_check — BLOCKING pre-flight, in-flight and post-flight oracle for a benchmark certification campaign (~4.5-5 GPU-hours). Invoke BEFORE starting a certification campaign, running the gates, `spark benchmark run … --pull-request-gate`, or `queue-perf-pr.sh`; between and DURING gates; and AFTER the campaign before committing `.benchmarks/` records, commenting `/stamp` or `/seal`, or believing `stamp status` / `seal status` / `PR Benchmark Certifications`. Also invoke when a stamp or seal check looks red, when asking whether the box or GPU is free, whether the tree is frozen, whether a signer is committed, or whether records agree. Fourteen litmus tests — clean PERF_PATHS tree, frozen sha, binary built from it, ATLAS_HOME and signer, stray shard dirs, subjects and hermetic pins, BFCL scorer imports, box free with a self-filtered pgrep, campaign-guard, other PRs mid-certification, top of stack, stamp/seal job sequencing, one git_sha across added records, one Speed-class signer — each tied to the code that enforces it. Hard block with advisory overrides recorded in the gitignored lockfile `.oracle_should_begin_cert`, read on start to detect a concurrent campaign and removed on release. Born from the 2026-08-28 nine-hour campaign invalidated twenty minutes before its end, and from two same-day false reds where a /stamp or /seal status was evaluated before the bot processed the command."
+argument-hint: "<pre | begin | during | post | release | status> [--pr <N>] [--branch <name>] [--session <id>] [--override T<n>[,T<n>] --reason \"…\"] [--abandon]"
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# /oracle_certification_state_check — may this campaign start, continue, or be banked?
+
+A certification campaign is ~4.5-5 GPU-hours and the box can do nothing else while it runs.
+This skill puts a blocking oracle in front of it, beside it, and after it. The oracle is an
+`opus` subagent (`.claude/agents/oracle_cert.md`). **Give it verbatim inputs, never a
+summary**, and treat its one-line verdict as the decision.
+
+Two incidents own this file. On 2026-08-28 a nine-hour, ten-gate campaign was
+content-invalidated by a 23-line push twenty minutes into its final gate, and the loss was
+discovered at the end. And twice on one day in 2026-09 a `/stamp` or `/seal` status was read
+**before** the bot had processed the command; the stale red looked like a failure and was
+reported as one. Everything below either prevents the first or dates the second.
+
+## Reuse, not invention
+
+| question | answered by | not by |
+|---|---|---|
+| did a perf path move? | `scripts/campaign-guard.sh <anchor> <branch>` (0/1/2) | a sha compare |
+| can the box write, sign, find recipes? | `./target/release/spark doctor` | `ls -ld ~/.atlas` |
+| what got recorded? | `spark benchmark --pull-request-gate-check --pr <N>` — read the words | the gate's `rc` |
+| what counts as a perf path? | `sed -n '/pub const PERF_PATHS/,/];/p' crates/atlas-plugin/src/gate/coverage.rs` | a list copied here |
+| is another PR mid-certification? | the bot's `<!-- atlas-certification-state: -->` marker, `isInMergeQueue`, added records | a guess from titles |
+| were the stamp/seal jobs stale? | `gh api …/actions/runs/<id>/jobs` vs the `Stamp`/`Seal` check-run times | the colour of the check |
+
+The one thing this skill adds is the lockfile, because none of the above remembers that a
+campaign is in progress across sessions.
+
+## Phases
+
+```
+pre ──▶ begin ──▶ during (× many) ──▶ post ──▶ release
+ │        │            │                │
+ │        │            │                └─ CERT-SEAL: commit records, /seal
+ │        │            └─ CERT-ABORT: kill the gate, release --abandon
+ │        └─ lockfile: evaluated → running_certification
+ └─ lockfile: (none) → evaluating → evaluated
+```
+
+| verb | when | tests | writes |
+|---|---|---|---|
+| `pre` | before the first gate | T0-T12 (+T13/T14 if records already added) | creates lock `evaluating` → `evaluated` |
+| `begin` | the moment before the driver launches | T0, T1, T2, T8, T9 | `evaluated` → `running_certification`, records `driver_pid` |
+| `during` | between gates, and on a 5-min timer inside long ones | T0, T1, T2, T8, T9 | heartbeat, `current_gate`, `guard_last_rc` |
+| `post` | after the last gate, BEFORE `git add .benchmarks`, BEFORE `/seal` | T0, T1, T2, T9, T12, T13, T14 + gate-check text | the `post` verdict |
+| `release` | after `post` returned `CERT-SEAL` and records are pushed; or `--abandon --reason` | T0 | renames the lock to `.released.<ts>` |
+| `status` | any time | none | nothing — prints the lock and its liveness |
+
+`pre` is the default when no verb is given.
+
+## Step 0 — read the lockfile before anything else
+
+Every verb starts here. The file is `<repo-root>/.oracle_should_begin_cert` (gitignored).
+
+```bash
+root=$(git rev-parse --show-toplevel); lock="$root/.oracle_should_begin_cert"
+[ -f "$lock" ] && jq . "$lock"
+```
+
+Then, in this order:
+
+1. **No file, verb `pre`** → create it (below).
+2. **No file, any other verb** → refuse: "no campaign is locked here; run `pre` first".
+   Never create a lockfile from `begin`/`during`/`post`.
+3. **File exists, LIVE, and not yours** → refuse, printing the owner block verbatim. **No
+   override bypasses a live lock**; wait, or kill the named driver.
+4. **File exists, yours, status matches the verb** → proceed.
+5. **File exists and is STALE** → **do not delete it.** Rename to
+   `.oracle_should_begin_cert.stale.<utc-ts>`, print the reason, and (for `pre` only) create a
+   fresh lock whose `superseded` field records the old path and reason. For any other verb,
+   refuse — a stale lock under `begin`/`during`/`post` means the campaign it described is gone.
+
+### How stale is stale — liveness beats age
+
+A lock whose campaign is demonstrably running is never stale, however old.
+
+| status | stale when |
+|---|---|
+| `evaluating` | `updated_at` older than **20 min** (an evaluation takes 2-5) |
+| `evaluated` | `expires_at` passed (**90 min**), OR `anchor_sha` != `git rev-parse HEAD`, OR `campaign-guard.sh` exits non-zero — a verdict describes one sha on one branch |
+| `running_certification` | **ALL** of: `kill -0 <driver_pid>` fails; `pgrep -x spark` empty; `nvidia-smi --query-compute-apps` empty; heartbeat older than **30 min**. Any one liveness signal positive → LIVE. If LIVE and started >12 h ago, still LIVE — print "runaway?" with the pid and let a human decide. |
+
+## `pre` — create, evaluate, record
+
+**Create atomically.** `ln(2)` fails `EEXIST` for exactly one of two racing sessions:
+
+```bash
+sid=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ); tmp="$lock.$$.tmp"
+jq -n --arg sid "$sid" --arg now "$now" --arg host "$(hostname)" --arg user "$(id -un)" \
+      --arg cwd "$root" --arg br "$BRANCH" --arg sha "$(git rev-parse HEAD)" \
+      --arg home "${ATLAS_HOME:-$HOME/.atlas}" '{
+  schema:"oracle_should_begin_cert/v1", status:"evaluating",
+  created_at:$now, updated_at:$now, expires_at:null,
+  owner:{session_id:$sid, hostname:$host, user:$user, cwd:$cwd},
+  campaign:{pr:null, branch:$br, anchor_sha:$sha, atlas_home:$home, driver_pid:null,
+            driver_cmdline:null, started_at:null, current_gate:null, gates_done:[],
+            heartbeat_at:null, guard_last_rc:null},
+  oracle:null, overrides:[], history:[], superseded:null }' > "$tmp"
+if ln "$tmp" "$lock" 2>/dev/null; then rm -f "$tmp"; echo "locked as $sid"
+else rm -f "$tmp"; echo "LOST THE RACE"; jq . "$lock"; exit 1; fi
+```
+
+Keep `$sid` — every later verb passes `--session $sid`.
+
+**Spawn the oracle** (`Agent`, `subagent_type: oracle_cert`) with, verbatim: the phase; the
+lockfile contents; `$sid`; PR, branch, anchor sha, `$ATLAS_HOME`; your own `$$` and the
+launcher line you will use; the exact override claim if any.
+
+**Record**: re-read the lock, confirm `owner.session_id` is still `$sid` (if not, another
+session superseded you — stop and print both), then write via temp + `mv -f`: `status=evaluated`,
+`expires_at` = now + 90 min, `oracle` = the JSON, append `history`.
+
+On `CERT-NO-GO` the lock **stays** as `evaluated` with the negative verdict, so a second
+session sees that a campaign was attempted and why.
+
+## `begin` — the read-on-start race check
+
+Lock must be yours, `evaluated`, unexpired, verdict GO. Spawn the oracle for phase `begin`
+(seconds). **This is the window between verdict and launch** in which a co-tenant can appear
+or the branch can move — the second half of "read on start". On `CERT-GO`, launch the driver,
+capture its PID, and write `status=running_certification` with `driver_pid`, `driver_cmdline`,
+`started_at`, `heartbeat_at`, `expires_at=null`.
+
+The driver runs this itself between Claude ticks, because a 1.6 h BFCL leg must not wait for
+an agent turn:
+
+```bash
+scripts/campaign-guard.sh "$ANCHOR" "$BRANCH"; rc=$?
+jq --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg g "$g" --argjson rc $rc \
+   '.campaign.heartbeat_at=$now|.updated_at=$now|.campaign.current_gate=$g|.campaign.guard_last_rc=$rc' \
+   "$lock" > "$lock.$$.tmp" && mv -f "$lock.$$.tmp" "$lock"
+[ $rc -eq 0 ] || { pkill -x spark; echo "ABORT: guard rc=$rc"; exit 1; }
+```
+
+`pkill -x`, never `pkill -f` — the latter has killed its own shell here.
+
+## `during` — continue or abort
+
+Lock yours, `running_certification`, LIVE. The oracle re-runs the guard, the clean-tree check,
+the anchor check (someone checking out another sha **in this worktree** is the same loss as a
+push), and the box check. On `CERT-ABORT`: **kill the running gate rather than let it finish**
+— a completed record for a superseded tree is the mistake repeated — then
+`release --abandon --reason "<verdict line>"`.
+
+## `post` — may the records be banked?
+
+Run `spark benchmark --pull-request-gate-check --pr <N>` and hand the oracle the full text.
+Its rule: refuse on `NONE`, `FAIL`, or `still need` — **`rc` is not the evidence**. The oracle
+adds T13 (one `git_sha` across added records — the gate check does not ask this) and T14 (one
+Speed-class signer). On `CERT-SEAL`: commit and push the records, wait for the `CI` run on the
+new head to reach the point T12 allows, **then** comment `/seal`, then `release`.
+
+## Overrides — advisory, recorded, never silent
+
+```
+/oracle_certification_state_check pre --pr 951 --override T10 --reason "owner serialising #946 by hand"
+```
+
+- The oracle still **runs** the overridden test and records its true `observed`.
+- Both verdicts are printed and stored: `verdict` and `verdict_without_override`.
+- Written twice: inside `oracle.override`, and appended to top-level `overrides[]`, never trimmed.
+- `by` is `git config user.email` plus hostname; an empty `--reason` is refused.
+- **Never overridable**: T0, T1, T3, T9, T13, the Speed-signer half of T14, and T12 in `post`.
+  Each is a case where CI rejects the outcome anyway, so the override would only buy wasted hours.
+- Quote any override verbatim in the wave report and the PR evidence comment. **An override
+  nobody can see afterwards is not advisory, it is a bypass.**
+
+## The JSON
+
+Returned to the caller and stored unchanged under `oracle` in the lockfile. ISO-8601 UTC `Z`.
+
+```json
+{
+  "schema": "oracle_certification_state_check/v1",
+  "phase": "pre|begin|during|post",
+  "verdict": "GO|NO-GO|CONTINUE|ABORT|SEAL|HOLD",
+  "verdict_line": "CERT-GO (override: T10 — owner serialising #946 by hand)",
+  "verdict_without_override": "NO-GO",
+  "evaluated_at": "2026-09-11T14:02:11Z",
+  "evaluation_ms": 41830,
+  "subject": {
+    "repo_root": "…", "pr": 951, "branch": "…", "head_sha": "…",
+    "origin_branch_sha": "…", "origin_main_sha": "…", "merge_base": "…",
+    "atlas_home": "…", "signer_fingerprint": "…", "signer_committed": true,
+    "hostname": "dgx2", "caller_pid": 412233, "caller_launcher": "…"
+  },
+  "tests": [{
+    "id": "T1", "name": "clean-perf-tree",
+    "group": "lock|sha|tree|agreement|timing|environment",
+    "result": "pass|fail|unknown|skipped|overridden",
+    "observed": "pass|fail|unknown|skipped",
+    "overridable": false, "overridden": false,
+    "command": "git status --porcelain --untracked-files=all -- …",
+    "evidence": "", "mechanism": "gate/mod.rs::dirty_perf_paths → check.rs fails a dirty-tree record",
+    "remedy": "commit or stash, rebuild, re-run pre",
+    "checked_at": "2026-09-11T14:01:40Z"
+  }],
+  "blocking": ["T10"],
+  "override": { "tests": ["T10"], "reason": "…", "by": "…@dgx2", "at": "…Z", "invocation": "…" },
+  "notes": ["TTFT baselines present for both gates; single runs suffice"],
+  "next": "run: /oracle_certification_state_check begin --session 6f1c… --pr 951"
+}
+```
+
+`result` is `overridden` iff `overridden`, and then `observed` holds the real outcome.
+`blocking` is every test whose `result` is `fail` or `unknown`. `override` is `null` when none
+was claimed.
+
+## What the lockfile can and cannot promise
+
+It is a file, not a mutex. Exactly:
+
+- **Creation is atomic** on a local filesystem (`ln` → `EEXIST`), so two `pre` invocations in
+  one checkout cannot both own a lock.
+- **Every rewrite re-checks ownership**, and `begin` re-runs the cheap tests, so the window
+  between verdict and launch is covered on both ends. What remains is the interval between
+  `begin` writing `running_certification` and the driver's first `spark serve` appearing on the
+  GPU (model load, minutes) — another checkout's `pre` in that window sees a free GPU.
+- **The lock is per checkout, not per box.** A second worktree has its own root and its own
+  lockfile. The box-level guard is T8 (GPU, `pgrep -x spark`, memory), which is real but polls.
+- **It does not stop a human** running `spark benchmark run` by hand, nor a push from another
+  machine — that is `campaign-guard.sh`'s job, and why `during` is on a timer.
+- **GitHub state lags.** T10 reads the marker and queue flag as of now.
+- **Session identity is a uuid you carry**, not a pid: each Bash call is a new shell. The
+  driver's pid is the only long-lived one, and it is the liveness signal.
+
+What the skill does about the residual TOCTOU: both sides re-read (`begin`, and the oracle's
+T0), evidence is kept rather than deleted (`.stale.*`, `.released.*`), "could not tell" is
+treated as "not safe", and the expensive guard runs on a timer inside the driver where no agent
+turn is needed.
+
+## Where this sits
+
+- `oracle` rules on stack ORDER before registration; this rules on STATE before the GPU is
+  spent. Different questions, both blocking.
+- `/measurement-discipline` governs the numbers a record carries; this governs whether the
+  record may exist.

--- a/.claude/skills/oracle_pre_commit_cross_hardware_check/SKILL.md
+++ b/.claude/skills/oracle_pre_commit_cross_hardware_check/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: oracle_pre_commit_cross_hardware_check
+description: "O.R.A.C.L.E::pre_commit_cross_hardware_check — run BEFORE pushing any commit that touches kernels/ (especially kernels/gb10/common/), a __SCALE__ / __HIP / __CUDA_ARCH__ arm, cfg!(atlas_scale) or cfg(atlas_hip) host dispatch, a KERNEL.toml / MODEL.toml / HARDWARE.toml, or a symlink under kernels/. Detects cross-hardware kernel interference (CHKI): a change meant for one hardware (gb10, strix, strix-hip, metal) that alters what another hardware compiles through symlinks, common/ fan-out, or kernel_source redirects — strix is 7 real files and 105 symlinks into gb10, so a gb10 edit silently changes what AMD builds. Runs the static reach check, gathers verbatim evidence, launches the oracle for the remedy verdict (benign / parameterize in HARDWARE.toml with a reader / separate kernel with no symlink), and writes the Hardware: and CHKI-Verdict: trailers the CI job cross-hardware-reach requires. Also use when that CI job is red, when a strix or strix-hip compile leg fails on a gb10 edit, or when tempted to add a __SCALE__ guard to a gb10 file. Born from d584c0c50 (a gb10 edit broke hipcc, caught only by a compile leg) and 17fe989ec (a Strix workaround in gb10 common code invalidated 27 targets' records)."
+argument-hint: "[<base-ref>=origin/main] [--staged | --range A..B | --paths p1 p2 ...]"
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# /oracle_pre_commit_cross_hardware_check — CHKI before push
+
+One question, answered before `git push`: **did this change alter another hardware's compiled
+inputs, and what is the remedy?** The static half is provable and runs in seconds; the
+judgement half goes to the `opus` agent `.claude/agents/oracle_chki.md`. The CI job
+`cross-hardware-reach` runs the same script and will fail the PR on anything this procedure
+would have caught — so run it here first.
+
+Why it exists, in two lines: `d584c0c50` (a gb10 edit broke hipcc, caught **only** because a
+compile leg failed) and `17fe989ec` (a Strix workaround in gb10 common code invalidated 27
+benchmark records). A performance-only leak has never been visible at all.
+
+## Step 1 — the static check (seconds, no GPU, no cargo)
+
+```bash
+python3 scripts/check_cross_hardware.py --base "${1:-origin/main}" --worktree
+```
+
+Modes: `--staged`, `--range A..B`, `--paths ...` (attribution only, never fails).
+
+Read the table. Every row saying `CHKI` or `DECLARED`, and every `structural:` finding, is an
+input to Step 3. **If the verdict is `OK` and no row is `DECLARED`, you are done — do not
+invent work.**
+
+`S1` (new cross-hardware symlink) and `S4` (dangling symlink) cannot be declared away. Replace
+the symlink with a real file, or restore the target, then re-run.
+
+Exit codes: `0` clean · `1` violation · `2` **cannot see the inputs**, which is as red as `1`
+— the same doctrine as `campaign-guard.sh`'s exit 2.
+
+## Step 2 — gather the verbatim inputs
+
+The oracle refuses summaries. Collect all of it:
+
+```bash
+python3 scripts/check_cross_hardware.py --base "$BASE" --worktree --json
+git diff "$BASE"...HEAD -- kernels/
+git log --format=%B "$BASE"..HEAD | grep -E '^(Hardware|CHKI-Verdict):' || true
+git diff --name-only "$BASE"...HEAD -- crates/ | xargs -r grep -ln 'atlas_scale\|atlas_hip' || true
+```
+
+For every file whose `reach_hw` has more than one entry, per reached AMD hardware:
+
+```bash
+git show "$BASE:$F" > /tmp/before.cu
+unifdef -k -D__SCALE__=1 /tmp/before.cu > /tmp/b.amd; unifdef -k -D__SCALE__=1 "$F" > /tmp/a.amd
+diff -u /tmp/b.amd /tmp/a.amd | wc -l      # 0 = the text AMD sees is unchanged
+unifdef -k -U__SCALE__  /tmp/before.cu > /tmp/b.nv;  unifdef -k -U__SCALE__  "$F" > /tmp/a.nv
+diff -u /tmp/b.nv /tmp/a.nv | wc -l        # 0 = the text NVIDIA sees is unchanged
+```
+
+If `unifdef` is absent, say so in the prompt — the oracle will classify arms by hand and hold
+you to a stricter proof. If `nvcc` is present, add a PTX sha256 before/after for the gb10 side.
+
+## Step 3 — launch the oracle
+
+Launch `oracle_chki` with everything from Step 2 pasted verbatim, plus one sentence naming the
+intended hardware and the evidence for it. Wait for exactly one verdict line. **Anything hedged
+is `CHKI-FAIL`.** On `CHKI-FAIL`, fix what it names and return to Step 1 — do not re-prompt for
+a softer answer.
+
+## Step 4 — apply the remedy
+
+**benign** — nothing changes in `kernels/`. Go to Step 5.
+
+**parameterize** — in the SAME commit: add the key to `kernels/<hw>/HARDWARE.toml`; add the
+reader in `crates/atlas-kernels/build.rs` beside the `arch`/`vendor` reads; replace the
+`__SCALE__` branch with `#if KEY == VALUE`. ★ Only `vendor` and `arch` are read today — a key
+with no reader is decoration, and `kernels/strix/HARDWARE.toml` says so in writing.
+
+**separate** — never a symlink: the intended hardware gets the changed kernel as a REAL file;
+every other hardware whose symlink pointed at it gets a real copy of the BASE bytes, proven by
+`sha256sum` on both sides. Then run `python3 scripts/check_kernel_shadows.py` — RULE 1 still
+applies within the hardware you just wrote into.
+
+## Step 5 — trailers, then re-run
+
+```
+Hardware: <every hardware in the reach table, comma-separated>
+CHKI-Verdict: <benign|parameterized|de-shared> — <the oracle's proof line>
+```
+
+Then `python3 scripts/check_cross_hardware.py --base "$BASE" --worktree` must print
+`verdict: OK`. Paste the reach table into the PR description; if the PR will be squash-merged,
+copy both trailers into the PR body too.
+
+## Do not
+
+- **Do not add a `__SCALE__` / `__HIP*` guard to a gb10-owned file as the remedy.** That is the
+  state this check exists to unwind; it passes only as `DECLARED`, and the oracle will send it
+  to (b) or (c).
+- **Do not create a symlink under `kernels/` that resolves into another hardware's tree.** S1
+  fails it with no override.
+- **Do not write `Hardware:` from memory.** Copy the reach column; R1 fails on any hardware you
+  omit, including the one that owns the bytes.
+- **Do not call a change benign for strix because "nobody can measure strix".** Unmeasured is
+  `CHKI-FAIL`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,66 @@ jobs:
       # violation. Stdlib-only; the runner's system python3 suffices.
       - run: python3 scripts/check_kernel_shadows.py
 
+  cross-hardware-reach:
+    name: cross-hardware kernel reach (CHKI)
+    runs-on: >-
+      ${{ vars.USE_AVAROK_UBUNTU_RUNNERS == '1'
+          && (github.event_name != 'pull_request'
+           || github.event.pull_request.head.repo.full_name == github.repository)
+          && (vars.PR_CHEAP_RUNNER || 'ubuntu-latest')
+          || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history: the check reads file bytes at HEAD (symlink
+          # resolution, lexical include walk) and needs the base to diff.
+          fetch-depth: 0
+      # Which hardware compiles the bytes this diff changed? `taxon::hardware_of`
+      # is a path prefix and cannot see that kernels/strix/common/*.cu are 105
+      # symlinks into kernels/gb10/common/, so a gb10 edit reads as gb10-only
+      # while hipcc compiles it verbatim. d584c0c50 was caught ONLY because a
+      # release compile leg failed; a performance-only leak has no leg at all.
+      #
+      # FAIL-CLOSED, unlike classify-diff.sh: that script decides what to SKIP
+      # and must fail open; this decides a VERDICT. rc 2 (cannot see inputs) is
+      # as red as rc 1, the same doctrine as campaign-guard.sh's exit 2. The
+      # script runs RED/GREEN self-fixtures first and refuses to scan if any
+      # rule cannot fire.
+      #
+      # Passing honestly costs one trailer pair, written after running
+      # /oracle_pre_commit_cross_hardware_check. Stdlib python3, no GPU, no cargo.
+      - name: Cross-hardware reach of changed kernel paths
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          # Through the environment, never interpolated into the script text:
+          # the body is attacker-controlled on a fork PR and is read only for a
+          # `Hardware:` / `CHKI-Verdict:` trailer.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              git fetch --no-tags origin "${PR_BASE_REF}"
+              python3 scripts/check_cross_hardware.py --base "origin/${PR_BASE_REF}" \
+                      --head "${PR_HEAD_SHA}" --merge-base ;;
+            merge_group)
+              python3 scripts/check_cross_hardware.py --base "${MG_BASE_SHA}" --head "${MG_HEAD_SHA}" ;;
+            push)
+              base="${PUSH_BEFORE}"
+              case "$base" in 0000000000000000000000000000000000000000|"") base="${GITHUB_SHA}~1" ;; esac
+              python3 scripts/check_cross_hardware.py --base "$base" --head "${GITHUB_SHA}" ;;
+            *)
+              # No diff to attribute; the self-fixtures and the consumer index
+              # still run, so a tree that cannot be indexed fails here too.
+              python3 scripts/check_cross_hardware.py --paths ;;
+          esac
+
   bench-threshold-prose:
     name: BENCH.toml threshold prose
     runs-on: ubuntu-latest
@@ -749,11 +809,12 @@ jobs:
           needs.license-headers.result == 'success' &&
           needs.typos.result == 'success' &&
           needs.kernel-structure.result == 'success' &&
+          needs.cross-hardware-reach.result == 'success' &&
           (needs.clippy.result == 'success' || needs.clippy.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.test-macos-metal.result == 'success' || needs.test-macos-metal.result == 'skipped') &&
           needs.stamp.outputs.stamped != 'false' }}
-    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
+    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, cross-hardware-reach, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
       version: 0.0.0-pr${{ github.event.number || 'queue' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,28 @@ jobs:
       - run: python3 scripts/check_kernel_shadows.py
 
   cross-hardware-reach:
-    name: cross-hardware kernel reach (CHKI)
+    # ADVISORY, by maintainer decision 2026-09-11 (tbraun96): "make it an
+    # advisory since AMD is second tier support".
+    #
+    # What that trades away, stated plainly so a later reader does not have to
+    # rediscover it: the reach this check reports is real. `taxon::hardware_of`
+    # is a path prefix, so a `kernels/gb10/common/*.cu` edit reads as gb10-only
+    # while hipcc compiles the same bytes through 105 symlinks. d584c0c50 was
+    # caught ONLY because a release compile leg failed, and a
+    # performance-only leak on AMD has no leg at all. Advisory means that class
+    # of defect can now land; it is accepted because strix/strix-hip are
+    # second-tier targets with no serving receipt, not because the risk is
+    # imaginary.
+    #
+    # The signal stays visible and stays honest: the job still runs on every
+    # PR, still fails closed on rc 2, and still prints the full reach table and
+    # remedies. Nothing `needs:` it, so a red blocks no merge.
+    #
+    # To make it enforcing again, delete `continue-on-error`, drop "advisory"
+    # from the name, and restore the two `release-matrix` references removed in
+    # this commit. Do that when AMD gets a compile leg on PRs.
+    name: cross-hardware kernel reach (CHKI, advisory)
+    continue-on-error: true
     runs-on: >-
       ${{ vars.USE_AVAROK_UBUNTU_RUNNERS == '1'
           && (github.event_name != 'pull_request'
@@ -809,12 +830,11 @@ jobs:
           needs.license-headers.result == 'success' &&
           needs.typos.result == 'success' &&
           needs.kernel-structure.result == 'success' &&
-          needs.cross-hardware-reach.result == 'success' &&
           (needs.clippy.result == 'success' || needs.clippy.result == 'skipped') &&
           (needs.test.result == 'success' || needs.test.result == 'skipped') &&
           (needs.test-macos-metal.result == 'success' || needs.test-macos-metal.result == 'skipped') &&
           needs.stamp.outputs.stamped != 'false' }}
-    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, cross-hardware-reach, test, test-macos-metal]
+    needs: [changes, stamp, fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
       version: 0.0.0-pr${{ github.event.number || 'queue' }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ docker/gb10/spark-fastbin
 # scratch; everything else under .claude/ stays ignored.
 .claude/*
 !.claude/skills/
+# `.claude/agents/` likewise: an agent file is a blocking review contract
+# (.claude/agents/oracle*.md), and a gate nobody can read is not a gate.
+!.claude/agents/
 .gemini/
 .agent*/
 .codex/
@@ -156,3 +159,7 @@ bench/ngram_ref/ngram_golden.npz
 *.swp
 bench/qwen4_exp/qwen4exp_forward_golden.npz
 .ncclstub
+
+# The certification-state oracle's per-checkout campaign lockfile, and its
+# .stale./.released. rotations. An interlock, never meant to travel.
+/.oracle_should_begin_cert*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,47 @@ bash scripts/check-license-headers.sh
 
 # 4. Typos
 typos  # crate-ci/typos — install once, `cargo install typos-cli`
+
+# 5. Cross-hardware kernel reach — ONLY if the diff touches kernels/.
+#    kernels/<hw>/ looks like one tree per hardware and is not: strix is 7 real
+#    files and 105 symlinks into kernels/gb10/common/. A gb10 edit therefore
+#    changes what AMD compiles, and the CI job `cross-hardware kernel reach
+#    (CHKI)` will say so.
+python3 scripts/check_cross_hardware.py --base origin/main --worktree
 ```
 
 A real build + test cycle requires a CUDA-capable host; see
 [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### If the diff touches a perf path
+
+`crates`, `kernels`, `Cargo.*`, `vendor`, `jinja-templates`, `rust-toolchain.toml`,
+`3rdparty_patches` — the gate's `PERF_PATHS` — mean the PR owes a benchmark certification
+campaign of **~4.5–5 GPU-hours**, and campaigns have been wasted. Before spending one, and
+again before reading `stamp status` / `seal status`, committing `.benchmarks/` records, or
+commenting `/stamp` or `/seal`:
+
+```
+/oracle_certification_state_check pre --pr <N>     # then: begin → during → post → release
+```
+
+It is a blocking oracle (`.claude/agents/oracle_cert.md`) running fourteen litmus tests —
+clean perf tree, frozen sha, binary built from it, `spark doctor`, stray shard dirs, hermetic
+pins, BFCL scorer imports, box free, `campaign-guard.sh`, other PRs mid-certification, top of
+stack, stamp/seal job sequencing, one `git_sha` across added records, one Speed-class signer —
+and holding the gitignored lockfile `.oracle_should_begin_cert` for the life of the campaign.
+Overrides exist for what it cannot see and are recorded in the lockfile; quote them in the PR.
+
+★ **A red `stamp status` or `seal status` is not a failure until it is dated.** Those jobs
+freeze their outputs for the life of a CI run, so a mark minted *after* they ran leaves them
+red until a FULL `gh run rerun <id>` — `--failed` cannot work, because they *succeeded* while
+emitting `false`. The oracle's T12 does the dating; do not do it by eye.
+
+For a `kernels/` change that reaches a second hardware, run
+`/oracle_pre_commit_cross_hardware_check` before pushing: it chooses the remedy (benign,
+parameterize in `kernels/<hw>/HARDWARE.toml` **with a reader added in the same change**, or a
+separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers CI
+requires.
 
 ## Adding a new model
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ typos  # crate-ci/typos — install once, `cargo install typos-cli`
 #    kernels/<hw>/ looks like one tree per hardware and is not: strix is 7 real
 #    files and 105 symlinks into kernels/gb10/common/. A gb10 edit therefore
 #    changes what AMD compiles, and the CI job `cross-hardware kernel reach
-#    (CHKI)` will say so.
+#    (CHKI, advisory)` will say so. ADVISORY since 2026-09-11 — AMD is
+#    second-tier support, so a red does not block a merge. It is still the only
+#    thing that sees this class of reach: read it, do not skip it.
 python3 scripts/check_cross_hardware.py --base origin/main --worktree
 ```
 
@@ -98,8 +100,13 @@ emitting `false`. The oracle's T12 does the dating; do not do it by eye.
 For a `kernels/` change that reaches a second hardware, run
 `/oracle_pre_commit_cross_hardware_check` before pushing: it chooses the remedy (benign,
 parameterize in `kernels/<hw>/HARDWARE.toml` **with a reader added in the same change**, or a
-separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers CI
-requires.
+separate kernel with **no symlink**) and writes the `Hardware:` and `CHKI-Verdict:` trailers.
+
+The CI job is **advisory** (AMD second-tier), so those trailers are no longer enforced at merge
+— which makes running the oracle a judgement you make rather than one CI makes for you. The
+reach it reports is real either way: a `kernels/gb10/common/` edit is compiled verbatim by
+hipcc through 105 symlinks, and `d584c0c50` was caught only because a release compile leg
+happened to fail.
 
 ## Adding a new model
 

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -303,3 +303,9 @@ required-features = ["cuda", "gpu-examples"]
 [[example]]
 name = "native_fp8_decode_proj_w8a8_microtest"
 required-features = ["cuda", "gpu-examples"]
+
+[[example]]
+# The PREFILL sibling: the SSM out_proj and cache-skip Q/K/V shapes that round 9
+# left on W8A16 (#917/#928). Selector clauses are CPU-tested next to each site.
+name = "native_fp8_prefill_proj_w8a8_microtest"
+required-features = ["cuda", "gpu-examples"]

--- a/crates/spark-model/examples/native_fp8_prefill_proj_w8a8_microtest.rs
+++ b/crates/spark-model/examples/native_fp8_prefill_proj_w8a8_microtest.rs
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! The PREFILL projections that round 9 left on W8A16, at Qwen3.8-27B shapes:
+//! the shipped `w8a16_gemm_pipelined` / `w8a16_gemm_t_m128` kernels against the
+//! W8A8 block-scaled cuBLASLt arm this change adds (#917/#928).
+//!
+//! WHY. nsys on 1xH100, 2026-09-11 round 9, `Qwen/Qwen3.8-27B-FP8`, recipe
+//! `ATLAS_CUBLAS_GEMM=ffn,ssm,attn` (`nsys-r9-prefill`). A 1193-token prefill
+//! is **368.263 ms** of GPU-busy union. `w8a16_gemm_pipelined` is **100.582 ms
+//! = 27.31%** over **112 launches** and `w8a16_gemm_t_m128` a further
+//! **12.012 ms** over 32. The kernels' launchers make the grid a shape decoder
+//! (`(ceil(N/32), ceil(M/128))` and `(ceil(N/128), ceil(M/128))`), and the
+//! 1193-token prompt is served as two chunks, 1168 + 25:
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 48 | 160x10 | N=5120 K=6144 M=1168 | SSM `out_proj`, chunk 0 | 54 119.7 |
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | attn `q_proj`, chunk 0 | 32 466.8 |
+//! | 48 | 160x1 | N=5120 K=6144 M=25 | SSM `out_proj`, chunk 1 | 13 995.4 |
+//! | 32 | 8x10 | N=1024 K=5120 M=1168 | attn `k_proj`+`v_proj`, chunk 0 | 12 012.2 |
+//!
+//! Those are the four shapes below. (The dense FFN is NOT among them: the same
+//! trace has gate/up/down on `nvjet…` cuBLASLt lines at every M.)
+//!
+//! It answers three questions per projection and guesses none:
+//!
+//!   1. NUMBERS. W8A8 quantizes the ACTIVATION to E4M3 per 128-wide K group,
+//!      which the W8A16 kernels do not, so the two are NOT bit-identical and no
+//!      bit gate would be honest. The gate is cosine >= 0.999 and relative RMS
+//!      <= 3e-2 against the W8A16 reference, plus: nothing outside the route's
+//!      extent (sentinel), nothing non-finite.
+//!
+//!      ⚠ THE FLOOR, so a marginal `rel_rms` is read correctly: E4M3 carries
+//!      3 stored mantissa bits, so round-to-nearest costs ~2.5% RMS relative
+//!      error per element and that error does NOT average down over a dot
+//!      product of independent terms. The EXPECTED `rel_rms` is ~2-2.6e-2 —
+//!      3e-2 is one notch of headroom over the floor, not a loose tolerance,
+//!      and cosine is the robust metric. Same floor the FFN and decode-proj
+//!      microtests state. `ATLAS_W8A8_REL_RMS_GATE` overrides it.
+//!
+//!   2. THE PHANTOM ROWS. cuBLASLt is handed `ceil16(M)` and WRITES rows
+//!      `M..ceil16(M)`. At M=1193 that is 1200, i.e. 7 rows past the real
+//!      output — the extent every capacity clause in
+//!      `qwen3_ssm/prefill_out_w8a8.rs` and
+//!      `qwen3_attention/prefill_qkv_w8a8.rs` is written against. This pins
+//!      that they land THERE and nowhere else: finite, inside the padded
+//!      extent, sentinel intact beyond it.
+//!
+//!   3. TIME. Per projection, sync'd over `REPS`: µs per launch and the
+//!      TFLOP/s it implies, for both routes.
+//!
+//! Run (H100): `cargo run --release -p spark-model --features cuda,gpu-examples
+//! --example native_fp8_prefill_proj_w8a8_microtest`. The example calls
+//! cuBLASLt directly, so `ATLAS_CUBLAS_GEMM` is not required here — the serve
+//! spelling is printed at the end for copy-paste.
+
+use anyhow::{Result, ensure};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_model::weight_map::{Fp8Weight, WeightQuantFormat};
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+use std::time::Instant;
+
+const H: usize = 5120; // hidden
+const VALUE_DIM: usize = 6144; // GDN out_proj contract width
+const Q_PROJ_DIM: usize = 12288; // gated [Q|gate]
+const KV_DIM: usize = 1024;
+/// Chunk 0 of the round-9 trace prompt is 1168; 1193 is the whole prompt and is
+/// deliberately NOT a multiple of 16, so the phantom rows are exercised.
+const ROWS: [usize; 2] = [64, 1193];
+const REPS: usize = 10;
+const GUARD: usize = 64;
+const SENTINEL: u8 = 0x5a;
+const COSINE_GATE: f64 = 0.999;
+const REL_RMS_GATE: f64 = 3e-2;
+
+/// Which W8A16 kernel a projection falls back to in the serve — the reference
+/// this compares and times against.
+#[derive(Clone, Copy, PartialEq)]
+enum Ref {
+    /// `w8a16_gemm_pipelined` over the row-major `[N, K]` weight.
+    Pipelined,
+    /// `w8a16_gemm_n128_m128` over the transposed `[K, N]` twin.
+    TransposedM128,
+}
+
+struct Proj {
+    name: &'static str,
+    n: usize,
+    k: usize,
+    reference: Ref,
+    weight: DevicePtr,
+    scale: DevicePtr,
+    weight_t: DevicePtr,
+    scale_t: DevicePtr,
+    act: DevicePtr,
+}
+
+impl Proj {
+    fn flops(&self, m: usize) -> f64 {
+        2.0 * m as f64 * self.n as f64 * self.k as f64
+    }
+    fn fp8w(&self) -> Fp8Weight {
+        Fp8Weight {
+            weight: self.weight,
+            row_scale: self.scale,
+            n: self.n as u32,
+            k: self.k as u32,
+            scale_format: WeightQuantFormat::Fp8BlockScaled,
+        }
+    }
+}
+
+struct Kernels {
+    pipelined: KernelHandle,
+    t_m128: KernelHandle,
+    quant: KernelHandle,
+    kmajor: KernelHandle,
+}
+
+struct Scratch {
+    act_fp8: DevicePtr,
+    act_scale: DevicePtr,
+    act_scale_kmajor: DevicePtr,
+}
+
+fn upload(gpu: &dyn GpuBackend, bytes: &[u8]) -> Result<DevicePtr> {
+    let ptr = gpu.alloc(bytes.len())?;
+    gpu.copy_h2d(bytes, ptr)?;
+    Ok(ptr)
+}
+
+fn values(bytes: &[u8]) -> Vec<f64> {
+    bytes
+        .chunks_exact(2)
+        .map(|x| bf16::from_bits(u16::from_le_bytes([x[0], x[1]])).to_f32() as f64)
+        .collect()
+}
+
+fn metrics(observed: &[u8], baseline: &[u8], live: usize) -> (f64, f64) {
+    let a = values(&observed[GUARD..GUARD + live]);
+    let b = values(&baseline[GUARD..GUARD + live]);
+    let (mut dot, mut na, mut nb, mut se, mut ss) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+        se += (x - y) * (x - y);
+        ss += y * y;
+    }
+    let cosine = if na > 0.0 && nb > 0.0 {
+        dot / (na.sqrt() * nb.sqrt())
+    } else {
+        0.0
+    };
+    let rel_rms = if ss > 0.0 { (se / ss).sqrt() } else { 0.0 };
+    (cosine, rel_rms)
+}
+
+/// `live` bytes are what the routes are COMPARED on (rows 0..M); `written`
+/// bytes are everything the W8A8 route may TOUCH (rows 0..ceil16(M)). Beyond
+/// `written` the sentinel must survive.
+fn check(
+    observed: &[u8],
+    baseline: &[u8],
+    sentinel: &[u8],
+    live: usize,
+    written: usize,
+    gate: f64,
+) -> Result<()> {
+    ensure!(
+        observed.len() == sentinel.len() && baseline.len() == sentinel.len(),
+        "output extent mismatch"
+    );
+    for i in 0..sentinel.len() {
+        if !(GUARD..GUARD + written).contains(&i) {
+            ensure!(
+                observed[i] == sentinel[i],
+                "route wrote outside its extent at byte {i}"
+            );
+        }
+    }
+    ensure!(
+        values(&observed[GUARD..GUARD + written])
+            .iter()
+            .all(|x| x.is_finite()),
+        "nonfinite projection output (phantom rows included)"
+    );
+    let (cosine, rel_rms) = metrics(observed, baseline, live);
+    ensure!(cosine >= COSINE_GATE, "cosine {cosine:.6} < {COSINE_GATE}");
+    ensure!(rel_rms <= gate, "rel_rms {rel_rms:.4e} > {gate:.1e}");
+    Ok(())
+}
+
+/// The shipped W8A16 arm for this projection — BF16 activations straight in.
+fn run_w8a16(gpu: &dyn GpuBackend, k: &Kernels, p: &Proj, out: DevicePtr, m: usize) -> Result<()> {
+    match p.reference {
+        Ref::Pipelined => ops::w8a16_gemm_pipelined(
+            gpu,
+            k.pipelined,
+            p.act,
+            p.weight,
+            p.scale,
+            out,
+            m as u32,
+            p.n as u32,
+            p.k as u32,
+            0,
+        ),
+        Ref::TransposedM128 => ops::w8a16_gemm_n128_m128(
+            gpu, k.t_m128, p.act, p.weight_t, p.scale_t, out, m as u32, p.n as u32, p.k as u32, 0,
+        ),
+    }
+}
+
+/// The arm under test, exactly as the two new prefill sites compose it:
+/// `per_token_group_quant_fp8` once, then `cublas_fp8_proj_prequant`.
+fn run_w8a8(
+    gpu: &dyn GpuBackend,
+    k: &Kernels,
+    s: &Scratch,
+    p: &Proj,
+    out: DevicePtr,
+    m: usize,
+) -> Result<()> {
+    ops::per_token_group_quant_fp8(
+        gpu,
+        k.quant,
+        p.act,
+        s.act_fp8,
+        s.act_scale,
+        m as u32,
+        p.k as u32,
+        0,
+    )?;
+    ops::cublas_fp8_proj_prequant(
+        gpu,
+        k.kmajor,
+        s.act_fp8,
+        s.act_scale,
+        s.act_scale_kmajor,
+        &p.fp8w(),
+        out,
+        m as u32,
+        p.n as u32,
+        p.k as u32,
+        0,
+    )
+}
+
+/// `[N, K]` FP8 -> `[K, N]`, and `[N/128, K/128]` FP32 -> `[K/128, N/128]`.
+/// The serve builds these once at load (`prefill_weights.rs`); here they exist
+/// so the `k_proj`/`v_proj` timing is against the kernel the serve really runs.
+fn transpose(weight: &[u8], scale: &[u8], n: usize, k: usize) -> (Vec<u8>, Vec<u8>) {
+    let mut wt = vec![0u8; n * k];
+    for row in 0..n {
+        for col in 0..k {
+            wt[col * n + row] = weight[row * k + col];
+        }
+    }
+    let (sn, sk) = (n / 128, k / 128);
+    let mut st = vec![0u8; sn * sk * 4];
+    for row in 0..sn {
+        for col in 0..sk {
+            let src = (row * sk + col) * 4;
+            let dst = (col * sn + row) * 4;
+            st[dst..dst + 4].copy_from_slice(&scale[src..src + 4]);
+        }
+    }
+    (wt, st)
+}
+
+struct Rng(u64);
+impl Rng {
+    fn bits(&mut self) -> u32 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (self.0 >> 32) as u32
+    }
+    /// FP8 E4M3 bytes, sign kept, exponents clipped off the NaN encodings.
+    fn fp8(&mut self, n: usize, depth: usize) -> Vec<u8> {
+        (0..n * depth)
+            .map(|_| {
+                let x = self.bits();
+                ((x % 127) as u8) | (((x >> 7) & 1) as u8 * 128)
+            })
+            .collect()
+    }
+    /// One FP32 scale per 128x128 weight block.
+    fn scales(&mut self, n: usize, depth: usize) -> Vec<u8> {
+        (0..(n / 128) * (depth / 128))
+            .flat_map(|_| (((self.bits() % 16 + 1) as f32) / 1024.0).to_le_bytes())
+            .collect()
+    }
+    fn acts(&mut self, elems: usize) -> Vec<u8> {
+        (0..elems)
+            .flat_map(|_| {
+                bf16::from_f32(((self.bits() % 2049) as f32 - 1024.0) / 1024.0)
+                    .to_bits()
+                    .to_le_bytes()
+            })
+            .collect()
+    }
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let k = Kernels {
+        pipelined: gpu.kernel("w8a16_gemm_pipelined", "w8a16_gemm_pipelined")?,
+        t_m128: gpu.kernel("w8a16_gemm_t_m128", "w8a16_gemm_t_m128")?,
+        quant: gpu.kernel("per_token_group_quant_fp8", "per_token_group_quant_fp8")?,
+        kmajor: gpu.kernel("fp8_scale_transpose", "fp8_act_scale_to_kmajor")?,
+    };
+    let gate: f64 = std::env::var("ATLAS_W8A8_REL_RMS_GATE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(REL_RMS_GATE);
+    let max_m = ops::cublas_fp8_m_pad(*ROWS.iter().max().unwrap() as u32) as usize;
+    println!(
+        "gates: cosine >= {COSINE_GATE}, rel_rms <= {gate:.1e} \
+         (E4M3 activation-quant floor is ~2-2.6e-2; see the module header)\n\
+         rows {ROWS:?}, cuBLASLt M pad reaches {max_m}"
+    );
+
+    let mut rng = Rng(0x0928_2026_5A5A_0001);
+    let act_h = upload(&gpu, &rng.acts(max_m * H))?;
+    let act_v = upload(&gpu, &rng.acts(max_m * VALUE_DIM))?;
+
+    let mut mk = |name, n: usize, kk: usize, reference, act| -> Result<Proj> {
+        let w = rng.fp8(n, kk);
+        let s = rng.scales(n, kk);
+        let (wt, st) = if reference == Ref::TransposedM128 {
+            transpose(&w, &s, n, kk)
+        } else {
+            (vec![0u8; 1], vec![0u8; 4])
+        };
+        Ok(Proj {
+            name,
+            n,
+            k: kk,
+            reference,
+            weight: upload(&gpu, &w)?,
+            scale: upload(&gpu, &s)?,
+            weight_t: upload(&gpu, &wt)?,
+            scale_t: upload(&gpu, &st)?,
+            act,
+        })
+    };
+    let projections = [
+        mk("ssm out_proj", H, VALUE_DIM, Ref::Pipelined, act_v)?,
+        mk("attn q_proj", Q_PROJ_DIM, H, Ref::Pipelined, act_h)?,
+        mk("attn k_proj", KV_DIM, H, Ref::TransposedM128, act_h)?,
+        mk("attn v_proj", KV_DIM, H, Ref::TransposedM128, act_h)?,
+    ];
+
+    let kg = H.max(VALUE_DIM) / 128;
+    let scratch = Scratch {
+        act_fp8: gpu.alloc(max_m * H.max(VALUE_DIM))?,
+        act_scale: gpu.alloc(max_m * kg * 4)?,
+        act_scale_kmajor: gpu.alloc(max_m * kg * 4)?,
+    };
+
+    let mut failures = 0usize;
+    let mut controls_done = false;
+    for m in ROWS {
+        let m_pad = ops::cublas_fp8_m_pad(m as u32) as usize;
+        println!("\n=== M = {m} (cuBLASLt pad = {m_pad}) ===");
+        for p in &projections {
+            let written = m_pad * p.n * 2;
+            let live = m * p.n * 2;
+            let sentinel = vec![SENTINEL; written + 2 * GUARD];
+            let base = upload(&gpu, &sentinel)?;
+            let out = base.offset(GUARD);
+
+            let capture = |w8a8: bool| -> Result<Vec<u8>> {
+                gpu.copy_h2d(&sentinel, base)?;
+                if w8a8 {
+                    run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                } else {
+                    run_w8a16(&gpu, &k, p, out, m)?;
+                }
+                gpu.synchronize(0)?;
+                let mut host = vec![0_u8; sentinel.len()];
+                gpu.copy_d2h(base, &mut host)?;
+                Ok(host)
+            };
+            let reference = capture(false)?;
+            let observed = capture(true)?;
+
+            if !controls_done {
+                // A green run has to be able to go red: three corruptions of
+                // the OBSERVED buffer, all refused by the real oracle.
+                for control in ["guard", "nonfinite", "value"] {
+                    let mut bad = observed.clone();
+                    match control {
+                        "guard" => bad[0] ^= 1,
+                        "nonfinite" => {
+                            bad[GUARD..GUARD + 2].copy_from_slice(&0x7fc0_u16.to_le_bytes())
+                        }
+                        _ => {
+                            for x in bad[GUARD..GUARD + p.n * 2].chunks_exact_mut(2) {
+                                x.copy_from_slice(&bf16::from_f32(1.0e3).to_bits().to_le_bytes());
+                            }
+                        }
+                    }
+                    let err = check(&bad, &reference, &sentinel, live, written, gate)
+                        .expect_err("known-bad output was admitted by the real oracle");
+                    println!("KNOWN_BAD {control}: refused: {err}");
+                }
+                controls_done = true;
+            }
+
+            let (cosine, rel_rms) = metrics(&observed, &reference, live);
+            let phantom = if m_pad > m {
+                let vals = values(&observed[GUARD + live..GUARD + written]);
+                format!(
+                    " phantom_rows={m}..{m_pad} finite={} max_abs={:.3}",
+                    vals.iter().all(|x| x.is_finite()),
+                    vals.iter().fold(0.0_f64, |a, x| a.max(x.abs()))
+                )
+            } else {
+                String::new()
+            };
+            println!(
+                "  {:<14} N={:<5} K={:<5} ref={:<10} cosine={cosine:.6} rel_rms={rel_rms:.4e}{phantom}",
+                p.name,
+                p.n,
+                p.k,
+                match p.reference {
+                    Ref::Pipelined => "pipelined",
+                    Ref::TransposedM128 => "t_m128",
+                },
+            );
+            if let Err(e) = check(&observed, &reference, &sentinel, live, written, gate) {
+                println!("  FAIL {} M={m}: {e}", p.name);
+                failures += 1;
+            }
+
+            println!("  --- timing, {REPS} reps ---");
+            for (label, w8a8) in [("W8A16 (shipped)", false), ("W8A8-cuBLASLt", true)] {
+                if w8a8 {
+                    run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                } else {
+                    run_w8a16(&gpu, &k, p, out, m)?;
+                }
+                gpu.synchronize(0)?;
+                let t0 = Instant::now();
+                for _ in 0..REPS {
+                    if w8a8 {
+                        run_w8a8(&gpu, &k, &scratch, p, out, m)?;
+                    } else {
+                        run_w8a16(&gpu, &k, p, out, m)?;
+                    }
+                }
+                gpu.synchronize(0)?;
+                let us = t0.elapsed().as_secs_f64() * 1e6 / REPS as f64;
+                println!(
+                    "  {:<14} {:<16} {us:>9.1} us  {:>7.1} TFLOP/s",
+                    p.name,
+                    label,
+                    p.flops(m) / (us / 1e6) / 1e12
+                );
+            }
+        }
+    }
+
+    ensure!(failures == 0, "{failures} case(s) failed");
+    println!(
+        "\nALL PASS: Qwen3.8-27B prefill projections at M in {ROWS:?} — W8A8 cuBLASLt within \
+         cosine {COSINE_GATE} / rel_rms {gate:.1e} of the W8A16 reference, phantom rows finite \
+         and confined to ceil16(M).\n\
+         Serve spelling: ATLAS_CUBLAS_GEMM=ffn,ssm,attn \
+         (ATLAS_SSM_OUT_W8A16_ONLY / ATLAS_ATTN_QKV_W8A16_ONLY revert per site)."
+    );
+    Ok(())
+}

--- a/crates/spark-model/src/layers/fp8_calibration.rs
+++ b/crates/spark-model/src/layers/fp8_calibration.rs
@@ -2,19 +2,38 @@
 
 //! Online FP8 KV cache scale calibration.
 //!
-//! Tracks running max |K| and max |V| values during the first N tokens of
-//! inference to compute per-tensor scales: `scale = max / 448.0` (mapping the
-//! observed dynamic range to FP8 E4M3 [-448, 448]).
+//! Tracks running max |K| and max |V| during the first
+//! `--fp8-kv-calibration-tokens` tokens of inference to compute per-tensor
+//! scales: `scale = amax * headroom / 448.0` (mapping the observed dynamic
+//! range onto FP8 E4M3 `[-448, 448]`).
 //!
-//! The scale is frozen on the FIRST observation (which runs immediately before
-//! the first KV write) and is then constant for the entire lifetime of every
-//! cache entry. This is required for correctness: FP8 KV round-trips (write
-//! `fp8=bf16/scale`, read `bf16=fp8*scale`) only if the SAME scale quantizes
-//! and dequantizes an entry. Freezing after N warmup tokens (the old design)
-//! wrote early entries at a placeholder scale, then froze to a different value,
-//! silently invalidating all already-written / cached KV — a paged multi-query
-//! read spanning the freeze boundary then read history through the wrong scale
-//! and generation degenerated. See the freeze block in `observe`.
+//! # The invariant
+//!
+//! FP8 KV round-trips (write `fp8 = bf16/scale`, read `bf16 = fp8*scale`) only
+//! if the SAME scale quantizes and dequantizes an entry. Paged / multi-query
+//! attention reads a sequence's whole history in one pass with ONE
+//! `k_scale`/`v_scale`, so a scale that changes under live cache entries
+//! dequantizes them through the wrong basis (~6x error → generation garbage:
+//! loops, empty completions). That is why the 2026-07-25 hardening froze the
+//! scale on the FIRST observe.
+//!
+//! # Atlas #919
+//!
+//! Freezing on the first observe made `--fp8-kv-calibration-tokens 256` a lie.
+//! Every H100 serve log showed
+//! `FP8 KV cache with online calibration (checkpoint ships no k/v scales):
+//!  freezing per-tensor scales on the first observed tokens.`
+//! and the thing being observed was the readiness probe — so a 24k-context
+//! serve ran on scales derived from ~13 tokens.
+//!
+//! The window is now real: the amax accumulates ACROSS requests until
+//! `window_tokens` have been observed, and the batch that reaches the window
+//! freezes on the amax of everything seen, itself included. The invariant is
+//! preserved by REWRITING the entries written inside the window — the window's
+//! BF16 K/V and slot mappings are staged aside and replayed through the
+//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see
+//! [`staging`] for the full tradeoff). A readiness probe therefore counts
+//! toward the window and can never end it on its own.
 //!
 //! Thread safety: uses `parking_lot::Mutex` for interior mutability. The lock
 //! is uncontended (single inference thread) so lock overhead is negligible.
@@ -24,11 +43,19 @@ use parking_lot::Mutex;
 use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
 use spark_runtime::kv_cache::KvCacheDtype;
 
-/// FP8 E4M3 max representable magnitude.
-const FP8_E4M3_MAX: f32 = 448.0;
+mod staging;
+mod state;
 
-/// Minimum scale to prevent division by zero or denormalized values.
-const MIN_SCALE: f32 = 1e-12;
+pub use staging::Fp8KvWriteTarget;
+use staging::{KvStaging, MAX_STAGED_TOKENS};
+use state::{CalibrationState, CalibrationStep, POST_FREEZE_OBSERVE_PERIOD};
+
+/// Scale used for the calibration window's own writes, before the freeze.
+///
+/// Covers ±896: models with large norm weights (Gemma-4 26B, Mistral) reach
+/// |K| ~600, which clips at scale 1.0. Those writes are requantized at the
+/// frozen scale when the window closes, so this only has to be SAFE, not tight.
+const PROVISIONAL_SCALE: f32 = 2.0;
 
 /// Whether this KV dtype's write path calls [`Fp8KvCalibration::observe`].
 ///
@@ -48,6 +75,10 @@ pub fn dtype_runs_online_fp8_kv_calibration(kv_dtype: KvCacheDtype) -> bool {
 /// `Some(false)` = still warming. Vacuously true when no layer calibrates.
 /// Must not use `find_map`: a BF16 boundary layer reporting `Some(false)`
 /// would shadow later FP8 layers that already froze.
+///
+/// #919 note: graphs now stay eager for the whole calibration window instead
+/// of one batch. That is the cost of calibrating on the requested token count;
+/// the window is a few hundred tokens, once per process.
 pub fn graphs_ready_after_fp8_kv_cal<I>(states: I) -> bool
 where
     I: IntoIterator<Item = Option<bool>>,
@@ -57,18 +88,10 @@ where
 
 /// Mutable calibration state protected by Mutex for Send + Sync.
 struct CalibrationInner {
-    /// Running max of |K| values observed so far.
-    k_running_max: f32,
-    /// Running max of |V| values observed so far.
-    v_running_max: f32,
-    /// Total tokens processed during calibration.
-    tokens_seen: usize,
-    /// Whether calibration is complete (scales frozen).
-    frozen: bool,
-    /// Calibrated k_scale (set once after warmup).
-    k_scale: f32,
-    /// Calibrated v_scale (set once after warmup).
-    v_scale: f32,
+    state: CalibrationState,
+    staging: KvStaging,
+    /// Set when a batch could not be staged, so the freeze log can say so.
+    unstaged_tokens: usize,
 }
 
 /// Online FP8 KV cache scale calibration tracker for one attention layer.
@@ -77,8 +100,10 @@ struct CalibrationInner {
 /// struct (required by `TransformerLayer` trait).
 pub struct Fp8KvCalibration {
     inner: Mutex<CalibrationInner>,
-    /// Headroom multiplier on the first-observe absmax (CLI `--fp8-kv-headroom`).
-    headroom: f32,
+    /// Attention-layer index, for the freeze log line.
+    attn_layer_idx: usize,
+    /// Tokens the window was asked for, before the `MAX_STAGED_TOKENS` clamp.
+    requested_tokens: usize,
     /// GPU buffer for absmax reduction output: `[1]` f32 for K, `[1]` f32 for V.
     /// Layout: `[k_absmax: f32, v_absmax: f32]` = 8 bytes.
     absmax_buf: DevicePtr,
@@ -95,21 +120,37 @@ unsafe impl Sync for Fp8KvCalibration {}
 impl Fp8KvCalibration {
     /// Create a new calibration tracker.
     ///
-    /// `_warmup_tokens`: retained for API/CLI compat but no longer gates the
-    ///   freeze — the scale is now frozen on the FIRST observe (before any KV is
-    ///   persisted), so a warmup window would only reintroduce the write/read
-    ///   scale mismatch. Any value > 0 simply enables online calibration.
-    /// `headroom`: multiplier on the first-observe absmax when freezing
+    /// `attn_layer_idx`: this layer's index, for the freeze log line.
+    /// `window_tokens`: `--fp8-kv-calibration-tokens`. The amax accumulates
+    ///   over this many observed tokens, across requests, before the scale
+    ///   freezes (#919). Clamped to `MAX_STAGED_TOKENS` so the BF16 staging
+    ///   cannot reserve gigabytes per layer; 1 reproduces the pre-#919
+    ///   freeze-on-first-observe behaviour, and 0 never gets here (the
+    ///   attention initializer does not build a calibrator at all).
+    /// `headroom`: multiplier on the accumulated amax when freezing
     ///   (`--fp8-kv-headroom`, CLI-validated ≥ 1.0; clamped here as defense in
     ///   depth because a sub-1.0 value guarantees clipping).
     /// `gpu`: GPU backend for allocating the absmax reduction buffer.
-    pub fn new(_warmup_tokens: usize, headroom: f32, gpu: &dyn GpuBackend) -> Result<Self> {
+    pub fn new(
+        attn_layer_idx: usize,
+        window_tokens: usize,
+        headroom: f32,
+        gpu: &dyn GpuBackend,
+    ) -> Result<Self> {
         let headroom = if headroom >= 1.0 {
             headroom
         } else {
             tracing::warn!("fp8-kv headroom {headroom} < 1.0 guarantees clipping; clamped to 1.0");
             1.0
         };
+        let effective = window_tokens.min(MAX_STAGED_TOKENS);
+        if effective != window_tokens && attn_layer_idx == 0 {
+            tracing::warn!(
+                "--fp8-kv-calibration-tokens {window_tokens} exceeds the {MAX_STAGED_TOKENS}-token \
+                 staging cap (the window's KV is held in BF16 so it can be requantized at the \
+                 freeze); calibrating on {effective} tokens instead."
+            );
+        }
         let absmax_kernel = gpu.kernel("reshape_and_cache", "bf16_absmax")?;
         // Allocate 8 bytes: [k_absmax: f32, v_absmax: f32]
         let absmax_buf = gpu.alloc(8)?;
@@ -119,18 +160,12 @@ impl Fp8KvCalibration {
 
         Ok(Self {
             inner: Mutex::new(CalibrationInner {
-                k_running_max: 0.0,
-                v_running_max: 0.0,
-                tokens_seen: 0,
-                frozen: false,
-                // Start with scale=2.0 (effective range ±896) during warmup.
-                // Models with large norm weights (Gemma-4 26B, Mistral) can produce
-                // K/V values up to ~600, which exceeds FP8 E4M3 range at scale=1.0 (±448).
-                // Scale=2.0 covers ±896 which is safe for all known models.
-                k_scale: 2.0,
-                v_scale: 2.0,
+                state: CalibrationState::new(effective, headroom, PROVISIONAL_SCALE),
+                staging: KvStaging::default(),
+                unstaged_tokens: 0,
             }),
-            headroom,
+            attn_layer_idx,
+            requested_tokens: window_tokens,
             absmax_buf,
             absmax_kernel,
         })
@@ -138,32 +173,33 @@ impl Fp8KvCalibration {
 
     /// Whether calibration is still in warmup phase (scales not yet frozen).
     pub fn is_calibrating(&self) -> bool {
-        let inner = self.inner.lock();
-        !inner.frozen
+        !self.inner.lock().state.frozen
     }
 
     /// Get current scales. Returns (k_scale, v_scale).
     ///
-    /// Before the first observe: the conservative construction default (2.0,
-    /// covering ±896) — never used for a persisted write, since observe() runs
-    /// before every write and freezes on its first call. After the first
-    /// observe: the frozen, data-derived scale (constant thereafter).
+    /// Inside the window: [`PROVISIONAL_SCALE`], which every read during the
+    /// window also uses — consistent, just coarse. After the freeze: the
+    /// data-derived scale the whole window was requantized to (constant
+    /// thereafter).
     pub fn scales(&self) -> (f32, f32) {
         let inner = self.inner.lock();
-        (inner.k_scale, inner.v_scale)
+        (inner.state.k_scale, inner.state.v_scale)
     }
 
-    /// Observe K/V projection outputs and update running max.
+    /// Observe K/V projection outputs and update the running max.
     ///
-    /// Launches absmax reduction kernels on the K and V buffers, then reads
-    /// the results back to CPU after a sync. Call this AFTER K/V projections
-    /// and BEFORE writing to the KV cache.
+    /// Launches absmax reductions on the K and V buffers, reads them back after
+    /// a sync, then either stages this batch (still inside the window) or
+    /// freezes and requantizes the staged window. Call this AFTER the K/V
+    /// projections and BEFORE writing to the KV cache — the caller's write then
+    /// uses [`Self::scales`], which is exactly what this call just decided.
     ///
-    /// `k_data`: device BF16 buffer of K projection output
-    /// `v_data`: device BF16 buffer of V projection output
-    /// `num_tokens`: number of tokens in the batch
-    /// `num_kv_heads`: number of KV heads
-    /// `head_dim`: dimension per head
+    /// `k_data`/`v_data`: device BF16 K/V projection outputs.
+    /// `num_tokens`/`num_kv_heads`/`head_dim`: this batch's shape.
+    /// `target`: where the caller is about to write, so the freeze can replay
+    ///   the window into the same pools.
+    #[allow(clippy::too_many_arguments)]
     pub fn observe(
         &self,
         gpu: &dyn GpuBackend,
@@ -173,264 +209,138 @@ impl Fp8KvCalibration {
         num_kv_heads: u32,
         head_dim: u32,
         stream: u64,
+        target: &Fp8KvWriteTarget,
     ) -> Result<()> {
-        // Observe during warmup (always) and periodically after (every 512 tokens)
-        // to catch distribution shifts in multi-turn conversations. Without periodic
-        // recalibration, FP8 KV scales become stale as context grows, causing recent
-        // K values to collapse into fewer E4M3 quantization buckets.
-        // Recalibrate every 128 tokens (was 512) to catch distribution shifts
-        // in multi-turn conversations where K/V statistics change frequently.
-        let should_observe = {
+        {
             let inner = self.inner.lock();
-            !inner.frozen || (inner.tokens_seen % 128 < num_tokens as usize)
-        };
-        if !should_observe {
-            return Ok(());
+            if !inner.state.should_observe(num_tokens as usize) {
+                return Ok(());
+            }
         }
 
+        let (k_max, v_max) = self.absmax(
+            gpu,
+            k_data,
+            v_data,
+            num_tokens,
+            num_kv_heads,
+            head_dim,
+            stream,
+        )?;
+
+        let mut inner = self.inner.lock();
+        match inner.state.record(k_max, v_max, num_tokens as usize) {
+            CalibrationStep::Stage => {
+                let capacity = inner.state.window_tokens;
+                let elems = (num_kv_heads * head_dim) as usize;
+                let staged = inner.staging.stage(
+                    gpu, k_data, v_data, num_tokens, elems, target, capacity, stream,
+                )?;
+                if !staged {
+                    inner.unstaged_tokens += num_tokens as usize;
+                }
+            }
+            CalibrationStep::Freeze {
+                k_scale,
+                v_scale,
+                tokens_seen,
+            } => {
+                let staged_tokens = inner.staging.used_tokens();
+                let inner = &mut *inner;
+                inner.staging.replay_and_release(
+                    gpu,
+                    target,
+                    num_kv_heads,
+                    head_dim,
+                    k_scale,
+                    v_scale,
+                    stream,
+                )?;
+                tracing::info!(
+                    "FP8 KV scales frozen after {} tokens (requested {}) on attn layer {}: \
+                     k_scale={:.6} (amax={:.3}), v_scale={:.6} (amax={:.3}), headroom={:.2}; \
+                     requantized {} staged tokens in {} batches, {} unstaged",
+                    tokens_seen,
+                    self.requested_tokens,
+                    self.attn_layer_idx,
+                    k_scale,
+                    inner.state.k_running_max,
+                    v_scale,
+                    inner.state.v_running_max,
+                    inner.state.headroom,
+                    staged_tokens,
+                    inner.state.staged_batches,
+                    inner.unstaged_tokens,
+                );
+            }
+            CalibrationStep::Frozen => {
+                if inner.state.tokens_seen % POST_FREEZE_OBSERVE_PERIOD < num_tokens as usize
+                    && ema_recal_enabled()
+                {
+                    // F5 (2026-05-26): post-freeze EMA recalibration is OPT-IN via
+                    // `ATLAS_FP8_KV_EMA_RECAL=1`, default OFF. Moving `k_scale` /
+                    // `v_scale` after the freeze makes every already-written cache
+                    // entry stale relative to the new scales — attention then reads
+                    // the whole history through a shifted quantization basis. The
+                    // forensic study of the canonical opencode probe shows
+                    // reasoning-channel collapse and drift-to-phantom-path patterns
+                    // whose timing matches deep-layer KV read through a rescaled
+                    // basis. #919's staging only covers the calibration window, so
+                    // this path is still unsafe by construction — it stays off.
+                    inner.state.ema_recalibrate(k_max, v_max);
+                    tracing::info!(
+                        "FP8 KV EMA-recalibrated after {} tokens on attn layer {}: \
+                         k_scale={:.6} (amax={:.2}), v_scale={:.6} (amax={:.2})",
+                        inner.state.tokens_seen,
+                        self.attn_layer_idx,
+                        inner.state.k_scale,
+                        inner.state.k_running_max,
+                        inner.state.v_scale,
+                        inner.state.v_running_max,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Absmax of the K and V projection outputs, read back to the host.
+    #[allow(clippy::too_many_arguments)]
+    fn absmax(
+        &self,
+        gpu: &dyn GpuBackend,
+        k_data: DevicePtr,
+        v_data: DevicePtr,
+        num_tokens: u32,
+        num_kv_heads: u32,
+        head_dim: u32,
+        stream: u64,
+    ) -> Result<(f32, f32)> {
         let n_elems = num_tokens * num_kv_heads * head_dim;
-
-        // Reset absmax buffer to 0.0 before reduction (async to avoid sync/async conflict)
+        // Reset the absmax buffer to 0.0 before the reduction (async, to avoid
+        // a sync/async conflict on the stream).
         gpu.memset_async(self.absmax_buf, 0, 8, stream)?;
-
-        // Launch absmax for K
         let k_out = self.absmax_buf;
         super::ops::bf16_absmax(gpu, self.absmax_kernel, k_data, k_out, n_elems, stream)?;
-
-        // Launch absmax for V (write to offset 4 = second f32)
+        // V writes to offset 4 = the second f32.
         let v_out = self.absmax_buf.offset(4);
         super::ops::bf16_absmax(gpu, self.absmax_kernel, v_data, v_out, n_elems, stream)?;
 
-        // Sync and read back
         gpu.synchronize(stream)?;
-        let mut result_buf = [0u8; 8];
-        gpu.copy_d2h(self.absmax_buf, &mut result_buf)?;
-        let k_max =
-            f32::from_le_bytes([result_buf[0], result_buf[1], result_buf[2], result_buf[3]]);
-        let v_max =
-            f32::from_le_bytes([result_buf[4], result_buf[5], result_buf[6], result_buf[7]]);
-
-        // Update running max and check if warmup is complete
-        let mut inner = self.inner.lock();
-        inner.k_running_max = inner.k_running_max.max(k_max);
-        inner.v_running_max = inner.v_running_max.max(v_max);
-        inner.tokens_seen += num_tokens as usize;
-
-        if !inner.frozen {
-            // HARDENING (2026-07-25): freeze the scale on the FIRST observation,
-            // BEFORE any KV is persisted with it. The write path calls observe()
-            // immediately before quantizing+writing KV (write_kv_cache.rs:482-485),
-            // so the scale frozen HERE is exactly what THIS batch — and every
-            // later batch — writes with, and what every read dequantizes with.
-            //
-            // The previous design wrote the first `warmup_tokens` (256) at a
-            // placeholder scale (2.0), then froze to a data-derived value (~0.3)
-            // and never re-quantized the already-written entries. A paged /
-            // multi-query attention read (chunked prefill, or a prefix-cache
-            // resume where seq_len_start>0) covers the whole history in one pass,
-            // so once the sequence crossed the freeze boundary it dequantized the
-            // pre-freeze KV (and cached/shared prefixes) through the NEW scale —
-            // ~6x error → generation garbage (loops/empty). Freezing on the first
-            // observe guarantees ONE constant scale for every cache entry's whole
-            // lifetime — the exact invariant the EMA-recal guard below documents.
-            // `warmup_tokens` no longer gates the freeze (kept for API compat).
-            //
-            // Headroom: the first observe sees only the first prefill chunk, so
-            // size the scale to cover headroom× its observed max, covering later
-            // tokens whose magnitude grows (trades <1 bit of precision for no
-            // clipping). CLI `--fp8-kv-headroom`, threaded through ModelConfig —
-            // deliberately NOT an env var (no knobs outside the command line).
-            let headroom = self.headroom;
-            inner.k_scale = (inner.k_running_max * headroom / FP8_E4M3_MAX).max(MIN_SCALE);
-            inner.v_scale = (inner.v_running_max * headroom / FP8_E4M3_MAX).max(MIN_SCALE);
-            inner.frozen = true;
-            tracing::info!(
-                "FP8 KV scale frozen on first observe ({} tok, headroom={:.1}): k_scale={:.6} (max={:.2}), v_scale={:.6} (max={:.2}) — constant for all entries",
-                inner.tokens_seen,
-                headroom,
-                inner.k_scale,
-                inner.k_running_max,
-                inner.v_scale,
-                inner.v_running_max,
-            );
-        } else if inner.frozen
-            && inner.tokens_seen % 128 < num_tokens as usize
-            && std::env::var("ATLAS_FP8_KV_EMA_RECAL")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false)
-        {
-            // F5 (2026-05-26): Periodic EMA recalibration is now OPT-IN
-            // via `ATLAS_FP8_KV_EMA_RECAL=1`, default OFF. Rationale:
-            // changing `k_scale` / `v_scale` after `frozen=true` makes
-            // previously-written KV cache entries (quantized with the
-            // OLD scales) stale relative to the NEW scales — every
-            // attention read after a recalibration sees the historical
-            // cache through a shifted quantization basis. The comment
-            // "responds faster to multi-turn topic switches" was correct
-            // about the calibration signal but missed that retroactively
-            // rescaling the cache corrupts already-stored multi-turn
-            // context. The forensic study of the canonical opencode
-            // probe shows reasoning-channel collapse + drift-to-phantom-
-            // path patterns whose timing is consistent with deep-layer
-            // KV reading through a rescaled basis.
-            let new_k = (k_max / FP8_E4M3_MAX).max(MIN_SCALE);
-            let new_v = (v_max / FP8_E4M3_MAX).max(MIN_SCALE);
-            let k_shift = (new_k - inner.k_scale).abs() / inner.k_scale.max(MIN_SCALE);
-            let v_shift = (new_v - inner.v_scale).abs() / inner.v_scale.max(MIN_SCALE);
-            let alpha = if k_shift > 0.2 || v_shift > 0.2 {
-                0.3
-            } else {
-                0.1
-            };
-            inner.k_scale = (1.0 - alpha) * inner.k_scale + alpha * new_k;
-            inner.v_scale = (1.0 - alpha) * inner.v_scale + alpha * new_v;
-            // Reset running max for next observation window
-            inner.k_running_max = k_max;
-            inner.v_running_max = v_max;
-
-            tracing::info!(
-                "FP8 KV calibrated after {} tokens: k_scale={:.6} (max={:.2}), v_scale={:.6} (max={:.2})",
-                inner.tokens_seen,
-                inner.k_scale,
-                inner.k_running_max,
-                inner.v_scale,
-                inner.v_running_max,
-            );
-        }
-
-        Ok(())
+        let mut buf = [0u8; 8];
+        gpu.copy_d2h(self.absmax_buf, &mut buf)?;
+        Ok((
+            f32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]),
+            f32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]),
+        ))
     }
+}
+
+fn ema_recal_enabled() -> bool {
+    std::env::var("ATLAS_FP8_KV_EMA_RECAL")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
-mod tests {
-    use spark_runtime::gpu::GpuBackend;
-    use spark_runtime::gpu::mock::MockGpuBackend;
-
-    use super::Fp8KvCalibration;
-
-    fn compact_source(src: &str) -> String {
-        src.chars().filter(|c| !c.is_whitespace()).collect()
-    }
-
-    /// The write/read-scale invariant, as a fails-without-the-fix test: the
-    /// scale a batch is WRITTEN with must be the scale every later read
-    /// dequantizes with, so after the first observe the scale may never move.
-    ///
-    /// On the pre-fix design this fails: the first 10-token observe leaves the
-    /// placeholder scale (2.0) live, and the observe that crosses the
-    /// `warmup_tokens = 256` boundary re-derives it (with the mock's zeroed
-    /// absmax buffer, to `MIN_SCALE` = 1e-12) — every entry written before the
-    /// boundary is then dequantized ~6× off in production, and here the
-    /// snapshot comparison trips.
-    #[test]
-    fn scale_freezes_on_first_observe_and_stays_fixed_by_default() {
-        let gpu = MockGpuBackend::new();
-        let cal = Fp8KvCalibration::new(256, 2.0, &gpu).expect("mock construct");
-        let k = gpu.alloc(4096).expect("k buf");
-        let v = gpu.alloc(4096).expect("v buf");
-        let stream = gpu.default_stream();
-
-        // First observe: a 10-token first prefill chunk. The fix freezes HERE,
-        // before any KV has been persisted.
-        cal.observe(&gpu, k, v, 10, 8, 128, stream)
-            .expect("observe");
-        assert!(
-            !cal.is_calibrating(),
-            "scale must freeze on the first observe"
-        );
-        let frozen = cal.scales();
-
-        // Cross the old warmup boundary (256 tokens) in later observes.
-        for _ in 0..30 {
-            cal.observe(&gpu, k, v, 10, 8, 128, stream)
-                .expect("observe");
-        }
-        assert_eq!(
-            cal.scales(),
-            frozen,
-            "the frozen scale moved after later observes — pre-freeze KV would \
-             now dequantize through a different scale than it was written with"
-        );
-    }
-
-    #[test]
-    fn only_plain_fp8_kv_runs_online_calibration() {
-        use spark_runtime::kv_cache::KvCacheDtype as D;
-        assert!(super::dtype_runs_online_fp8_kv_calibration(D::Fp8));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Bf16));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Nvfp4));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Turbo8));
-        assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Fp8KTurbo4V));
-    }
-
-    #[test]
-    fn graphs_ready_vacuous_when_no_calibrator() {
-        assert!(super::graphs_ready_after_fp8_kv_cal([None, None]));
-    }
-
-    #[test]
-    fn graphs_ready_blocked_while_any_calibrator_is_warm() {
-        assert!(!super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(false),
-            Some(true)
-        ]));
-    }
-
-    #[test]
-    fn graphs_ready_when_every_calibrator_frozen() {
-        assert!(super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(true),
-            Some(true)
-        ]));
-    }
-
-    #[test]
-    fn graphs_stay_blocked_when_a_warm_layer_follows_a_frozen_layer() {
-        assert!(!super::graphs_ready_after_fp8_kv_cal([
-            None,
-            Some(true),
-            Some(false),
-            None
-        ]));
-    }
-
-    #[test]
-    fn attention_init_gates_calibrator_on_tokens_and_plain_fp8() {
-        let src = compact_source(include_str!("qwen3_attention/init.rs"));
-        assert!(
-            src.contains(
-                "fp8_calibration:iffp8_calibration_tokens>0&&crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype){Some(Fp8KvCalibration::new("
-            ),
-            "the attention initializer must require enabled tokens and an observing KV dtype"
-        );
-    }
-
-    #[test]
-    fn decode_uses_shared_calibration_readiness() {
-        let src = compact_source(include_str!("../model/trait_impl/decode_a.rs"));
-        assert!(
-            src.contains(
-                "fnfp8_calibration_frozen(&self)->bool{crate::layers::fp8_calibration::graphs_ready_after_fp8_kv_cal(self.layers.iter().map(|l|l.fp8_calibration_frozen()),)}"
-            ),
-            "decode readiness must aggregate every layer through the shared policy"
-        );
-    }
-
-    #[test]
-    fn fused_verify_unsuppress_matches_decode_frozen_flag() {
-        let src = compact_source(include_str!("../model/trait_impl/verify_fused.rs"));
-        assert!(
-            src.contains(
-                "&&self.fp8_calibration_frozen(){self.suppress_graphs.store(false,std::sync::atomic::Ordering::Relaxed);"
-            ),
-            "fused verify must unsuppress graphs from the frozen-state predicate"
-        );
-        assert!(
-            !src.contains("calibration_tokens+10"),
-            "old token-count gate kept fused verify eager for ~266 tokens"
-        );
-    }
-}
+mod tests;

--- a/crates/spark-model/src/layers/fp8_calibration.rs
+++ b/crates/spark-model/src/layers/fp8_calibration.rs
@@ -31,9 +31,10 @@
 //! freezes on the amax of everything seen, itself included. The invariant is
 //! preserved by REWRITING the entries written inside the window — the window's
 //! BF16 K/V and slot mappings are staged aside and replayed through the
-//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see
-//! [`staging`] for the full tradeoff). A readiness probe therefore counts
-//! toward the window and can never end it on its own.
+//! existing `reshape_and_cache_fp8` kernel at the frozen scale (see the
+//! private `staging` submodule of this module for the full tradeoff). A
+//! readiness probe therefore counts toward the window and can never end it on
+//! its own.
 //!
 //! Thread safety: uses `parking_lot::Mutex` for interior mutability. The lock
 //! is uncontended (single inference thread) so lock overhead is negligible.
@@ -178,10 +179,10 @@ impl Fp8KvCalibration {
 
     /// Get current scales. Returns (k_scale, v_scale).
     ///
-    /// Inside the window: [`PROVISIONAL_SCALE`], which every read during the
-    /// window also uses — consistent, just coarse. After the freeze: the
-    /// data-derived scale the whole window was requantized to (constant
-    /// thereafter).
+    /// Inside the window: `PROVISIONAL_SCALE` (private to this module), which
+    /// every read during the window also uses — consistent, just coarse. After
+    /// the freeze: the data-derived scale the whole window was requantized to
+    /// (constant thereafter).
     pub fn scales(&self) -> (f32, f32) {
         let inner = self.inner.lock();
         (inner.state.k_scale, inner.state.v_scale)

--- a/crates/spark-model/src/layers/fp8_calibration/staging.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/staging.rs
@@ -87,7 +87,7 @@ struct StagedBatch {
 }
 
 /// Device-side copies of the calibration window's BF16 K/V and slot mappings.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(super) struct KvStaging {
     k: DevicePtr,
     v: DevicePtr,
@@ -96,6 +96,20 @@ pub(super) struct KvStaging {
     elems_per_token: usize,
     used_tokens: usize,
     batches: Vec<StagedBatch>,
+}
+
+impl Default for KvStaging {
+    fn default() -> Self {
+        Self {
+            k: DevicePtr(0),
+            v: DevicePtr(0),
+            slots: DevicePtr(0),
+            capacity_tokens: 0,
+            elems_per_token: 0,
+            used_tokens: 0,
+            batches: Vec::new(),
+        }
+    }
 }
 
 impl KvStaging {

--- a/crates/spark-model/src/layers/fp8_calibration/staging.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/staging.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! BF16 staging for the FP8 KV calibration window (Atlas #919).
+//!
+//! ## Why this exists
+//!
+//! The FP8 KV round-trip is only correct if the scale that quantized a cache
+//! entry is the scale that dequantizes it: paged attention reads a sequence's
+//! whole history in one pass with ONE `k_scale`/`v_scale`. That is why the
+//! 2026-07-25 hardening froze the scale on the FIRST observe — but it is also
+//! why #919 happened, because "the first observe" is the readiness probe and a
+//! 24k serve ended up calibrated on 13 tokens.
+//!
+//! ## The fix, and its tradeoff
+//!
+//! Accumulate the amax over the requested window and, when the freeze finally
+//! fires, make the already-written entries agree with the new scale by
+//! REWRITING them. Of the three options considered (#919):
+//!
+//! * (a) hold pre-freeze tokens in BF16 — impossible without a second pool:
+//!   the FP8 pools are sized for 1 byte/element and attention must be able to
+//!   read those tokens back DURING the window.
+//! * (b) rescale the stored FP8 codes in place — needs a new dequant/requant
+//!   kernel in all five arch trees (`kernels/{hopper,b200,gb10,strix,strix-hip}`)
+//!   and loses precision twice.
+//! * (c) **chosen**: keep the original BF16 K/V of the window's batches, plus
+//!   their slot mappings, and replay them through the EXISTING
+//!   `reshape_and_cache_fp8` kernel at the frozen scale. No new kernel, and the
+//!   rewritten entries are quantized once, from the original BF16, at the final
+//!   scale — strictly better than a code-domain rescale.
+//!
+//! Replay is chronological, so "last writer wins" per slot is identical to the
+//! original write order even if a block was freed and re-allocated inside the
+//! window. The crossing batch is written by the caller AFTER the replay, at the
+//! frozen scale, so it needs no staging.
+//!
+//! Cost: `window_tokens * num_kv_heads * head_dim * 2 B * 2` device bytes per
+//! attention layer, freed at the freeze. 256 tokens x 4 KV heads x 128 dims is
+//! 512 KiB/layer. `MAX_STAGED_TOKENS` caps a pathological `--fp8-kv-calibration-
+//! tokens`.
+//!
+//! Known gap, documented rather than fixed: KV spilled to host
+//! (`--high-speed-swap`) inside the window is not replayed. The window is a few
+//! hundred tokens, long before spill pressure.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+use crate::layers::ops;
+
+/// Hard cap on staged calibration tokens, so an absurd
+/// `--fp8-kv-calibration-tokens` cannot reserve gigabytes of device memory per
+/// layer. The effective window is clamped to this in `Fp8KvCalibration::new`.
+pub(super) const MAX_STAGED_TOKENS: usize = 4096;
+
+/// Bytes per BF16 element.
+const BF16: usize = 2;
+/// Bytes per `slot_mapping` entry (int64, see `reshape_and_cache_fp8.cu`).
+const SLOT: usize = 8;
+
+/// Everything the replay needs to re-run `reshape_and_cache_fp8` for one layer.
+#[derive(Debug, Clone, Copy)]
+pub struct Fp8KvWriteTarget {
+    /// `reshape_and_cache_fp8` kernel handle (the layer's `reshape_cache_k`).
+    pub kernel: KernelHandle,
+    /// Base pointer of this layer's K pool.
+    pub k_pool: DevicePtr,
+    /// Base pointer of this layer's V pool.
+    pub v_pool: DevicePtr,
+    /// Tokens per KV block.
+    pub block_size: u32,
+    /// Pool stride in ELEMENTS (`block_size * num_kv_heads * head_dim`).
+    pub cache_stride: u64,
+    /// Source K row stride in elements, as passed to the live write.
+    pub key_stride: u32,
+    /// Source V row stride in elements, as passed to the live write.
+    pub value_stride: u32,
+    /// This batch's `slot_mapping` (int64 per token), staged alongside the
+    /// BF16 K/V so the replay lands on exactly the entries the window wrote.
+    pub slot: DevicePtr,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StagedBatch {
+    offset_tokens: usize,
+    num_tokens: u32,
+}
+
+/// Device-side copies of the calibration window's BF16 K/V and slot mappings.
+#[derive(Debug, Default)]
+pub(super) struct KvStaging {
+    k: DevicePtr,
+    v: DevicePtr,
+    slots: DevicePtr,
+    capacity_tokens: usize,
+    elems_per_token: usize,
+    used_tokens: usize,
+    batches: Vec<StagedBatch>,
+}
+
+impl KvStaging {
+    /// Tokens staged so far.
+    pub(super) fn used_tokens(&self) -> usize {
+        self.used_tokens
+    }
+
+    /// Copy one pre-freeze batch aside. Silently declines (returns `false`) if
+    /// the window no longer fits — the caller then writes the batch at the
+    /// provisional scale and the freeze simply leaves it alone, which is the
+    /// pre-#919 behaviour for that batch rather than a correctness cliff.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn stage(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        k: DevicePtr,
+        v: DevicePtr,
+        num_tokens: u32,
+        elems_per_token: usize,
+        target: &Fp8KvWriteTarget,
+        capacity_tokens: usize,
+        stream: u64,
+    ) -> Result<bool> {
+        if self.capacity_tokens == 0 {
+            self.k = gpu.alloc(capacity_tokens * elems_per_token * BF16)?;
+            self.v = gpu.alloc(capacity_tokens * elems_per_token * BF16)?;
+            self.slots = gpu.alloc(capacity_tokens * SLOT)?;
+            self.capacity_tokens = capacity_tokens;
+            self.elems_per_token = elems_per_token;
+        }
+        let n = num_tokens as usize;
+        if elems_per_token != self.elems_per_token || self.used_tokens + n > self.capacity_tokens {
+            return Ok(false);
+        }
+
+        let row = elems_per_token * BF16;
+        let dst_off = self.used_tokens * row;
+        copy_rows(
+            gpu,
+            k,
+            target.key_stride,
+            self.k.offset(dst_off),
+            row,
+            n,
+            stream,
+        )?;
+        copy_rows(
+            gpu,
+            v,
+            target.value_stride,
+            self.v.offset(dst_off),
+            row,
+            n,
+            stream,
+        )?;
+        gpu.copy_d2d_async(
+            target.slot,
+            self.slots.offset(self.used_tokens * SLOT),
+            n * SLOT,
+            stream,
+        )?;
+
+        self.batches.push(StagedBatch {
+            offset_tokens: self.used_tokens,
+            num_tokens,
+        });
+        self.used_tokens += n;
+        Ok(true)
+    }
+
+    /// Requantize every staged batch at the frozen scale, in write order, then
+    /// release the staging buffers. Returns the number of tokens rewritten.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn replay_and_release(
+        &mut self,
+        gpu: &dyn GpuBackend,
+        target: &Fp8KvWriteTarget,
+        num_kv_heads: u32,
+        head_dim: u32,
+        k_scale: f32,
+        v_scale: f32,
+        stream: u64,
+    ) -> Result<usize> {
+        let rewritten = self.used_tokens;
+        let row = self.elems_per_token * BF16;
+        for batch in std::mem::take(&mut self.batches) {
+            let off = batch.offset_tokens;
+            ops::reshape_and_cache_fp8(
+                gpu,
+                target.kernel,
+                self.k.offset(off * row),
+                self.v.offset(off * row),
+                target.k_pool,
+                target.v_pool,
+                self.slots.offset(off * SLOT),
+                batch.num_tokens,
+                num_kv_heads,
+                head_dim,
+                target.block_size,
+                k_scale,
+                v_scale,
+                // The staging buffers are packed, whatever the live source
+                // strides were.
+                self.elems_per_token as u32,
+                self.elems_per_token as u32,
+                target.cache_stride,
+                stream,
+            )?;
+        }
+        self.release(gpu)?;
+        Ok(rewritten)
+    }
+
+    /// Free the staging buffers. Idempotent.
+    pub(super) fn release(&mut self, gpu: &dyn GpuBackend) -> Result<()> {
+        if self.capacity_tokens == 0 {
+            return Ok(());
+        }
+        gpu.free(self.k)?;
+        gpu.free(self.v)?;
+        gpu.free(self.slots)?;
+        *self = Self::default();
+        Ok(())
+    }
+}
+
+/// Copy `rows` rows of `row_bytes` from a source with `src_stride` ELEMENTS
+/// between rows into a packed destination.
+fn copy_rows(
+    gpu: &dyn GpuBackend,
+    src: DevicePtr,
+    src_stride: u32,
+    dst: DevicePtr,
+    row_bytes: usize,
+    rows: usize,
+    stream: u64,
+) -> Result<()> {
+    let src_pitch = src_stride as usize * BF16;
+    if src_pitch == row_bytes {
+        return gpu.copy_d2d_async(src, dst, row_bytes * rows, stream);
+    }
+    gpu.copy_d2d_2d_async(src, src_pitch, dst, row_bytes, row_bytes, rows, stream)
+}

--- a/crates/spark-model/src/layers/fp8_calibration/state.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/state.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pure, GPU-free state machine behind [`super::Fp8KvCalibration`].
+//!
+//! SSOT for "when does the FP8 KV scale freeze, and on what data". Split out
+//! of `fp8_calibration.rs` so the decision can be unit-tested without a GPU:
+//! the glue module owns the absmax kernel launch and the BF16 staging, this
+//! module owns nothing but arithmetic.
+//!
+//! Atlas #919: the serve log line
+//! `FP8 KV cache with online calibration (checkpoint ships no k/v scales):
+//!  freezing per-tensor scales on the first observed tokens.`
+//! meant exactly that — the freeze fired on the FIRST `observe`, so a 24k
+//! serve got its per-tensor scales from whatever the readiness probe sent
+//! (13 tokens). `--fp8-kv-calibration-tokens N` now means what it reads like:
+//! accumulate the running amax over the first N observed tokens, ACROSS
+//! requests, and freeze on the observe that reaches N.
+
+/// FP8 E4M3 max representable magnitude.
+pub(super) const FP8_E4M3_MAX: f32 = 448.0;
+
+/// Minimum scale to prevent division by zero or denormalized values.
+pub(super) const MIN_SCALE: f32 = 1e-12;
+
+/// Post-freeze re-observation period, in tokens. Only used by the opt-in EMA
+/// recalibration path (`ATLAS_FP8_KV_EMA_RECAL=1`).
+pub(super) const POST_FREEZE_OBSERVE_PERIOD: usize = 128;
+
+/// What the caller must do with the batch it is about to write.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum CalibrationStep {
+    /// Still inside the calibration window. Write this batch with the current
+    /// (provisional) scales AND stage its BF16 K/V + slot mapping, so the
+    /// freeze can rewrite those cache entries at the final scale.
+    Stage,
+    /// This batch reached the window. `k_scale`/`v_scale` are final and were
+    /// computed over every token observed so far, this batch included. The
+    /// caller replays the staged batches at these scales, then writes this
+    /// batch at them too.
+    Freeze {
+        k_scale: f32,
+        v_scale: f32,
+        tokens_seen: usize,
+    },
+    /// Already frozen — nothing to stage, nothing to replay.
+    Frozen,
+}
+
+/// Mutable calibration state. One per attention layer.
+#[derive(Debug)]
+pub(super) struct CalibrationState {
+    /// Running max of |K| over every token observed so far.
+    pub(super) k_running_max: f32,
+    /// Running max of |V| over every token observed so far.
+    pub(super) v_running_max: f32,
+    /// Total tokens observed (calibration window + post-freeze probes).
+    pub(super) tokens_seen: usize,
+    /// Whether calibration is complete (scales frozen).
+    pub(super) frozen: bool,
+    /// Live k_scale: provisional before the freeze, final after it.
+    pub(super) k_scale: f32,
+    /// Live v_scale: provisional before the freeze, final after it.
+    pub(super) v_scale: f32,
+    /// Tokens that must be observed before the freeze (`>= 1`).
+    pub(super) window_tokens: usize,
+    /// Headroom multiplier on the accumulated amax (`--fp8-kv-headroom`).
+    pub(super) headroom: f32,
+    /// Tokens actually staged for requantization (`<= window_tokens`).
+    pub(super) staged_tokens: usize,
+    /// Staged batch count, for the freeze log line.
+    pub(super) staged_batches: usize,
+}
+
+impl CalibrationState {
+    /// `window_tokens` is clamped to `>= 1`: `--fp8-kv-calibration-tokens 0`
+    /// never constructs a calibrator at all (checkpoint/static scales win), and
+    /// a 1-token window reproduces the pre-#919 freeze-on-first-observe
+    /// behaviour exactly — nothing is ever staged, so nothing is ever rewritten.
+    pub(super) fn new(window_tokens: usize, headroom: f32, provisional_scale: f32) -> Self {
+        Self {
+            k_running_max: 0.0,
+            v_running_max: 0.0,
+            tokens_seen: 0,
+            frozen: false,
+            k_scale: provisional_scale,
+            v_scale: provisional_scale,
+            window_tokens: window_tokens.max(1),
+            headroom,
+            staged_tokens: 0,
+            staged_batches: 0,
+        }
+    }
+
+    /// Whether this batch needs an absmax reduction at all.
+    ///
+    /// Every pre-freeze batch is observed (that is the whole point of the
+    /// window). After the freeze only the periodic probe runs, and only to feed
+    /// the opt-in EMA path.
+    pub(super) fn should_observe(&self, num_tokens: usize) -> bool {
+        !self.frozen || self.tokens_seen % POST_FREEZE_OBSERVE_PERIOD < num_tokens
+    }
+
+    /// Fold one observation into the window and decide what happens to the
+    /// batch it came from.
+    ///
+    /// The freeze uses the amax over EVERY token in the window, this batch
+    /// included, so a single 300-token first request freezes on all 300 rather
+    /// than on a prefix of them — and a 13-token readiness probe followed by a
+    /// 243-token request freezes on the max of both.
+    pub(super) fn record(&mut self, k_max: f32, v_max: f32, num_tokens: usize) -> CalibrationStep {
+        self.k_running_max = self.k_running_max.max(k_max);
+        self.v_running_max = self.v_running_max.max(v_max);
+        self.tokens_seen += num_tokens;
+
+        if self.frozen {
+            return CalibrationStep::Frozen;
+        }
+        if self.tokens_seen < self.window_tokens {
+            self.staged_tokens += num_tokens;
+            self.staged_batches += 1;
+            return CalibrationStep::Stage;
+        }
+
+        // `headroom >= 1.0` (CLI-validated, clamped again in the glue), so the
+        // frozen scale can never quantize the window's own amax into clipping:
+        // `k_scale * 448 == k_running_max * headroom >= k_running_max`.
+        self.k_scale = (self.k_running_max * self.headroom / FP8_E4M3_MAX).max(MIN_SCALE);
+        self.v_scale = (self.v_running_max * self.headroom / FP8_E4M3_MAX).max(MIN_SCALE);
+        self.frozen = true;
+        CalibrationStep::Freeze {
+            k_scale: self.k_scale,
+            v_scale: self.v_scale,
+            tokens_seen: self.tokens_seen,
+        }
+    }
+
+    /// Opt-in post-freeze EMA nudge (`ATLAS_FP8_KV_EMA_RECAL=1`).
+    ///
+    /// Default OFF and deliberately so: moving a frozen scale re-bases every
+    /// already-written cache entry. Kept because the flag is documented.
+    pub(super) fn ema_recalibrate(&mut self, k_max: f32, v_max: f32) {
+        let new_k = (k_max / FP8_E4M3_MAX).max(MIN_SCALE);
+        let new_v = (v_max / FP8_E4M3_MAX).max(MIN_SCALE);
+        let k_shift = (new_k - self.k_scale).abs() / self.k_scale.max(MIN_SCALE);
+        let v_shift = (new_v - self.v_scale).abs() / self.v_scale.max(MIN_SCALE);
+        let alpha = if k_shift > 0.2 || v_shift > 0.2 {
+            0.3
+        } else {
+            0.1
+        };
+        self.k_scale = (1.0 - alpha) * self.k_scale + alpha * new_k;
+        self.v_scale = (1.0 - alpha) * self.v_scale + alpha * new_v;
+        self.k_running_max = k_max;
+        self.v_running_max = v_max;
+    }
+}
+
+#[cfg(test)]
+#[path = "state_tests.rs"]
+mod state_tests;

--- a/crates/spark-model/src/layers/fp8_calibration/state_tests.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/state_tests.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Atlas #919 regression tests for the FP8 KV calibration state machine.
+//!
+//! Red before the fix: pre-#919 `record` froze unconditionally on its first
+//! call, so every `freeze_at_*` case below returned `Freeze` after 13 tokens
+//! with the amax of those 13 tokens only.
+
+use super::{CalibrationState, CalibrationStep, FP8_E4M3_MAX};
+
+/// `--fp8-kv-calibration-tokens 256` with the H100 readiness probe in front of
+/// the real request: the 13-token probe must COUNT but must not freeze, and the
+/// frozen scale must see the larger amax that only the second request exposed.
+#[test]
+fn readiness_probe_counts_toward_the_window_but_does_not_freeze_it() {
+    let mut st = CalibrationState::new(256, 1.0, 2.0);
+
+    // The readiness probe: 13 tokens, small activations.
+    assert_eq!(st.record(1.0, 0.5, 13), CalibrationStep::Stage);
+    assert!(
+        !st.frozen,
+        "a 13-token probe must not end a 256-token window"
+    );
+    assert_eq!(st.tokens_seen, 13);
+    assert_eq!(
+        st.k_scale, 2.0,
+        "provisional scale stays live while staging"
+    );
+
+    // The real request completes the window and carries the true dynamic range.
+    let step = st.record(8.0, 4.0, 243);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 8.0 / FP8_E4M3_MAX,
+            v_scale: 4.0 / FP8_E4M3_MAX,
+            tokens_seen: 256,
+        },
+        "the freeze must use the amax over all 256 observed tokens"
+    );
+    assert_eq!(st.staged_tokens, 13, "only the probe needed staging");
+    assert_eq!(st.staged_batches, 1);
+}
+
+/// A single request longer than the window freezes at the window, on the amax
+/// of the whole batch that crossed it — not on a 256-token prefix of it, and
+/// not on the first 13 tokens.
+#[test]
+fn a_single_oversized_first_request_freezes_on_all_of_it() {
+    let mut st = CalibrationState::new(256, 1.0, 2.0);
+    let step = st.record(6.0, 3.0, 300);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 6.0 / FP8_E4M3_MAX,
+            v_scale: 3.0 / FP8_E4M3_MAX,
+            tokens_seen: 300,
+        }
+    );
+    assert_eq!(
+        st.staged_tokens, 0,
+        "the batch that crosses the window is written at the frozen scale, \
+         so it never needs staging or a rewrite"
+    );
+}
+
+/// Many small requests still reach the window; the freeze fires on the observe
+/// that crosses it, and every earlier batch is staged for requantization.
+#[test]
+fn many_small_requests_accumulate_across_the_window() {
+    let mut st = CalibrationState::new(64, 1.0, 2.0);
+    for i in 0..7 {
+        assert_eq!(
+            st.record(1.0 + i as f32, 1.0, 9),
+            CalibrationStep::Stage,
+            "batch {i} is inside the window"
+        );
+    }
+    assert_eq!(st.tokens_seen, 63);
+    let step = st.record(2.0, 9.0, 1);
+    assert_eq!(
+        step,
+        CalibrationStep::Freeze {
+            k_scale: 7.0 / FP8_E4M3_MAX,
+            v_scale: 9.0 / FP8_E4M3_MAX,
+            tokens_seen: 64,
+        },
+        "K keeps the largest earlier max, V picks up the crossing batch's"
+    );
+    assert_eq!(st.staged_tokens, 63);
+    assert_eq!(st.staged_batches, 7);
+}
+
+/// A 1-token window is the pre-#919 behaviour, kept as the explicit
+/// "freeze immediately" mode: freeze on the first observe, stage nothing.
+#[test]
+fn a_one_token_window_freezes_immediately_like_before() {
+    let mut st = CalibrationState::new(1, 1.0, 2.0);
+    assert!(matches!(
+        st.record(3.0, 2.0, 13),
+        CalibrationStep::Freeze { .. }
+    ));
+    assert_eq!(st.staged_tokens, 0);
+    assert_eq!(st.staged_batches, 0);
+}
+
+/// `window_tokens` is clamped to 1, so a 0 that slipped past the CLI cannot
+/// produce a never-freezing calibrator (which would pin CUDA graphs eager for
+/// the life of the process — see `graphs_ready_after_fp8_kv_cal`).
+#[test]
+fn a_zero_window_is_clamped_and_still_freezes() {
+    let mut st = CalibrationState::new(0, 1.0, 2.0);
+    assert_eq!(st.window_tokens, 1);
+    assert!(matches!(
+        st.record(3.0, 2.0, 1),
+        CalibrationStep::Freeze { .. }
+    ));
+}
+
+/// The frozen scale must never be able to clip the very data it was calibrated
+/// on: `scale * 448 >= amax` for every observation in the window.
+#[test]
+fn the_frozen_scale_never_shrinks_below_the_pre_freeze_amax() {
+    for headroom in [1.0_f32, 1.25, 2.0] {
+        let mut st = CalibrationState::new(32, headroom, 2.0);
+        let ks = [0.5_f32, 11.0, 3.0, 7.5];
+        let vs = [9.0_f32, 1.0, 2.0, 0.25];
+        for i in 0..3 {
+            assert_eq!(st.record(ks[i], vs[i], 8), CalibrationStep::Stage);
+        }
+        let CalibrationStep::Freeze {
+            k_scale, v_scale, ..
+        } = st.record(ks[3], vs[3], 8)
+        else {
+            panic!("must freeze at the window");
+        };
+        let k_amax = ks.iter().copied().fold(0.0_f32, f32::max);
+        let v_amax = vs.iter().copied().fold(0.0_f32, f32::max);
+        assert!(
+            k_scale * FP8_E4M3_MAX >= k_amax,
+            "headroom {headroom}: k_scale {k_scale} clips the window's own amax {k_amax}"
+        );
+        assert!(
+            v_scale * FP8_E4M3_MAX >= v_amax,
+            "headroom {headroom}: v_scale {v_scale} clips the window's own amax {v_amax}"
+        );
+    }
+}
+
+/// Once frozen the scale is constant: that is the write/read invariant the
+/// whole staging + replay design exists to protect.
+#[test]
+fn later_observes_never_move_a_frozen_scale() {
+    let mut st = CalibrationState::new(16, 1.0, 2.0);
+    let CalibrationStep::Freeze {
+        k_scale, v_scale, ..
+    } = st.record(4.0, 2.0, 16)
+    else {
+        panic!("must freeze at the window");
+    };
+    for _ in 0..40 {
+        assert_eq!(st.record(400.0, 400.0, 16), CalibrationStep::Frozen);
+    }
+    assert_eq!((st.k_scale, st.v_scale), (k_scale, v_scale));
+}
+
+/// Every pre-freeze batch must be observed — a batch that skipped the absmax
+/// would also skip staging, leaving cache entries nothing can rewrite.
+#[test]
+fn every_pre_freeze_batch_is_observed() {
+    let mut st = CalibrationState::new(1024, 1.0, 2.0);
+    for _ in 0..50 {
+        assert!(st.should_observe(3));
+        st.record(1.0, 1.0, 3);
+    }
+    assert!(!st.frozen);
+}

--- a/crates/spark-model/src/layers/fp8_calibration/tests.rs
+++ b/crates/spark-model/src/layers/fp8_calibration/tests.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! GPU-glue tests for [`super::Fp8KvCalibration`]. The freeze DECISION is
+//! tested without a GPU in `state_tests.rs`; these cover the wiring around it.
+
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend};
+
+use super::{Fp8KvCalibration, Fp8KvWriteTarget};
+
+fn compact_source(src: &str) -> String {
+    src.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+/// Kernel-arg count of `reshape_and_cache_fp8`.
+const RESHAPE_FP8_ARGS: usize = 13;
+
+fn reshape_fp8_launches(gpu: &MockGpuBackend) -> usize {
+    gpu.launches_snapshot()
+        .iter()
+        .filter(|l| l.args.len() == RESHAPE_FP8_ARGS)
+        .count()
+}
+
+const NKV: u32 = 4;
+const HD: u32 = 32;
+
+fn target(gpu: &MockGpuBackend, slot: DevicePtr) -> Fp8KvWriteTarget {
+    Fp8KvWriteTarget {
+        kernel: gpu
+            .kernel("reshape_and_cache", "reshape_and_cache_fp8")
+            .unwrap(),
+        k_pool: gpu.alloc(1 << 16).unwrap(),
+        v_pool: gpu.alloc(1 << 16).unwrap(),
+        block_size: 16,
+        cache_stride: (16 * NKV * HD) as u64,
+        key_stride: NKV * HD,
+        value_stride: NKV * HD,
+        slot,
+    }
+}
+
+/// Atlas #919, the reported shape: a 13-token readiness probe must NOT end a
+/// 256-token calibration window. Red before the fix — the calibrator froze on
+/// the first observe, so `is_calibrating()` was already false here.
+#[test]
+fn a_readiness_probe_does_not_end_a_256_token_window() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(0, 256, 2.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(256 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    cal.observe(&gpu, k, v, 13, NKV, HD, stream, &tgt)
+        .expect("probe observe");
+    assert!(
+        cal.is_calibrating(),
+        "a 13-token probe froze a 256-token window (#919)"
+    );
+    assert_eq!(
+        cal.scales(),
+        (super::PROVISIONAL_SCALE, super::PROVISIONAL_SCALE),
+        "the window's own writes use the provisional scale"
+    );
+
+    cal.observe(&gpu, k, v, 243, NKV, HD, stream, &tgt)
+        .expect("second observe");
+    assert!(!cal.is_calibrating(), "the window must close at 256 tokens");
+}
+
+/// The freeze requantizes the staged window through `reshape_and_cache_fp8`
+/// before the caller writes the crossing batch, and frees its staging buffers.
+#[test]
+fn the_freeze_replays_the_staged_window_and_releases_its_buffers() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(3, 64, 1.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(64 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    for _ in 0..3 {
+        cal.observe(&gpu, k, v, 16, NKV, HD, stream, &tgt)
+            .expect("staged observe");
+    }
+    let before = gpu.alloc_count();
+    // The mock hands out one KernelHandle for every lookup, so the requantizing
+    // writes are told apart from the absmax reductions by arity:
+    // `reshape_and_cache_fp8` takes 13 kernel args, `bf16_absmax` takes 3.
+    let replays_before = reshape_fp8_launches(&gpu);
+
+    cal.observe(&gpu, k, v, 16, NKV, HD, stream, &tgt)
+        .expect("crossing observe");
+
+    let replays = reshape_fp8_launches(&gpu) - replays_before;
+    assert_eq!(
+        replays, 3,
+        "one requantizing write per staged batch, in write order"
+    );
+    assert!(
+        gpu.alloc_count() < before,
+        "staging buffers must be freed at the freeze"
+    );
+}
+
+/// A window of 1 is the explicit "freeze immediately" mode: nothing is staged,
+/// so the freeze replays nothing.
+#[test]
+fn a_one_token_window_stages_nothing() {
+    let gpu = MockGpuBackend::new();
+    let cal = Fp8KvCalibration::new(0, 1, 2.0, &gpu).expect("mock construct");
+    let k = gpu.alloc(1 << 16).expect("k buf");
+    let v = gpu.alloc(1 << 16).expect("v buf");
+    let slot = gpu.alloc(64 * 8).expect("slot buf");
+    let tgt = target(&gpu, slot);
+    let stream = gpu.default_stream();
+
+    let before = gpu.alloc_count();
+    cal.observe(&gpu, k, v, 13, NKV, HD, stream, &tgt)
+        .expect("observe");
+    assert!(!cal.is_calibrating());
+    assert_eq!(
+        gpu.alloc_count(),
+        before,
+        "freeze-on-first-observe must not allocate staging"
+    );
+}
+
+#[test]
+fn only_plain_fp8_kv_runs_online_calibration() {
+    use spark_runtime::kv_cache::KvCacheDtype as D;
+    assert!(super::dtype_runs_online_fp8_kv_calibration(D::Fp8));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Bf16));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Nvfp4));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Turbo8));
+    assert!(!super::dtype_runs_online_fp8_kv_calibration(D::Fp8KTurbo4V));
+}
+
+#[test]
+fn graphs_ready_vacuous_when_no_calibrator() {
+    assert!(super::graphs_ready_after_fp8_kv_cal([None, None]));
+}
+
+#[test]
+fn graphs_ready_blocked_while_any_calibrator_is_warm() {
+    assert!(!super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(false),
+        Some(true)
+    ]));
+}
+
+#[test]
+fn graphs_ready_when_every_calibrator_frozen() {
+    assert!(super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(true),
+        Some(true)
+    ]));
+}
+
+#[test]
+fn graphs_stay_blocked_when_a_warm_layer_follows_a_frozen_layer() {
+    assert!(!super::graphs_ready_after_fp8_kv_cal([
+        None,
+        Some(true),
+        Some(false),
+        None
+    ]));
+}
+
+#[test]
+fn attention_init_gates_calibrator_on_tokens_and_plain_fp8() {
+    let src = compact_source(include_str!("../qwen3_attention/init.rs"));
+    assert!(
+        src.contains(
+            "fp8_calibration:iffp8_calibration_tokens>0&&crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype){Some(Fp8KvCalibration::new("
+        ),
+        "the attention initializer must require enabled tokens and an observing KV dtype"
+    );
+}
+
+#[test]
+fn decode_uses_shared_calibration_readiness() {
+    let src = compact_source(include_str!("../../model/trait_impl/decode_a.rs"));
+    assert!(
+        src.contains(
+            "fnfp8_calibration_frozen(&self)->bool{crate::layers::fp8_calibration::graphs_ready_after_fp8_kv_cal(self.layers.iter().map(|l|l.fp8_calibration_frozen()),)}"
+        ),
+        "decode readiness must aggregate every layer through the shared policy"
+    );
+}
+
+#[test]
+fn fused_verify_unsuppress_matches_decode_frozen_flag() {
+    let src = compact_source(include_str!("../../model/trait_impl/verify_fused.rs"));
+    assert!(
+        src.contains(
+            "&&self.fp8_calibration_frozen(){self.suppress_graphs.store(false,std::sync::atomic::Ordering::Relaxed);"
+        ),
+        "fused verify must unsuppress graphs from the frozen-state predicate"
+    );
+    assert!(
+        !src.contains("calibration_tokens+10"),
+        "old token-count gate kept fused verify eager for ~266 tokens"
+    );
+}

--- a/crates/spark-model/src/layers/ops/dispatch_proj.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_proj.rs
@@ -229,34 +229,38 @@ pub fn cublas_fp8_m_pad(m: u32) -> u32 {
     m.div_ceil(16) * 16
 }
 
-/// Dequantize a block-scaled FP8 weight `[N,K]` → BF16 on-GPU once, cached by the
-/// FP8 weight pointer (weights are immutable after load). 128×128 blocks + FP32
-/// scales (the holo layout). Backs [`cublas_bf16_proj`].
-fn dequant_fp8_bf16_cached(
+/// Dequantize a block-scaled OR per-row FP8 weight `[N,K]` → BF16 into a
+/// CALLER-OWNED buffer of `n*k*2` bytes. Allocates nothing.
+///
+/// The kernel reads `scale[(n / block_n) * sk + (k / block_k)]`, so the SAME
+/// kernel serves both layouts — the block geometry is what selects between
+/// them, not a second kernel:
+///
+///   block-scaled   block_n = block_k = 128, sk = K/128
+///   PER-ROW        block_n = 1, block_k = K, sk = 1
+///                  -> offset = n * 1 + 0 = n, one multiplier per row
+///
+/// That per-row case is what a mixed-precision compressed-tensors checkpoint
+/// ships, and dequantising it is lossless: every FP8 E4M3 value is exactly
+/// representable in BF16, so this is the fold's no-double-quant path even
+/// though the GEMM downstream is BF16.
+///
+/// SSOT for every FP8→BF16 weight expansion in this file. It takes a
+/// destination rather than producing one because the #917 H100 receipt
+/// (2026-09-11, `Qwen/Qwen3.8-27B-FP8`) was a `gpu.alloc` hidden in here:
+/// `167772160` B per GDN layer with no `BufferSizes` entry, invisible to
+/// `--gpu-memory-utilization`, which killed a 28-token prefill at layer 36
+/// with `cuMemAlloc_v2 failed: status 2`. Who owns the bytes is now the
+/// caller's decision, and the row-wise GDN arms answer it with the ledgered
+/// `buffers.take_ssm_rowwise_w_bf16` slab.
+pub fn dequant_fp8_bf16_into(
     gpu: &dyn spark_runtime::gpu::GpuBackend,
-    derived: &super::DerivedWeights,
     fp8w: &crate::weight_map::Fp8Weight,
+    dst: spark_runtime::gpu::DevicePtr,
     stream: u64,
-) -> anyhow::Result<u64> {
+) -> anyhow::Result<()> {
     use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
-    let cache_key = fp8w.weight.0;
-    if let Some(hit) = derived.get_ptr(super::Derivation::Bf16, cache_key) {
-        return Ok(hit);
-    }
     let (n, kk) = (fp8w.n, fp8w.k);
-    let out = gpu.alloc(n as usize * kk as usize * 2)?; // BF16 [N,K]
-    // The kernel reads `scale[(n / block_n) * sk + (k / block_k)]`, so the
-    // SAME kernel serves both layouts — the block geometry is what selects
-    // between them, not a second kernel:
-    //
-    //   block-scaled   block_n = block_k = 128, sk = K/128
-    //   PER-ROW        block_n = 1, block_k = K, sk = 1
-    //                  -> offset = n * 1 + 0 = n, one multiplier per row
-    //
-    // That per-row case is what a mixed-precision compressed-tensors
-    // checkpoint ships, and dequantising it here is lossless: every FP8 E4M3
-    // value is exactly representable in BF16, so this is the fold's
-    // no-double-quant path even though the GEMM downstream is BF16.
     let per_row = fp8w.scale_format == crate::weight_map::WeightQuantFormat::Fp8PerRow;
     let (block_n, block_k, sk) = if per_row {
         (1u32, kk, 1u32)
@@ -272,71 +276,70 @@ fn dequant_fp8_bf16_cached(
         .block([64, 4, 1])
         .arg_ptr(fp8w.weight)
         .arg_ptr(fp8w.row_scale)
-        .arg_ptr(out)
+        .arg_ptr(dst)
         .arg_u32(n)
         .arg_u32(kk)
         .arg_u32(block_n)
         .arg_u32(block_k)
         .arg_u32(sk)
         .arg_u32(1) // scale_is_fp32
-        .launch(stream)?;
+        .launch(stream)
+}
+
+/// BF16 bytes [`dequant_fp8_bf16_into`] writes for `fp8w`.
+pub fn dequant_fp8_bf16_bytes(fp8w: &crate::weight_map::Fp8Weight) -> usize {
+    fp8w.n as usize * fp8w.k as usize * 2
+}
+
+/// [`dequant_fp8_bf16_into`] into a FRESH allocation, memoised by FP8 weight
+/// pointer (weights are immutable after load).
+///
+/// ⚠ OFF-LEDGER. The allocation has no `spark_runtime::buffers::sizes::BufferSizes`
+/// entry, so `--gpu-memory-utilization` cannot see it — the #917 defect named
+/// on [`dequant_fp8_bf16_into`]. The last caller is [`cutlass_bf16_proj`], a
+/// benchmark-only reference path that a shipping recipe cannot reach; the GDN
+/// row-wise arms moved to the ledgered slab in
+/// `qwen3_ssm/rowwise_bf16.rs`. Do NOT add callers — take a ledgered
+/// destination and call [`dequant_fp8_bf16_into`] instead.
+fn dequant_fp8_bf16_cached(
+    gpu: &dyn spark_runtime::gpu::GpuBackend,
+    derived: &super::DerivedWeights,
+    fp8w: &crate::weight_map::Fp8Weight,
+    stream: u64,
+) -> anyhow::Result<u64> {
+    let cache_key = fp8w.weight.0;
+    if let Some(hit) = derived.get_ptr(super::Derivation::Bf16, cache_key) {
+        return Ok(hit);
+    }
+    let out = gpu.alloc(dequant_fp8_bf16_bytes(fp8w))?; // BF16 [N,K]
+    dequant_fp8_bf16_into(gpu, fp8w, out, stream)?;
     derived.insert_ptr(super::Derivation::Bf16, cache_key, out.0);
     Ok(out.0)
 }
 
+/// [`dequant_fp8_bf16_into`] into a FRESH allocation the caller FREES — the
+/// NVFP4 packer's transient, which never outlives the pack.
 fn dequant_fp8_bf16_uncached(
     gpu: &dyn spark_runtime::gpu::GpuBackend,
     fp8w: &crate::weight_map::Fp8Weight,
     stream: u64,
 ) -> anyhow::Result<spark_runtime::gpu::DevicePtr> {
-    use spark_runtime::kernel_args::{KernelLaunch, div_ceil};
-    let (n, kk) = (fp8w.n, fp8w.k);
-    let out = gpu.alloc(n as usize * kk as usize * 2)?;
-    let block = 128u32;
-    let sk = kk / block;
-    let kernel = gpu.kernel(
-        "dequant_fp8_blockscaled_bf16",
-        "dequant_fp8_blockscaled_bf16",
-    )?;
-    KernelLaunch::new(gpu, kernel)
-        .grid([div_ceil(kk, 64), div_ceil(n, 4), 1])
-        .block([64, 4, 1])
-        .arg_ptr(fp8w.weight)
-        .arg_ptr(fp8w.row_scale)
-        .arg_ptr(out)
-        .arg_u32(n)
-        .arg_u32(kk)
-        .arg_u32(block)
-        .arg_u32(block)
-        .arg_u32(sk)
-        .arg_u32(1)
-        .launch(stream)?;
+    let out = gpu.alloc(dequant_fp8_bf16_bytes(fp8w))?;
+    dequant_fp8_bf16_into(gpu, fp8w, out, stream)?;
     Ok(out)
 }
 
-/// Route a projection `out[M,N] = act[M,K] @ weightᵀ` through cuBLASLt BF16.
-/// The FP8 weight is dequantized to BF16 once (cached); W16A16 here is strictly
-/// more accurate than the blockscaled W8A8 path it replaces.
-#[allow(clippy::too_many_arguments)]
-pub fn cublas_bf16_proj(
-    gpu: &dyn spark_runtime::gpu::GpuBackend,
-    derived: &super::DerivedWeights,
-    act: spark_runtime::gpu::DevicePtr,
-    fp8w: &crate::weight_map::Fp8Weight,
-    out: spark_runtime::gpu::DevicePtr,
-    m: u32,
-    n: u32,
-    k: u32,
-    stream: u64,
-) -> anyhow::Result<()> {
-    let w_bf16 = dequant_fp8_bf16_cached(gpu, derived, fp8w, stream)?;
-    spark_runtime::cublaslt::bf16_gemm_act_weight_t(act.0, w_bf16, out.0, m, n, k, stream)
-}
-
 /// Route a projection `out[M,N] = act[M,K] @ weightᵀ` through cuBLASLt BF16 for
-/// a weight that is already native BF16 `[N,K]` (no dequant step). Used by
-/// models whose attention/shared-expert weights ship unquantized (e.g. Laguna),
-/// which can never satisfy the `as_fp8()` gate of [`cublas_bf16_proj`].
+/// a weight that is already BF16 `[N,K]`. Two kinds of caller: models whose
+/// attention/shared-expert weights ship unquantized (e.g. Laguna), and the
+/// row-wise GDN prefill arms, which hand it the ledgered BF16 dequant
+/// `qwen3_ssm/rowwise_bf16.rs` writes once per layer.
+///
+/// There is deliberately NO `cublas_bf16_proj` beside it any more — the
+/// dequant-and-cache variant that used to own the FP8→BF16 expansion is the
+/// #917 off-ledger allocation (see [`dequant_fp8_bf16_into`]). Splitting
+/// "who owns the BF16 bytes" from "multiply them" is what keeps the ledger
+/// honest: this function cannot allocate.
 pub fn cublas_bf16_proj_dense(
     act: spark_runtime::gpu::DevicePtr,
     weight_bf16: spark_runtime::gpu::DevicePtr,

--- a/crates/spark-model/src/layers/ops/dispatch_proj_rowwise.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_proj_rowwise.rs
@@ -10,10 +10,12 @@
 //! ⚠ The GEMM at the end of this path — `fp8_gemm_act_weight_t_rowwise` —
 //! returns NOT_SUPPORTED on sm_121 (measured 2026-08-15, reproduced through the
 //! block-scaled path with `ATLAS_CUBLAS_FP8=1`, so it is the GEMM and not the
-//! weights). The mixed-precision loader therefore routes through
-//! `cublas_bf16_proj` instead; see `weight_loader/qwen35_dense/rowwise_fp8.rs`.
-//! This module stays because the passthrough is what a working per-row FP8
-//! kernel would plug into.
+//! weights). The mixed-precision loader therefore routes through a ONE-TIME
+//! ledgered BF16 dequant instead (`qwen3_ssm/rowwise_bf16.rs`, #917); see
+//! `weight_loader/qwen35_dense/rowwise_fp8.rs`. This module stays because the
+//! passthrough is what a working per-row FP8 kernel would plug into — and it
+//! is the route that would retire that BF16 slab, since a per-row checkpoint
+//! reaches `fp8_gemm_act_weight_t_rowwise` with no conversion and no copy.
 
 // Everything here names its paths explicitly (`super::DerivedWeights`,
 // `crate::weight_map::…`), so this file needs no glob import — unlike

--- a/crates/spark-model/src/layers/qwen3_attention/decode/write_kv_cache.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/decode/write_kv_cache.rs
@@ -467,8 +467,34 @@ impl Qwen3AttentionLayer {
             ),
             _ => {
                 // FP8 KV cache
+                // #919: `observe` accumulates the amax over the requested
+                // `--fp8-kv-calibration-tokens` window ACROSS requests and,
+                // when the window closes, requantizes the entries the window
+                // wrote — so it needs to know where this write is going. It
+                // runs BEFORE the write below, so `effective_fp8_scales()`
+                // returns exactly the scale this batch is about to be written
+                // with (and every later read dequantizes with).
                 if !graph_capture && let Some(ref cal) = self.fp8_calibration {
-                    cal.observe(gpu, k, v, num_tokens, num_kv_heads, head_dim, stream)?;
+                    let target = crate::layers::fp8_calibration::Fp8KvWriteTarget {
+                        kernel: self.reshape_cache_k,
+                        k_pool: kv_cache.k_pool_ptr(self.attn_layer_idx),
+                        v_pool: kv_cache.v_pool_ptr(self.attn_layer_idx),
+                        block_size,
+                        cache_stride: kv_cache.cache_stride() as u64,
+                        key_stride,
+                        value_stride,
+                        slot,
+                    };
+                    cal.observe(
+                        gpu,
+                        k,
+                        v,
+                        num_tokens,
+                        num_kv_heads,
+                        head_dim,
+                        stream,
+                        &target,
+                    )?;
                 }
                 let (k_scale, v_scale) = self.effective_fp8_scales();
                 ops::reshape_and_cache_fp8(

--- a/crates/spark-model/src/layers/qwen3_attention/init.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/init.rs
@@ -663,6 +663,7 @@ impl Qwen3AttentionLayer {
                 && crate::layers::fp8_calibration::dtype_runs_online_fp8_kv_calibration(kv_dtype)
             {
                 Some(Fp8KvCalibration::new(
+                    attn_layer_idx,
                     fp8_calibration_tokens,
                     config.fp8_kv_headroom,
                     gpu,

--- a/crates/spark-model/src/layers/qwen3_attention/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/mod.rs
@@ -33,6 +33,7 @@ pub mod innerq_driver;
 mod prefill;
 // The cuBLASLt W8A8 prefill arm that replaced `ATLAS_CUBLAS_GEMM=attn`'s
 // off-ledger BF16 weight dequant (#917 round 3 / #927).
+mod prefill_qkv_w8a8;
 mod prefill_w8a8;
 mod prefill_weights;
 mod trait_impl;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/alloc_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/alloc_tests.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Allocation contract for the two ATTENTION prefill projection chains that
+//! `ATLAS_CUBLAS_GEMM=attn` arms: the cache-skip Q/K/V chain
+//! (`cache_skip_qkv.rs`) and the paged O-projection (`paged_oproj.rs`).
+//!
+//! H100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`: both chains used to carry an arm
+//! guarded by nothing but `ctx.dispatch.cublas.attn && weight.as_fp8()` that
+//! called `ops::cublas_bf16_proj`, whose `dequant_fp8_bf16_cached` allocates a
+//! BF16 twin of the FP8 weight — 2 bytes per weight element, lazily, with no
+//! entry in `spark_runtime::buffers::sizes::BufferSizes`, so
+//! `--gpu-memory-utilization` cannot see it. That is the same leak the SSM
+//! QKVZ arm hit at `167772160` bytes PER LAYER, where 48 layers came to
+//! ~10.3 GiB and a 28-token prefill died at layer 36 with
+//! `cuMemAlloc_v2 failed: status 2` — and on the same receipt the attention
+//! arms are most of the gap between the 27 SSM layers' 4.3 GiB and the
+//! 6120 MiB actually consumed before the OOM. #927/#928 deleted both arms in
+//! favour of the W8A8 routes; these tests are what keeps them deleted, because
+//! the serve recipe for the 5..16-row decode projections is
+//! `ATLAS_CUBLAS_GEMM=ffn,ssm,attn` and arming `attn` for decode must not
+//! re-arm a prefill arm that allocates.
+//!
+//! The assertion is deliberately taken BEFORE the first call, not between the
+//! two: the old allocation was CACHED by weight pointer, so a first-vs-second
+//! comparison alone would have passed it. What is wrong is that the projection
+//! allocates at all — the arena already owns every buffer it needs.
+//!
+//! The k-major scale adapter is zeroed in both fixtures so each chain takes the
+//! in-tree kernel: a CPU test cannot enter cuBLASLt's FFI. That is the same
+//! device `qwen3_ssm::prefill_alloc_tests` uses, and it does not weaken the
+//! guard — the deleted BF16 arms sat ABOVE the W8A8 arms in both dispatch
+//! chains and had no k-major clause, so a reintroduced one fires here. The
+//! cuBLASLt arms' own clauses are pinned in `prefill_qkv_w8a8_tests.rs`, and
+//! they allocate nothing by construction (activation, scales and the k-major
+//! transpose are all arena buffers).
+
+use super::super::Qwen3AttentionLayer;
+use crate::layer::{ForwardContext, MoeLoraRoute};
+use crate::layers::FfnComponent;
+use crate::layers::ops::{CublasScope, DerivedWeights, GemmDispatch, ModelLevers, ModelStats};
+use crate::weight_map::{
+    AttentionWeights, DenseWeight, Fp8Weight, QuantWeight, QuantizedWeight, WeightQuantFormat,
+};
+use atlas_core::config::ModelConfig;
+use spark_runtime::buffers::BufferArena;
+use spark_runtime::gpu::mock::MockGpuBackend;
+use spark_runtime::gpu::{GpuBackend, KernelHandle};
+use spark_runtime::kv_cache::KvCacheDtype;
+
+/// The smoke prompt that killed the H100 run.
+const M: u32 = 28;
+const QUANT_K: KernelHandle = KernelHandle(0xA101);
+const BLOCKSCALED_K: KernelHandle = KernelHandle(0xA102);
+const W8A16_PIPELINED_K: KernelHandle = KernelHandle(0xA103);
+
+fn fp8(gpu: &MockGpuBackend, n: u32, k: u32) -> Fp8Weight {
+    Fp8Weight {
+        weight: gpu.alloc(n as usize * k as usize).unwrap(),
+        row_scale: gpu
+            .alloc((n as usize).div_ceil(128) * (k as usize).div_ceil(128) * 4)
+            .unwrap(),
+        n,
+        k,
+        scale_format: WeightQuantFormat::Fp8BlockScaled,
+    }
+}
+
+/// A full-attention layer whose Q/K/V/O weights are block-scaled FP8 — the
+/// shape class `Qwen/Qwen3.8-27B-FP8` presents and the only one that can
+/// satisfy the deleted arms' `as_fp8()` gate.
+fn native_fp8_attention_layer(gpu: &MockGpuBackend, config: &ModelConfig) -> Qwen3AttentionLayer {
+    let dense = DenseWeight {
+        weight: gpu
+            .alloc(config.hidden_size * config.hidden_size * 2)
+            .unwrap(),
+    };
+    let attn = AttentionWeights {
+        q_proj: dense,
+        k_proj: dense,
+        v_proj: dense,
+        o_proj: QuantizedWeight::null(),
+        q_norm: dense,
+        k_norm: dense,
+        q_norm_full: None,
+        k_norm_full: None,
+        k_scale: 1.0,
+        v_scale: 1.0,
+    };
+    let mut layer = Qwen3AttentionLayer::new(
+        dense,
+        attn,
+        dense,
+        FfnComponent::None,
+        0,
+        None,
+        None,
+        None,
+        gpu,
+        KvCacheDtype::Bf16,
+        0,
+        config,
+    )
+    .unwrap();
+    let h = config.hidden_size as u32;
+    let nq = config.num_attention_heads as u32;
+    let nkv = config.num_key_value_heads as u32;
+    let hd = config.head_dim as u32;
+    let q_proj_dim = if layer.gated { 2 * nq * hd } else { nq * hd };
+    layer.q_weight = Some(QuantWeight::Fp8(fp8(gpu, q_proj_dim, h)));
+    layer.k_weight = Some(QuantWeight::Fp8(fp8(gpu, nkv * hd, h)));
+    layer.v_weight = Some(QuantWeight::Fp8(fp8(gpu, nkv * hd, h)));
+    layer.o_weight = Some(QuantWeight::Fp8(fp8(gpu, h, nq * hd)));
+    // Transposed and FP8xFP8 twins stay absent so the chains resolve the arms
+    // the H100 trace actually shows (`w8a16_gemm_pipelined` for Q/K/V).
+    layer.q_fp8w_t = None;
+    layer.k_fp8w_t = None;
+    layer.v_fp8w_t = None;
+    layer.o_fp8w_t = None;
+    layer.q_fp8 = None;
+    layer.k_fp8 = None;
+    layer.v_fp8 = None;
+    layer.o_fp8 = None;
+    layer.per_token_group_quant_fp8_k = QUANT_K;
+    layer.fp8_gemm_t_blockscaled_k = BLOCKSCALED_K;
+    layer.w8a16_gemm_pipelined_k = W8A16_PIPELINED_K;
+    // See the module header: no k-major adapter -> the in-tree kernel, which a
+    // mock backend can reach and cuBLASLt's FFI cannot.
+    layer.fp8_act_scale_kmajor_k = KernelHandle(0);
+    layer
+}
+
+/// `ATLAS_CUBLAS_GEMM=attn` armed, which is what the decode recipe sets.
+fn armed_dispatch() -> GemmDispatch {
+    GemmDispatch {
+        cublas: CublasScope::ALL,
+        ..GemmDispatch::defaults()
+    }
+}
+
+macro_rules! fwd_ctx {
+    ($buffers:expr, $gpu:expr, $config:expr, $dispatch:expr, $derived:expr, $levers:expr, $stats:expr) => {
+        ForwardContext {
+            buffers: $buffers,
+            hc_row_offset: 0,
+            gpu: $gpu,
+            config: $config,
+            dispatch: $dispatch,
+            derived: $derived,
+            levers: $levers,
+            stats: $stats,
+            attn_metadata: None,
+            decode_step: false,
+            profile: false,
+            comm: None,
+            graph_capture: false,
+            gdn_exact_replay: false,
+            token_ids: None,
+            host_token_ids: None,
+            routed_lora_layers: None,
+            midchunk_capture: None,
+            moe_lora_route: MoeLoraRoute::Fold,
+        }
+    };
+}
+
+/// `paged_oproj.rs`: the O-projection must not allocate with the `attn` family
+/// armed. Before #927 this chain's second arm dequantized `o_proj`
+/// (`[h, nq*hd]`) to BF16 and cached it off-ledger.
+#[test]
+fn attention_o_projection_prefill_allocates_nothing_with_the_cublas_lever_armed() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_attention_layer(&gpu, &config);
+    let buffers = BufferArena::new(&config, 64, 4096, 16, 32, &gpu).unwrap();
+    let (dispatch, derived) = (armed_dispatch(), DerivedWeights::new());
+    let (levers, stats) = (ModelLevers::defaults(), ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &config, &dispatch, &derived, &levers, &stats
+    );
+
+    let h = config.hidden_size as u32;
+    let nq = config.num_attention_heads as u32;
+    let hd = config.head_dim as u32;
+    let run = || layer.prefill_attention_paged_oproj(buffers.attn_output(), M, h, nq, hd, &ctx, 0);
+    let (allocs, bytes) = (gpu.live_alloc_count(), gpu.live_bytes());
+    let launches = gpu.launch_count();
+    // The allocation is checked BEFORE the result is unwrapped: the deleted arm
+    // allocates and only then calls cuBLASLt, so on a mock backend the FFI error
+    // would otherwise mask the leak this test exists to name.
+    let first = run();
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the O-projection prefill allocated on its FIRST call — that is the \
+         off-ledger BF16 weight dequant from the H100 receipt (here `o_proj` \
+         [h, nq*hd] x 2 B = 16777216 bytes, per layer)"
+    );
+    first.expect("first O-projection prefill");
+    // Two launches, and the same two again: the per-token FP8 activation quant
+    // and the block-scaled GEMM. Pinned so "allocated nothing" cannot be
+    // satisfied by "did nothing", and so a future arm that slips a dequant
+    // kernel back in is visible even if it reuses a buffer.
+    assert_eq!(
+        gpu.launch_count() - launches,
+        2,
+        "expected per_token_group_quant_fp8 + fp8_gemm_t_blockscaled"
+    );
+    let second = run();
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the O-projection prefill allocated per call"
+    );
+    second.expect("second O-projection prefill");
+    assert_eq!(gpu.launch_count() - launches, 4);
+}
+
+/// `cache_skip_qkv.rs`: the chunk-0 Q/K/V chain must not allocate with the
+/// `attn` family armed. Before #927 each of the three projections had its own
+/// dequant-and-cache arm, so one armed prefill left a BF16 twin of `q_proj`,
+/// `k_proj` AND `v_proj` behind per layer.
+#[test]
+fn attention_cache_skip_qkv_prefill_allocates_nothing_with_the_cublas_lever_armed() {
+    let config = ModelConfig::qwen3_next_80b_nvfp4();
+    let gpu = MockGpuBackend::new();
+    let layer = native_fp8_attention_layer(&gpu, &config);
+    let buffers = BufferArena::new(&config, 64, 4096, 16, 32, &gpu).unwrap();
+    let (dispatch, derived) = (armed_dispatch(), DerivedWeights::new());
+    let (levers, stats) = (ModelLevers::defaults(), ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &config, &dispatch, &derived, &levers, &stats
+    );
+
+    let h = config.hidden_size as u32;
+    let nq = config.num_attention_heads as u32;
+    let nkv = config.num_key_value_heads as u32;
+    let hd = config.head_dim as u32;
+    let q_dim = (nq * hd) as usize;
+    let q_proj_dim = if layer.gated { q_dim * 2 } else { q_dim };
+    let kv_dim = (nkv * hd) as usize;
+    let run = || {
+        layer.prefill_attention_cache_skip_qkv(
+            buffers.norm_output(),
+            spark_runtime::gpu::DevicePtr::NULL,
+            M,
+            h,
+            nkv,
+            hd,
+            q_proj_dim,
+            kv_dim,
+            M as usize,
+            2,
+            &ctx,
+            0,
+        )
+    };
+    let (allocs, bytes) = (gpu.live_alloc_count(), gpu.live_bytes());
+    let launches = gpu.launch_count();
+    // Allocation before unwrap — see the O-projection twin above.
+    let first = run();
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the Q/K/V prefill chain allocated on its FIRST call — that is the \
+         off-ledger BF16 weight dequant from the H100 receipt, once per projection"
+    );
+    first.expect("first Q/K/V prefill chain");
+    // Three launches, one per projection: `w8a16_gemm_pipelined`, the arm the
+    // round-9 nsys trace shows at 100.582 ms over 112 launches.
+    assert_eq!(
+        gpu.launch_count() - launches,
+        3,
+        "expected one w8a16_gemm_pipelined per projection"
+    );
+    let second = run();
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the Q/K/V prefill chain allocated per call"
+    );
+    second.expect("second Q/K/V prefill chain");
+    assert_eq!(gpu.launch_count() - launches, 6);
+}

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -52,6 +52,18 @@ impl Qwen3AttentionLayer {
             };
         }
 
+        // ONE decision for all three projections, then ONE activation
+        // quantization they share — see `prefill_qkv_w8a8.rs` for why it is
+        // all-or-none (k's phantom rows land in v's region and are covered by
+        // v's own write, which only holds if both take the same arm in this
+        // order) and for the nsys receipt that made it worth doing (#917/#928:
+        // q_proj 16 x 2029.2 µs + k/v 32 x 375.4 µs = 44.5 ms of a 368.3 ms
+        // 1193-token prefill, all of it W8A16).
+        let w8a8 = self.cache_skip_qkv_w8a8_selected(ctx, n, q_proj_dim as u32, nkv * hd, h);
+        self.log_cache_skip_qkv_route(ctx, w8a8);
+        if w8a8 {
+            self.cache_skip_qkv_w8a8_quant(ctx, normed, n, h, stream)?;
+        }
         let qg_out = ctx.buffers.qkv_output();
         let t0 = std::time::Instant::now();
         self.cache_skip_one_proj(
@@ -62,6 +74,7 @@ impl Qwen3AttentionLayer {
             n,
             q_proj_dim as u32,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -85,6 +98,7 @@ impl Qwen3AttentionLayer {
             n,
             nkv * hd,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -108,6 +122,7 @@ impl Qwen3AttentionLayer {
             n,
             nkv * hd,
             h,
+            w8a8,
             ctx,
             stream,
         )?;
@@ -134,6 +149,7 @@ impl Qwen3AttentionLayer {
         n: u32,
         out_dim: u32,
         h: u32,
+        w8a8: bool,
         ctx: &ForwardContext,
         stream: u64,
     ) -> Result<()> {
@@ -192,15 +208,17 @@ impl Qwen3AttentionLayer {
         // (#917 round 3). It mattered again because the 5..16-row decode
         // recipe arms `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`.
         //
-        // Unlike `paged_oproj.rs`, there is no cuBLASLt W8A8 arm to put in its
-        // place HERE: the cache-skip path writes q/k/v into three back-to-back
-        // regions of one buffer (`q_contiguous`, then `+ n*q_dim`, then
-        // `+ n*kv_dim`), and cuBLASLt writes `ceil16(M)` rows — with a prefill
-        // token count that is not a multiple of 16 the pad would cross into the
-        // NEXT projection's region. Giving this path the cuBLASLt arm needs
-        // per-region capacity accounting it does not have today, so it keeps
-        // the transposed W8A16 kernels below, which are byte-identical to what
-        // an un-armed serve already runs.
+        // THE cuBLASLt W8A8 ARM (#928). It used to be absent here — unlike
+        // `paged_oproj.rs` — because this path writes q/k/v into back-to-back
+        // regions of two arena buffers and cuBLASLt writes `ceil16(M)` rows, so
+        // `k`'s pad crosses into `v`'s region. `prefill_qkv_w8a8.rs` now does
+        // the per-region capacity accounting that was missing, and shows why
+        // the k->v overlap is benign (v is written after k, and its real rows
+        // cover k's pad whenever `m >= 16`, which the selector requires). The
+        // decision and the single shared activation quantization are made once
+        // per chain by the caller; `w8a8` is that decision.
+        } else if w8a8 && let Some(fp8w) = weight_opt.and_then(|w| w.as_fp8()) {
+            self.cache_skip_qkv_w8a8_gemm(ctx, fp8w, out, n, out_dim, h, stream)?;
         } else if let Some(fp8t) = fp8w_t
             && use_t_pipelined
             && self.w8a16_gemm_t_pipelined_k.0 != 0

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/cache_skip_qkv.rs
@@ -207,6 +207,10 @@ impl Qwen3AttentionLayer {
         // cost the SSM QKVZ arm ~10.3 GiB and killed a 28-token H100 prefill
         // (#917 round 3). It mattered again because the 5..16-row decode
         // recipe arms `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`.
+        // `alloc_tests.rs` drives this chain on a mock backend with the `attn`
+        // family armed and fails if it allocates at all, on the FIRST call —
+        // the dequant was cached by weight pointer, so a first-vs-second
+        // comparison alone would pass it.
         //
         // THE cuBLASLt W8A8 ARM (#928). It used to be absent here — unlike
         // `paged_oproj.rs` — because this path writes q/k/v into back-to-back

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/mod.rs
@@ -11,6 +11,11 @@
 //! helper method with 10-20 args — multi-day kernel-level surgery
 //! beyond this wave's scope.
 
+// The allocation contract for the two chains `ATLAS_CUBLAS_GEMM=attn` arms
+// (#917 round 3 / #927): neither may allocate a BF16 weight dequant the buffer
+// ledger cannot see.
+#[cfg(test)]
+mod alloc_tests;
 mod cache_skip;
 mod cache_skip_mla;
 mod cache_skip_qkv;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_oproj.rs
@@ -85,6 +85,10 @@ impl Qwen3AttentionLayer {
         // `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`. The W8A8 arm below IS the
         // replacement: it now routes to cuBLASLt when `attn` is armed, with no
         // dequant and no allocation (`prefill_w8a8.rs`).
+        // `alloc_tests.rs` drives this chain on a mock backend with the `attn`
+        // family armed and fails if it allocates at all — the assertion is taken
+        // BEFORE the first call, because the dequant was cached by weight
+        // pointer and a first-vs-second comparison alone would pass it.
         } else if force_w8a8
             && let Some(fp8w) = self.o_weight.as_ref().and_then(|w| w.as_fp8())
             && self.per_token_group_quant_fp8_k.0 != 0

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! W8A8 block-scaled cuBLASLt arm for the **cache-skip Q/K/V PREFILL** chain —
+//! the `ATLAS_CUBLAS_GEMM=attn` route for chunk 0 of a prefill, which
+//! `prefill_w8a8.rs` (o_proj) and `paged_qkv.rs` (later chunks) left behind.
+//!
+//! WHY THIS EXISTS (#917 / #928). nsys on 1xH100, 2026-09-11 round 9,
+//! `Qwen/Qwen3.8-27B-FP8`, recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`
+//! (`nsys-r9-prefill`). In the 368.263 ms GPU-busy union of a 1193-token
+//! prefill, `w8a16_gemm_pipelined` is 100.582 ms over 112 launches and
+//! `w8a16_gemm_t_m128` a further 12.012 ms over 32. Resolving them by launch
+//! geometry — `w8a16_gemm_pipelined`'s grid is `(ceil(N/32), ceil(M/128))`,
+//! `w8a16_gemm_n128_m128`'s is `(ceil(N/128), ceil(M/128))` — names the sites:
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | **`q_proj`, this chain** | 32 466.8 |
+//! | 32 | 8x10 | N=1024 K=5120 M=1168 | **`k_proj`+`v_proj`, this chain** | 12 012.2 |
+//!
+//! i.e. one pass per attention layer (16 of them) over the FIRST prefill chunk,
+//! **44.5 ms** of the 1193-token TTFT. The *later* chunks of the same prefill
+//! go through `paged_qkv.rs`, whose W8A8 arm the trace does show
+//! (`fp8_gemm_t_blockscaled`, 48 launches at M=25) — so the split was never
+//! "attention has no W8A8", it was "chunk 0 has no W8A8".
+//!
+//! WHY IT WAS EXCLUDED, and what changed. `cache_skip_one_proj` documented the
+//! reason in place: the three projections write into two arena buffers as
+//! back-to-back regions (`q` alone in `qkv_output`; `k` at `ssm_qkvz` + 0 and
+//! `v` at `ssm_qkvz + num_tokens*kv_dim`), and cuBLASLt writes `ceil16(M)`
+//! rows, so `k`'s padded rows land inside `v`'s region. THE CHOICE MADE HERE is
+//! per-region capacity accounting rather than a padded scratch + copy, because
+//! the overlap is provably benign and a copy would cost a full `[M, kv_dim]`
+//! D2D per projection per layer:
+//!
+//!   * `q` is alone in `qkv_output`; it only needs `ceil16(M) * q_proj_dim`
+//!     BF16 of room, which `sizes.rs` now allocates.
+//!   * `k` runs BEFORE `v` on the same stream, so `k`'s phantom rows
+//!     (`M..ceil16(M)`, at most 15) land in `v`'s region and are then
+//!     OVERWRITTEN by `v`'s own write. With the `m >= 16` clause below,
+//!     `ceil16(M) - M <= 15 < M`, so `v`'s REAL rows cover every one of them —
+//!     no reader ever sees `k`'s pad.
+//!   * `v`'s own phantom rows are the only ones that survive, at the tail, so
+//!     the buffer must hold `(M + ceil16(M)) * kv_dim` BF16. That is the clause
+//!     `ssm_qkvz` is checked against, and the extent `sizes.rs` now allocates.
+//!
+//! Both buffers are bounds-checked at dispatch: if either is too small the
+//! whole chain falls back to the W8A16 kernels, which is what an un-armed serve
+//! runs byte for byte.
+//!
+//! WHAT ELSE IT BUYS. The three projections share one `normed` input, so the
+//! activation is quantized ONCE for all three instead of once per projection —
+//! `paged_qkv.rs` re-quantizes per projection, which the same trace shows as
+//! three `per_token_group_quant_fp8` launches per attention layer.
+//!
+//! ACCURACY. W8A8 quantizes the activation to E4M3 per 128-wide K group and is
+//! lossier than W8A16 by construction — the same deliberate trade the o_proj,
+//! SSM and dense-FFN prefills already made.
+//! `native_fp8_prefill_proj_w8a8_microtest` gates it at cosine >= 0.999 /
+//! rel_rms <= 3e-2 against the W8A16 reference at these shapes.
+//! `ATLAS_ATTN_QKV_W8A16_ONLY` (presence) restores W8A16.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+use super::Qwen3AttentionLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// `ATLAS_ATTN_QKV_W8A16_ONLY` kill switch: PRESENCE (any value, including
+/// empty) keeps the cache-skip Q/K/V prefill on the W8A16 kernels. Presence
+/// rather than `=1`, matching `ATLAS_FFN_W8A16_ONLY` — an escape hatch whose
+/// `=0` spelling must not mean "on".
+pub(super) fn attn_qkv_w8a16_only() -> bool {
+    static ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ONLY.get_or_init(|| std::env::var_os("ATLAS_ATTN_QKV_W8A16_ONLY").is_some())
+}
+
+/// The three destination extents this chain writes, in BF16 elements, given
+/// `m` real rows and the cuBLASLt pad. SSOT for both the selector's capacity
+/// clauses and the module header's argument above.
+///
+/// Returns `(q_elems_in_qkv_output, kv_elems_in_ssm_qkvz)`.
+pub(super) fn cache_skip_qkv_extents(m: u32, q_proj_dim: u32, kv_dim: u32) -> (usize, usize) {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    // `v` starts at row `m` of its buffer and writes `m_pad` rows from there.
+    (
+        m_pad * q_proj_dim as usize,
+        (m as usize + m_pad) * kv_dim as usize,
+    )
+}
+
+/// Whether the WHOLE cache-skip Q/K/V chain takes the cuBLASLt W8A8 arm, as a
+/// pure function so the CPU tests can pin each clause without a GPU.
+///
+/// All three projections or none: the phantom-row argument in the module header
+/// depends on `k` and `v` both going through the same arm in the same order, so
+/// a per-projection decision would be a correctness hazard, not a refinement.
+///
+/// Clauses, each load-bearing:
+///
+/// * `!w8a16_only` — the kill switch above.
+/// * `cublas_attn` — `ATLAS_CUBLAS_GEMM` must name the `attn` family.
+/// * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch.
+/// * `m >= 16` — the covering argument for `k`'s phantom rows (header). It is
+///   stricter than the `m > 4` floor the other prefill arms use, and it is the
+///   clause that makes the shared-buffer overlap safe rather than merely
+///   in-bounds.
+/// * all three weights `Fp8BlockScaled` — cuBLASLt is told the weight scales
+///   are a `[N/128, K/128]` grid; a per-row `row_scale` would be read as
+///   garbage.
+/// * `q_n % 128 == 0`, `kv_n % 128 == 0`, `k % 128 == 0` — that grid, and the
+///   activation quantizer's one-scale-per-128-of-K contract.
+/// * `blk128x128_stride_ok(k)` (`k % 512 == 0`) — cuBLAS requires the weight
+///   scale column stride `K/128` to be a multiple of 4.
+/// * room in BOTH destination buffers for the padded extents above.
+/// * activation scratch room for `ceil16(M) * K` FP8 and its scales —
+///   `cublas_fp8_proj_prequant` zeroes and reads the pad rows of both.
+/// * the quantizer kernel, and the VEC128 scale-layout adapter (kernel,
+///   scratch, capacity). Without the transpose the GEMM is fast and WRONG
+///   (H100 2026-09-11: rel_rms 7.7e-2 on identical FP8 bytes), so a missing
+///   adapter must fall back, never proceed.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn cache_skip_qkv_cublas_selected(
+    cublas_attn: bool,
+    fp8_blockscaled_prefill: bool,
+    w8a16_only: bool,
+    formats: [Option<WeightQuantFormat>; 3],
+    m: u32,
+    q_n: u32,
+    kv_n: u32,
+    k: u32,
+    qkv_output_capacity_bytes: usize,
+    ssm_qkvz_capacity_bytes: usize,
+    act_capacity_bytes: usize,
+    act_scale_capacity_bytes: usize,
+    quant_k: KernelHandle,
+    scale_kmajor_k: KernelHandle,
+    scale_kmajor_buf: DevicePtr,
+    scale_kmajor_capacity_bytes: usize,
+) -> bool {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    let kg = k as usize / 128;
+    let (q_elems, kv_elems) = cache_skip_qkv_extents(m, q_n, kv_n);
+    let kmajor_ready = scale_kmajor_k.0 != 0
+        && scale_kmajor_buf.0 != 0
+        && scale_kmajor_capacity_bytes >= m_pad * kg * 4;
+    !w8a16_only
+        && cublas_attn
+        && fp8_blockscaled_prefill
+        && m >= 16
+        && formats
+            .iter()
+            .all(|f| *f == Some(WeightQuantFormat::Fp8BlockScaled))
+        && q_n.is_multiple_of(128)
+        && kv_n.is_multiple_of(128)
+        && k.is_multiple_of(128)
+        && spark_runtime::cublaslt::scale_layout::blk128x128_stride_ok(k as usize)
+        && q_elems * 2 <= qkv_output_capacity_bytes
+        && kv_elems * 2 <= ssm_qkvz_capacity_bytes
+        && m_pad * (k as usize) <= act_capacity_bytes
+        && m_pad * kg * 4 <= act_scale_capacity_bytes
+        && quant_k.0 != 0
+        && (kmajor_ready || !ops::cublas_scale_layout_kmajor())
+}
+
+impl Qwen3AttentionLayer {
+    /// Whether this layer's cache-skip Q/K/V chain runs on cuBLASLt W8A8.
+    ///
+    /// `m` is the chunk's token count, `k` the hidden size all three contract
+    /// over. Called ONCE per chain, not per projection — see the all-or-none
+    /// note on [`cache_skip_qkv_cublas_selected`].
+    pub(super) fn cache_skip_qkv_w8a8_selected(
+        &self,
+        ctx: &ForwardContext,
+        m: u32,
+        q_proj_dim: u32,
+        kv_dim: u32,
+        k: u32,
+    ) -> bool {
+        let fmt = |w: Option<&crate::weight_map::QuantWeight>| {
+            w.and_then(|w| w.as_fp8()).map(|f| f.scale_format)
+        };
+        cache_skip_qkv_cublas_selected(
+            ctx.dispatch.cublas.attn,
+            ctx.dispatch.fp8_blockscaled_prefill,
+            attn_qkv_w8a16_only(),
+            [
+                fmt(self.q_weight.as_ref()),
+                fmt(self.k_weight.as_ref()),
+                fmt(self.v_weight.as_ref()),
+            ],
+            m,
+            q_proj_dim,
+            kv_dim,
+            k,
+            ctx.buffers.qkv_output_bytes(),
+            ctx.buffers.ssm_qkvz_bytes(),
+            ctx.buffers.fp8_act_bytes(),
+            ctx.buffers.fp8_act_scale_bytes(),
+            self.per_token_group_quant_fp8_k,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            ctx.buffers.fp8_act_scale_kmajor_bytes(),
+        )
+    }
+
+    /// Quantize `normed[m, k]` ONCE into the arena's `fp8_act` /
+    /// `fp8_act_scale` scratch for all three projections.
+    ///
+    /// Q, K and V share one input, so one quantization serves all three. The
+    /// chain is same-stream ordered, so the three GEMMs read it without a host
+    /// sync and nothing else writes it in between.
+    pub(super) fn cache_skip_qkv_w8a8_quant(
+        &self,
+        ctx: &ForwardContext,
+        normed: DevicePtr,
+        m: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+        debug_assert!(m_pad * k as usize <= ctx.buffers.fp8_act_bytes());
+        debug_assert!(m_pad * (k as usize / 128) * 4 <= ctx.buffers.fp8_act_scale_bytes());
+        ops::per_token_group_quant_fp8(
+            ctx.gpu,
+            self.per_token_group_quant_fp8_k,
+            normed,
+            ctx.buffers.fp8_act(),
+            ctx.buffers.fp8_act_scale(),
+            m,
+            k,
+            stream,
+        )
+    }
+
+    /// One projection of the chain: `out[m, n] = a_fp8[m, k] @ weight[n, k]ᵀ`
+    /// with both block-scale sets folded in an FP32 epilogue, through cuBLASLt.
+    ///
+    /// Consumes the activation [`Self::cache_skip_qkv_w8a8_quant`] produced;
+    /// allocates nothing. Callers MUST have checked
+    /// [`Self::cache_skip_qkv_w8a8_selected`] — this does not re-check and does
+    /// not fall back.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn cache_skip_qkv_w8a8_gemm(
+        &self,
+        ctx: &ForwardContext,
+        fp8w: &Fp8Weight,
+        out: DevicePtr,
+        m: u32,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        ops::cublas_fp8_proj_prequant(
+            ctx.gpu,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act(),
+            ctx.buffers.fp8_act_scale(),
+            ctx.buffers.fp8_act_scale_kmajor(),
+            fp8w,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        )
+    }
+
+    /// Log-once route line for the cache-skip Q/K/V prefill, emitted from BOTH
+    /// arms so the absence of the W8A8 line is never ambiguous between "not
+    /// armed" and "log lost".
+    pub(super) fn log_cache_skip_qkv_route(&self, ctx: &ForwardContext, cublas: bool) {
+        if ctx.stats.once("log:attn_cache_skip_qkv_prefill") {
+            if cublas {
+                tracing::info!(
+                    "[atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A8 block-scaled \
+                     via cuBLASLt, activation quantized once for all three \
+                     (per-token 1x128 act scales x 128x128 weight scales, FP32 epilogue). \
+                     ATLAS_CUBLAS_GEMM=attn selected it; ATLAS_ATTN_QKV_W8A16_ONLY restores \
+                     W8A16. This arm allocates nothing."
+                );
+            } else {
+                tracing::info!(
+                    "[atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A16 \
+                     (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `attn` to \
+                     ATLAS_CUBLAS_GEMM; see #917/#928."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "prefill_qkv_w8a8_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill_qkv_w8a8_tests.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Clause-by-clause contract for the cache-skip Q/K/V prefill cuBLASLt arm,
+//! plus the buffer-extent arithmetic the phantom-row argument rests on. Every
+//! selection case defaults to SELECTING and perturbs exactly one thing, so a
+//! failure names the clause.
+
+use super::{cache_skip_qkv_cublas_selected, cache_skip_qkv_extents};
+use crate::layers::ops::cublas_fp8_m_pad;
+use crate::weight_map::WeightQuantFormat;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+/// Qwen3.8-27B attention: hidden 5120, gated `q_proj` 12288 `[Q|gate]`,
+/// kv 1024. The shapes the round-9 H100 trace shows at grid 384x10 (q) and
+/// 8x10 (k, v) on chunk 0 of the 1193-token prompt.
+const H: u32 = 5120;
+const Q_N: u32 = 12288;
+const KV_N: u32 = 1024;
+const M: u32 = 1168;
+const QUANT_K: KernelHandle = KernelHandle(0xBEEF);
+const KMAJOR_K: KernelHandle = KernelHandle(0xC0DE);
+const KMAJOR_BUF: DevicePtr = DevicePtr(0x1000);
+const BLK: Option<WeightQuantFormat> = Some(WeightQuantFormat::Fp8BlockScaled);
+
+fn m_pad(m: u32) -> usize {
+    cublas_fp8_m_pad(m) as usize
+}
+
+fn caps(m: u32) -> (usize, usize, usize, usize) {
+    let (q_elems, kv_elems) = cache_skip_qkv_extents(m, Q_N, KV_N);
+    (
+        q_elems * 2,
+        kv_elems * 2,
+        m_pad(m) * H as usize,
+        m_pad(m) * (H as usize / 128) * 4,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn selected(
+    cublas_attn: bool,
+    blockscaled: bool,
+    w8a16_only: bool,
+    formats: [Option<WeightQuantFormat>; 3],
+    m: u32,
+    q_n: u32,
+    kv_n: u32,
+    k: u32,
+    qkv_cap: usize,
+    qkvz_cap: usize,
+    act_cap: usize,
+    act_scale_cap: usize,
+    quant_k: KernelHandle,
+    kmajor_k: KernelHandle,
+    kmajor_buf: DevicePtr,
+    kmajor_cap: usize,
+) -> bool {
+    cache_skip_qkv_cublas_selected(
+        cublas_attn,
+        blockscaled,
+        w8a16_only,
+        formats,
+        m,
+        q_n,
+        kv_n,
+        k,
+        qkv_cap,
+        qkvz_cap,
+        act_cap,
+        act_scale_cap,
+        quant_k,
+        kmajor_k,
+        kmajor_buf,
+        kmajor_cap,
+    )
+}
+
+fn ready_at(m: u32) -> bool {
+    let (q, kv, a, s) = caps(m);
+    selected(
+        true,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        m,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    )
+}
+
+/// `v` starts at row `m` and writes `ceil16(m)` rows, so the furthest byte is
+/// `(m + ceil16(m)) * kv_dim` — the number the `ssm_qkvz` clause checks and the
+/// number `sizes.rs` allocates. Pinned here because the whole phantom-row
+/// argument in the module header is this arithmetic.
+#[test]
+fn extents_cover_the_furthest_padded_write() {
+    for m in [16u32, 25, 1168, 1193, 4593] {
+        let (q, kv) = cache_skip_qkv_extents(m, Q_N, KV_N);
+        assert_eq!(q, m_pad(m) * Q_N as usize);
+        assert_eq!(kv, (m as usize + m_pad(m)) * KV_N as usize);
+        // Never smaller than the pre-#928 `m * 2 * kv_dim` allocation.
+        assert!(kv >= 2 * m as usize * KV_N as usize);
+        // And k's phantom rows (m..m_pad of k's region) are inside v's region.
+        assert!(m_pad(m) <= m as usize + m_pad(m));
+    }
+}
+
+#[test]
+fn selected_at_prefill_m_with_the_attn_scope_armed() {
+    assert!(ready_at(M), "the round-9 chunk-0 shape must select");
+    assert!(ready_at(4593), "the long-prompt shape must select");
+}
+
+#[test]
+fn not_selected_without_the_attn_scope() {
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        false,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn kill_switch_refuses_even_with_the_scope_armed() {
+    // ATLAS_ATTN_QKV_W8A16_ONLY.
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        true,
+        true,
+        true,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn single_scale_kill_switch_refuses() {
+    let (q, kv, a, s) = caps(M);
+    assert!(!selected(
+        true,
+        false,
+        false,
+        [BLK, BLK, BLK],
+        M,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        kv,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+/// The clause that makes the shared-buffer overlap safe, not merely in-bounds:
+/// below 16 rows `ceil16(m) - m` can exceed `m`, so `v`'s real rows would no
+/// longer cover `k`'s phantom rows.
+#[test]
+fn fewer_than_sixteen_rows_falls_back() {
+    for m in [1u32, 5, 8, 15] {
+        assert!(!ready_at(m), "M={m} must fall back to W8A16");
+    }
+    assert!(ready_at(16));
+}
+
+/// All three or none: a chain where only some weights are block-scaled must
+/// not take the arm for the ones that are.
+#[test]
+fn every_projection_must_be_block_scaled() {
+    let (q, kv, a, s) = caps(M);
+    let case = |formats: [Option<WeightQuantFormat>; 3]| {
+        selected(
+            true, true, false, formats, M, Q_N, KV_N, H, q, kv, a, s, QUANT_K, KMAJOR_K,
+            KMAJOR_BUF, s,
+        )
+    };
+    assert!(case([BLK, BLK, BLK]));
+    let rowwise = Some(WeightQuantFormat::Fp8PerRow);
+    assert!(!case([rowwise, BLK, BLK]), "q per-row");
+    assert!(!case([BLK, rowwise, BLK]), "k per-row");
+    assert!(!case([BLK, BLK, rowwise]), "v per-row");
+    assert!(!case([None, BLK, BLK]), "q not FP8 at all");
+}
+
+#[test]
+fn shape_clauses() {
+    let (q, kv, a, s) = caps(M);
+    let case = |q_n: u32, kv_n: u32, k: u32| {
+        let (qe, kve) = cache_skip_qkv_extents(M, q_n, kv_n);
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            q_n,
+            kv_n,
+            k,
+            qe * 2,
+            kve * 2,
+            m_pad(M) * k as usize,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+        )
+    };
+    let _ = (q, kv, a, s);
+    assert!(case(Q_N, KV_N, H));
+    assert!(!case(Q_N + 64, KV_N, H), "q N must be a multiple of 128");
+    assert!(!case(Q_N, KV_N + 64, H), "kv N must be a multiple of 128");
+    assert!(!case(Q_N, KV_N, H + 64), "K must be a multiple of 128");
+    assert!(!case(Q_N, KV_N, H + 128), "K/128 must be a multiple of 4");
+}
+
+#[test]
+fn capacity_clauses_each_refuse_on_their_own() {
+    let (q, kv, a, s) = caps(M);
+    let case = |q: usize, kv: usize, a: usize, sc: usize, km: usize| {
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            Q_N,
+            KV_N,
+            H,
+            q,
+            kv,
+            a,
+            sc,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            km,
+        )
+    };
+    assert!(case(q, kv, a, s, s));
+    assert!(!case(q - 1, kv, a, s, s), "qkv_output room");
+    assert!(!case(q, kv - 1, a, s, s), "ssm_qkvz room for v's pad");
+    assert!(!case(q, kv, a - 1, s, s), "activation room");
+    assert!(!case(q, kv, a, s - 1, s), "act-scale room");
+    assert!(!case(q, kv, a, s, s - 1), "k-major room");
+}
+
+/// The pre-#928 `ssm_qkvz` sizing (`m * 2 * kv_dim`) is exactly one row short
+/// once M is not a multiple of 16, which is the whole reason `sizes.rs` moved.
+#[test]
+fn the_old_kv_sizing_is_refused_for_a_ragged_m() {
+    let m = 1193;
+    let (q, _kv, a, s) = caps(m);
+    let old = 2 * m as usize * KV_N as usize * 2;
+    assert!(!selected(
+        true,
+        true,
+        false,
+        [BLK, BLK, BLK],
+        m,
+        Q_N,
+        KV_N,
+        H,
+        q,
+        old,
+        a,
+        s,
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        s,
+    ));
+}
+
+#[test]
+fn missing_handles_fall_back() {
+    let (q, kv, a, s) = caps(M);
+    let case = |quant: KernelHandle, kmajor: KernelHandle, buf: DevicePtr| {
+        selected(
+            true,
+            true,
+            false,
+            [BLK, BLK, BLK],
+            M,
+            Q_N,
+            KV_N,
+            H,
+            q,
+            kv,
+            a,
+            s,
+            quant,
+            kmajor,
+            buf,
+            s,
+        )
+    };
+    assert!(case(QUANT_K, KMAJOR_K, KMAJOR_BUF));
+    assert!(!case(KernelHandle(0), KMAJOR_K, KMAJOR_BUF), "quantizer");
+    if crate::layers::ops::cublas_scale_layout_kmajor() {
+        assert!(!case(QUANT_K, KernelHandle(0), KMAJOR_BUF), "kmajor kernel");
+        assert!(!case(QUANT_K, KMAJOR_K, DevicePtr(0)), "kmajor scratch");
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/init.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/init.rs
@@ -46,6 +46,8 @@ impl Qwen3SsmLayer {
             out_proj_fp8w: None,
             qkvz_fp8w_rowwise: None,
             out_proj_fp8w_rowwise: None,
+            qkvz_rowwise_bf16: std::sync::atomic::AtomicU64::new(0),
+            out_proj_rowwise_bf16: std::sync::atomic::AtomicU64::new(0),
             qkvz_q2: None,
             q2_0_gemv_k: super::super::try_kernel(gpu, "q2_0_gemv_vec", "q2_0_gemv_vec"),
             dequant_q2_0_gn_k: super::super::try_kernel(

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -80,6 +80,17 @@ pub struct Qwen3SsmLayer {
     /// decode keeps the NVFP4 copy.
     qkvz_fp8w_rowwise: Option<Fp8Weight>,
     out_proj_fp8w_rowwise: Option<Fp8Weight>,
+    /// This layer's slice of the LEDGERED row-wise BF16-weight slab
+    /// (`BufferSizes::ssm_rowwise_w_bf16`), or 0 before the first prefill
+    /// through the matching arm carves and fills it. See `rowwise_bf16.rs`
+    /// for the #917 receipt that moved these bytes out of a by-pointer cache
+    /// of `gpu.alloc`s and into the arena.
+    ///
+    /// Per LAYER rather than per weight pointer, because that is what the
+    /// lifetime is: the slab is the arena's, and the arena outlives every
+    /// prefill this layer runs.
+    qkvz_rowwise_bf16: std::sync::atomic::AtomicU64,
+    out_proj_rowwise_bf16: std::sync::atomic::AtomicU64,
     /// Tier-1c keep-packed ternary Q2_0 fused in_proj_qkvz (`ATLAS_GGUF_NATIVE_Q2`).
     /// [Q|K|V|Z] rows byte-concatenated from packed `in_proj_qkv` (V-region
     /// row-permuted) + `in_proj_z` (row-permuted) at load, so the 2-bit weight is
@@ -399,6 +410,7 @@ mod kernel_select;
 mod lora;
 mod prefill_out_w8a8;
 mod prefill_w8a8;
+mod rowwise_bf16;
 mod ssm_forward;
 pub(crate) mod ssm_h_fp16;
 mod trait_decode;
@@ -432,6 +444,9 @@ pub use gdn_flags::{
 #[cfg(test)]
 #[path = "prefill_alloc_tests.rs"]
 mod prefill_alloc_tests;
+#[cfg(test)]
+#[path = "rowwise_alloc_tests.rs"]
+mod rowwise_alloc_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/spark-model/src/layers/qwen3_ssm/mod.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/mod.rs
@@ -397,6 +397,7 @@ mod init_fp8;
 mod init_q2;
 mod kernel_select;
 mod lora;
+mod prefill_out_w8a8;
 mod prefill_w8a8;
 mod ssm_forward;
 pub(crate) mod ssm_h_fp16;

--- a/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! W8A8 block-scaled cuBLASLt arm for the SSM/GDN **`out_proj` PREFILL**
+//! projection — the `ATLAS_CUBLAS_GEMM=ssm` route for the second half of the
+//! GDN block, alongside `prefill_w8a8.rs`'s `in_proj_qkvz` arm.
+//!
+//! WHY THIS EXISTS (#917 / #928). nsys on 1xH100, 2026-09-11 round 9,
+//! `Qwen/Qwen3.8-27B-FP8`, best recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`
+//! (`nsys-r9-prefill`, kernel-sum CSV). A 1193-token prefill is **368.263 ms**
+//! of GPU-busy union, and `w8a16_gemm_pipelined` is **100.582 ms = 27.31%** of
+//! it across **112 launches**. Resolved by launch geometry — the kernel's grid
+//! is `(ceil(N/32), ceil(M/128))`, so GrdX names N and GrdY names the chunk —
+//! those 112 are NOT the dense FFN (which the same trace shows on `nvjet…`
+//! cuBLASLt lines for gate/up/down at every M):
+//!
+//! | launches | grid | shape | site | µs |
+//! |---|---|---|---|---|
+//! | 48 | 160x10 | N=5120 K=6144 M=1168 | **SSM `out_proj`, chunk 0** | 54 119.7 |
+//! | 16 | 384x10 | N=12288 K=5120 M=1168 | attn `q_proj`, chunk 0 (`cache_skip_qkv.rs`) | 32 466.8 |
+//! | 48 | 160x1 | N=5120 K=6144 M=25 | **SSM `out_proj`, chunk 1** | 13 995.4 |
+//!
+//! i.e. **96 of the 112 launches and 68.1 ms of the 100.6 ms are this one
+//! projection**, once per GDN layer per prefill chunk, on all 48 GDN layers.
+//! At 4593 tokens it is 163.5 ms of the kernel's 285.5 ms.
+//!
+//! WHY IT WAS EXCLUDED. `prefill_out_proj_dispatch` had no cuBLASLt arm at all,
+//! and its only W8A8 arm was gated on a bare `ATLAS_FP8_W8A8=1` env read —
+//! **not** on `ctx.dispatch.fp8_blockscaled_prefill` (the gate the QKVZ,
+//! attention and dense-FFN prefills use) and **not** on any `ATLAS_CUBLAS_GEMM`
+//! family. So the serve recipe that armed `ssm` moved `in_proj_qkvz` to
+//! cuBLASLt and left `out_proj` — the same layer's other GEMM — on the W8A16
+//! tensor-core kernel, where BF16 activations against E4M3 weights turn the
+//! FP8 bytes into pure memory savings and none of the FLOPs.
+//!
+//! WHAT THIS ADDS. The same quantize-once + k-major-scale pattern as
+//! `prefill_w8a8.rs` / `dense_ffn_w8a8_prefill.rs` / `paged_oproj.rs`: the
+//! `per_token_group_quant_fp8` activation already on this path, re-laid-out by
+//! `fp8_act_scale_to_kmajor`, handed to `ops::cublas_fp8_proj_prequant`. No
+//! dequant, no cache, no device memory — every buffer is arena scratch that
+//! already exists. **The W8A16 kernels remain the fallback** and are what an
+//! un-armed serve still runs, byte for byte.
+//!
+//! ACCURACY. W8A8 quantizes the activation to E4M3 per 128-wide K group, so it
+//! is lossier than W8A16 by construction — the same deliberate trade the other
+//! three prefill families already made. `native_fp8_prefill_proj_w8a8_microtest`
+//! gates it at cosine >= 0.999 / rel_rms <= 3e-2 against the W8A16 reference at
+//! the real shapes. `ATLAS_SSM_OUT_W8A16_ONLY` (presence) restores W8A16.
+
+use anyhow::Result;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+use super::Qwen3SsmLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::{Fp8Weight, WeightQuantFormat};
+
+/// `ATLAS_SSM_OUT_W8A16_ONLY` kill switch: PRESENCE (any value, including
+/// empty) keeps the SSM `out_proj` prefill on the W8A16 kernels. Presence
+/// rather than `=1` for the same reason as `ATLAS_FFN_W8A16_ONLY` — this is an
+/// escape hatch reached for mid-incident, and `=0` meaning "on" is a trap.
+///
+/// `OnceLock`-cached: the selector runs once per GDN layer per prefill chunk
+/// (48x per chunk on a 27B) and `var_os` walks the whole environment block.
+pub(super) fn ssm_out_w8a16_only() -> bool {
+    static ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ONLY.get_or_init(|| std::env::var_os("ATLAS_SSM_OUT_W8A16_ONLY").is_some())
+}
+
+/// Everything the `out_proj` cuBLASLt arm needs, as a pure function so the CPU
+/// tests can pin each clause without a GPU.
+///
+/// Clauses, each load-bearing:
+///
+/// * `!w8a16_only` — the kill switch above.
+/// * `cublas_ssm` — `ATLAS_CUBLAS_GEMM` must name the `ssm` family. Scoped,
+///   deliberately: arming the dense FFN must not arm this.
+/// * `fp8_blockscaled_prefill` — the `ATLAS_FP8_SINGLE_SCALE` kill switch that
+///   already governs every other W8A8 prefill arm.
+/// * `m > 4` — the same floor `w8a8_prefill_selected` uses; at M<=4 the GEMV
+///   tier streams each weight once and beats any MMA tile.
+/// * `Fp8BlockScaled` — cuBLASLt is told the weight scales are a `[N/128,
+///   K/128]` BLK128x128 grid; a per-row `row_scale` has a different shape and
+///   would be read as garbage.
+/// * `n % 128 == 0`, `k % 128 == 0` — that grid, and the activation
+///   quantizer's one-scale-per-128-of-K contract.
+/// * `blk128x128_stride_ok(k)` (`k % 512 == 0`) — cuBLAS requires the weight
+///   scale column stride `K/128` to be a multiple of 4.
+/// * output room for `ceil16(M) * N` BF16 — the padded rows are WRITTEN.
+///   `moe_output` is already sized `ceil16(m) * hidden` (`sizes.rs`), so this
+///   is a check that a future re-sizing cannot silently invalidate.
+/// * activation scratch room for `ceil16(M) * K` FP8 and its `ceil16(M) *
+///   K/128` FP32 scales — `cublas_fp8_proj_prequant` ZEROES the pad rows of
+///   both before the matmul, so it writes past M in each.
+/// * the quantizer kernel, and the VEC128 scale-layout adapter, kernel AND
+///   scratch AND its capacity. cuBLASLt reads the activation scales
+///   token-contiguous; handing over the quantizer's `[M, K/128]` order is fast
+///   and WRONG (H100 2026-09-11: rel_rms 7.7e-2 on identical FP8 bytes).
+///   Falling back to W8A16 is the only safe answer when it is missing.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn out_proj_cublas_selected(
+    cublas_ssm: bool,
+    fp8_blockscaled_prefill: bool,
+    w8a16_only: bool,
+    scale_format: WeightQuantFormat,
+    m: u32,
+    n: u32,
+    k: u32,
+    out_capacity_bytes: usize,
+    act_capacity_bytes: usize,
+    act_scale_capacity_bytes: usize,
+    quant_k: KernelHandle,
+    scale_kmajor_k: KernelHandle,
+    scale_kmajor_buf: DevicePtr,
+    scale_kmajor_capacity_bytes: usize,
+) -> bool {
+    let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+    let kg = k as usize / 128;
+    let kmajor_ready = scale_kmajor_k.0 != 0
+        && scale_kmajor_buf.0 != 0
+        && scale_kmajor_capacity_bytes >= m_pad * kg * 4;
+    !w8a16_only
+        && cublas_ssm
+        && fp8_blockscaled_prefill
+        && m > 4
+        && scale_format == WeightQuantFormat::Fp8BlockScaled
+        && n.is_multiple_of(128)
+        && k.is_multiple_of(128)
+        && spark_runtime::cublaslt::scale_layout::blk128x128_stride_ok(k as usize)
+        && m_pad * (n as usize) * 2 <= out_capacity_bytes
+        && m_pad * (k as usize) <= act_capacity_bytes
+        && m_pad * kg * 4 <= act_scale_capacity_bytes
+        && quant_k.0 != 0
+        && (kmajor_ready || !ops::cublas_scale_layout_kmajor())
+}
+
+impl Qwen3SsmLayer {
+    /// Whether ONE SSM `out_proj` prefill takes the W8A8 cuBLASLt arm.
+    ///
+    /// `n` is the hidden size (the projection's output width) and `k` the GDN
+    /// `value_dim` it contracts over — the 5120 x 6144 of the round-9 receipt.
+    pub(super) fn prefill_out_proj_w8a8_selected(
+        &self,
+        ctx: &ForwardContext,
+        m: u32,
+        n: u32,
+        k: u32,
+        fp8w: &Fp8Weight,
+    ) -> bool {
+        out_proj_cublas_selected(
+            ctx.dispatch.cublas.ssm,
+            ctx.dispatch.fp8_blockscaled_prefill,
+            ssm_out_w8a16_only(),
+            fp8w.scale_format,
+            m,
+            n,
+            k,
+            ctx.buffers.moe_output_bytes(),
+            ctx.buffers.fp8_act_bytes(),
+            ctx.buffers.fp8_act_scale_bytes(),
+            self.per_token_group_quant_fp8_k,
+            self.fp8_act_scale_kmajor_k,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            ctx.buffers.fp8_act_scale_kmajor_bytes(),
+        )
+    }
+
+    /// `out[m, n] = quant(normed_out)[m, k] @ weight[n, k]ᵀ` through cuBLASLt,
+    /// with the per-token 1x128 activation scales and the checkpoint's 128x128
+    /// weight scales folded in an FP32 epilogue.
+    ///
+    /// Quantizes ONCE into the arena's `fp8_act` / `fp8_act_scale` scratch —
+    /// the same buffers the QKVZ arm used earlier in this layer, safely reused
+    /// because the whole chain is same-stream ordered — then hands both to
+    /// `ops::cublas_fp8_proj_prequant`, which does the k-major scale transpose
+    /// and the matmul. Allocates nothing.
+    ///
+    /// Callers MUST have checked [`Qwen3SsmLayer::prefill_out_proj_w8a8_selected`]
+    /// first; this method does not re-check and does not fall back.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prefill_out_proj_w8a8_cublas(
+        &self,
+        ctx: &ForwardContext,
+        normed_out: DevicePtr,
+        fp8w: &Fp8Weight,
+        out: DevicePtr,
+        m: u32,
+        n: u32,
+        k: u32,
+        stream: u64,
+    ) -> Result<()> {
+        let a_fp8 = ctx.buffers.fp8_act();
+        let a_scale = ctx.buffers.fp8_act_scale();
+        // Padded extents, because `cublas_fp8_proj_prequant` zeroes and then
+        // READS rows `m..ceil16(m)` of both. The selector already gated on
+        // these; the debug asserts are the loud version for a dev build.
+        let m_pad = ops::cublas_fp8_m_pad(m) as usize;
+        debug_assert!(m_pad * k as usize <= ctx.buffers.fp8_act_bytes());
+        debug_assert!(m_pad * (k as usize / 128) * 4 <= ctx.buffers.fp8_act_scale_bytes());
+        ops::per_token_group_quant_fp8(
+            ctx.gpu,
+            self.per_token_group_quant_fp8_k,
+            normed_out,
+            a_fp8,
+            a_scale,
+            m,
+            k,
+            stream,
+        )?;
+        ops::cublas_fp8_proj_prequant(
+            ctx.gpu,
+            self.fp8_act_scale_kmajor_k,
+            a_fp8,
+            a_scale,
+            ctx.buffers.fp8_act_scale_kmajor(),
+            fp8w,
+            out,
+            m,
+            n,
+            k,
+            stream,
+        )
+    }
+
+    /// Log-once route line for the SSM `out_proj` prefill. Emitted from BOTH
+    /// arms so the absence of the W8A8 line is never ambiguous between "not
+    /// armed" and "log lost" — the failure mode that let round 9's 100.6 ms be
+    /// attributed to the dense FFN, which the same trace shows on `nvjet…`.
+    pub(super) fn log_out_proj_prefill_route(&self, ctx: &ForwardContext, cublas: bool) {
+        if ctx.stats.once("log:ssm_out_proj_prefill") {
+            if cublas {
+                tracing::info!(
+                    "[atlas] SSM out_proj prefill: W8A8 block-scaled via cuBLASLt \
+                     (per-token 1x128 act scales x 128x128 weight scales, FP32 epilogue). \
+                     ATLAS_CUBLAS_GEMM=ssm selected it; ATLAS_SSM_OUT_W8A16_ONLY restores W8A16. \
+                     This arm allocates nothing."
+                );
+            } else {
+                tracing::info!(
+                    "[atlas] SSM out_proj prefill: W8A16 (BF16 act x FP8 weight). \
+                     W8A8 cuBLASLt not selected — add `ssm` to ATLAS_CUBLAS_GEMM; see #917/#928."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "prefill_out_w8a8_tests.rs"]
+mod tests;

--- a/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/prefill_out_w8a8_tests.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Clause-by-clause contract for the SSM `out_proj` prefill cuBLASLt arm's
+//! selection rule. Every case defaults to SELECTING and perturbs exactly one
+//! thing, so a failure names the clause. The numerics are the GPU microtest's
+//! job (`examples/native_fp8_prefill_proj_w8a8_microtest.rs`).
+
+use super::out_proj_cublas_selected;
+use crate::layers::ops::cublas_fp8_m_pad;
+use crate::weight_map::WeightQuantFormat;
+use spark_runtime::gpu::{DevicePtr, KernelHandle};
+
+/// Qwen3.8-27B GDN `out_proj`: N = hidden 5120, K = value_dim 6144. The shape
+/// the round-9 H100 trace shows 48x per prefill chunk at grid 160xceil(M/128).
+const N: u32 = 5120;
+const K: u32 = 6144;
+/// Chunk 0 of the 1193-token trace prompt (chunk 1 is the 25-token tail, which
+/// the `m > 4` clause still admits).
+const M: u32 = 1168;
+const QUANT_K: KernelHandle = KernelHandle(0xBEEF);
+const KMAJOR_K: KernelHandle = KernelHandle(0xC0DE);
+const KMAJOR_BUF: DevicePtr = DevicePtr(0x1000);
+
+fn m_pad(m: u32) -> usize {
+    cublas_fp8_m_pad(m) as usize
+}
+
+fn out_bytes(m: u32) -> usize {
+    m_pad(m) * N as usize * 2
+}
+
+fn act_bytes(m: u32) -> usize {
+    m_pad(m) * K as usize
+}
+
+fn scale_bytes(m: u32) -> usize {
+    m_pad(m) * (K as usize / 128) * 4
+}
+
+/// The full-argument form; every helper below is this with one field moved.
+#[allow(clippy::too_many_arguments)]
+fn selected(
+    cublas_ssm: bool,
+    blockscaled: bool,
+    w8a16_only: bool,
+    fmt: WeightQuantFormat,
+    m: u32,
+    n: u32,
+    k: u32,
+    out_capacity: usize,
+    act_capacity: usize,
+    act_scale_capacity: usize,
+    quant_k: KernelHandle,
+    kmajor_k: KernelHandle,
+    kmajor_buf: DevicePtr,
+    kmajor_capacity: usize,
+) -> bool {
+    out_proj_cublas_selected(
+        cublas_ssm,
+        blockscaled,
+        w8a16_only,
+        fmt,
+        m,
+        n,
+        k,
+        out_capacity,
+        act_capacity,
+        act_scale_capacity,
+        quant_k,
+        kmajor_k,
+        kmajor_buf,
+        kmajor_capacity,
+    )
+}
+
+fn ready_at(m: u32) -> bool {
+    selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        m,
+        N,
+        K,
+        out_bytes(m),
+        act_bytes(m),
+        scale_bytes(m),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(m),
+    )
+}
+
+#[test]
+fn selected_at_prefill_m_with_the_ssm_scope_armed() {
+    assert!(ready_at(M), "the round-9 chunk-0 shape must select");
+    assert!(ready_at(25), "the 25-token tail chunk must select too");
+}
+
+#[test]
+fn not_selected_without_the_ssm_scope() {
+    // The whole point of the scoped lever: `ATLAS_CUBLAS_GEMM=ffn` must leave
+    // this projection exactly where it was.
+    assert!(!selected(
+        false,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn kill_switch_refuses_even_with_the_scope_armed() {
+    // ATLAS_SSM_OUT_W8A16_ONLY.
+    assert!(!selected(
+        true,
+        true,
+        true,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn single_scale_kill_switch_refuses() {
+    // ATLAS_FP8_SINGLE_SCALE clears `dispatch.fp8_blockscaled_prefill`.
+    assert!(!selected(
+        true,
+        false,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn m_at_or_below_four_stays_on_the_gemv_tier() {
+    for m in [1, 2, 4] {
+        assert!(!ready_at(m), "M={m} must stay on the GEMV tier");
+    }
+    assert!(ready_at(5), "M=5 is the first row count this arm claims");
+}
+
+#[test]
+fn per_row_scales_are_refused() {
+    assert!(!selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8PerRow,
+        M,
+        N,
+        K,
+        out_bytes(M),
+        act_bytes(M),
+        scale_bytes(M),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(M),
+    ));
+}
+
+#[test]
+fn shape_clauses() {
+    let case = |n: u32, k: u32| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            n,
+            k,
+            m_pad(M) * n as usize * 2,
+            m_pad(M) * k as usize,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            m_pad(M) * (k as usize).div_ceil(128) * 4,
+        )
+    };
+    assert!(case(N, K));
+    assert!(!case(N + 64, K), "N must be a multiple of 128");
+    assert!(!case(N, K + 64), "K must be a multiple of 128");
+    // k % 512: the weight-scale column stride K/128 must be a multiple of 4.
+    assert!(
+        !case(N, 5120 + 128),
+        "K=5248 has stride 41, not a multiple of 4"
+    );
+}
+
+#[test]
+fn capacity_clauses_each_refuse_on_their_own() {
+    let full = (out_bytes(M), act_bytes(M), scale_bytes(M), scale_bytes(M));
+    let case = |o: usize, a: usize, s: usize, km: usize| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            N,
+            K,
+            o,
+            a,
+            s,
+            QUANT_K,
+            KMAJOR_K,
+            KMAJOR_BUF,
+            km,
+        )
+    };
+    assert!(case(full.0, full.1, full.2, full.3));
+    assert!(!case(full.0 - 1, full.1, full.2, full.3), "output room");
+    assert!(!case(full.0, full.1 - 1, full.2, full.3), "activation room");
+    assert!(!case(full.0, full.1, full.2 - 1, full.3), "act-scale room");
+    assert!(!case(full.0, full.1, full.2, full.3 - 1), "k-major room");
+}
+
+#[test]
+fn an_unpadded_output_buffer_is_refused_when_m_is_not_a_multiple_of_16() {
+    // M=25 pads to 32: an arena sized for the REAL rows would be written past.
+    let m = 25;
+    let unpadded = m as usize * N as usize * 2;
+    assert!(!selected(
+        true,
+        true,
+        false,
+        WeightQuantFormat::Fp8BlockScaled,
+        m,
+        N,
+        K,
+        unpadded,
+        act_bytes(m),
+        scale_bytes(m),
+        QUANT_K,
+        KMAJOR_K,
+        KMAJOR_BUF,
+        scale_bytes(m),
+    ));
+}
+
+#[test]
+fn missing_handles_fall_back() {
+    let case = |quant: KernelHandle, kmajor: KernelHandle, buf: DevicePtr| {
+        selected(
+            true,
+            true,
+            false,
+            WeightQuantFormat::Fp8BlockScaled,
+            M,
+            N,
+            K,
+            out_bytes(M),
+            act_bytes(M),
+            scale_bytes(M),
+            quant,
+            kmajor,
+            buf,
+            scale_bytes(M),
+        )
+    };
+    assert!(case(QUANT_K, KMAJOR_K, KMAJOR_BUF));
+    assert!(!case(KernelHandle(0), KMAJOR_K, KMAJOR_BUF), "quantizer");
+    // The k-major clauses only bite in the default layout; guard the assert on
+    // it so `ATLAS_CUBLAS_SCALE_LAYOUT=rowmajor` in the environment does not
+    // turn this into a spurious failure.
+    if crate::layers::ops::cublas_scale_layout_kmajor() {
+        assert!(!case(QUANT_K, KernelHandle(0), KMAJOR_BUF), "kmajor kernel");
+        assert!(!case(QUANT_K, KMAJOR_K, DevicePtr(0)), "kmajor scratch");
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/rowwise_alloc_tests.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/rowwise_alloc_tests.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Allocation contract for the two `ATLAS_FP8_ROWWISE` GDN prefill arms —
+//! `trait_prefill_proj.rs`'s `in_proj_qkvz` and `trait_prefill_helper.rs`'s
+//! `out_proj`.
+//!
+//! H100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8` (#917): both arms got their BF16
+//! weight from `ops::cublas_bf16_proj`, whose `dequant_fp8_bf16_cached` did a
+//! `gpu.alloc` memoised by weight pointer — `167772160` B for the fused
+//! `[QKV|Z]` weight PER LAYER, with no `spark_runtime::buffers::sizes::BufferSizes`
+//! entry, so `--gpu-memory-utilization` could not see it. One 28-token prefill
+//! consumed 6120 MiB and died at layer 36 with `cuMemAlloc_v2 failed: status 2`.
+//! The attention arms that shared the defect were deleted in #927 and are held
+//! deleted by `qwen3_attention/prefill/alloc_tests.rs`; these two cannot be —
+//! a per-row checkpoint has no other route while
+//! `cublaslt::fp8_gemm_act_weight_t_rowwise` is NOT_SUPPORTED on sm_121 — so
+//! the bytes moved into the arena instead (`rowwise_bf16.rs`).
+//!
+//! The assertion is deliberately taken BEFORE the first call, not between the
+//! two: the old allocation was CACHED by weight pointer, so a first-vs-second
+//! comparison alone would have passed it. What is wrong is that the projection
+//! allocates at all — the arena already owns every buffer it needs.
+//!
+//! WHERE THE TESTS STOP, AND WHY. These bracket the arms at their dequant
+//! seam (`rowwise_qkvz_bf16` / `rowwise_out_proj_bf16`), which is the step
+//! that allocated, and NOT through the cuBLASLt matmul that follows it. That
+//! is not squeamishness about an FFI error: this binary also builds real
+//! `AtlasCudaBackend`s (`qsa_tests.rs`, `ngram_embed/tests.rs`), so a process
+//! CUDA context may well exist by the time these run, and handing
+//! `cublasLtMatmul` a `MockGpuBackend`'s fabricated device pointers would
+//! fault that shared context and take the rest of the suite with it. The arms
+//! themselves are exercised end to end by
+//! `the_arms_refuse_to_run_when_the_ledger_entry_is_absent` below, which stops
+//! at the ledger check for a REASON rather than by luck.
+
+use super::tests::native_fp8_gdn_layer;
+use super::*;
+use crate::weight_map::WeightQuantFormat;
+use atlas_core::config::{LayerType, ModelConfig};
+use spark_runtime::buffers::{BufferArena, BufferSizes, ssm_rowwise_w_bf16_bytes_for};
+use spark_runtime::gpu::mock::MockGpuBackend;
+
+/// The smoke prompt that killed the H100 run.
+const M: u32 = 28;
+
+/// A COMPACT GDN model — 4 layers on a 4-cycle (3 GDN, 1 full attention),
+/// hidden 512, 4x64 key heads, 8x64 value heads.
+///
+/// Deliberately not the 27B: `MockGpuBackend::alloc` is `vec![0u8; bytes]`, so
+/// the real checkpoint's 10.31 GiB slab would be 10.31 GiB of HOST memory in a
+/// unit test. The EXACT 27B integers — `167772160` B of `in_proj_qkvz` per
+/// layer, 48 layers — are pinned where nothing has to be allocated to check
+/// them: `spark_runtime::buffers::tests::rowwise_bf16_slab_is_sized_only_when_the_lever_is_armed`.
+/// What these tests pin is the property that does not depend on the shape:
+/// the arms take their BF16 weight from the ledger and allocate nothing.
+fn compact_gdn() -> ModelConfig {
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.hidden_size = 512;
+    c.num_hidden_layers = 4;
+    c.linear_num_key_heads = 4;
+    c.linear_key_head_dim = 64;
+    c.linear_num_value_heads = 8;
+    c.linear_value_head_dim = 64;
+    c.full_attention_interval = 4;
+    c.layer_types = (0..4)
+        .map(|i| {
+            if (i + 1) % 4 == 0 {
+                LayerType::FullAttention
+            } else {
+                LayerType::LinearAttention
+            }
+        })
+        .collect();
+    c
+}
+
+/// A per-row FP8 pair, the `Fp8PerRow` shape a mixed-precision
+/// compressed-tensors checkpoint ships and the only one
+/// `set_fp8_rowwise_prefill_weights` accepts.
+fn fp8_per_row(gpu: &MockGpuBackend, n: usize, k: usize) -> Fp8Weight {
+    Fp8Weight {
+        weight: gpu.alloc(n * k).unwrap(),
+        row_scale: gpu.alloc(n * 4).unwrap(),
+        n: n as u32,
+        k: k as u32,
+        scale_format: WeightQuantFormat::Fp8PerRow,
+    }
+}
+
+/// `ATLAS_FP8_ROWWISE` ARMED, without touching the process environment:
+/// `set_var` is unsafe and process-global and would race every other test in
+/// this binary, so the ledger is built with the lever passed in and handed to
+/// `BufferArena::from_sizes` — the same bytes `BufferSizes::from_config` would
+/// have produced with the variable exported.
+fn armed_arena(config: &ModelConfig, gpu: &MockGpuBackend) -> BufferArena {
+    let mut sizes = BufferSizes::from_config(config, 64, 4096, 16, 32);
+    sizes.ssm_rowwise_w_bf16 = ssm_rowwise_w_bf16_bytes_for(config, true);
+    BufferArena::from_sizes(config, sizes, 64, 32, gpu).unwrap()
+}
+
+/// An arena sized WITHOUT the lever — the default recipe's ledger, in which
+/// the slab is NULL.
+fn unarmed_arena(config: &ModelConfig, gpu: &MockGpuBackend) -> BufferArena {
+    let mut sizes = BufferSizes::from_config(config, 64, 4096, 16, 32);
+    sizes.ssm_rowwise_w_bf16 = 0;
+    BufferArena::from_sizes(config, sizes, 64, 32, gpu).unwrap()
+}
+
+macro_rules! fwd_ctx {
+    ($buffers:expr, $gpu:expr, $config:expr, $dispatch:expr, $derived:expr, $levers:expr, $stats:expr) => {
+        ForwardContext {
+            buffers: $buffers,
+            hc_row_offset: 0,
+            gpu: $gpu,
+            config: $config,
+            dispatch: $dispatch,
+            derived: $derived,
+            levers: $levers,
+            stats: $stats,
+            attn_metadata: None,
+            decode_step: false,
+            profile: false,
+            comm: None,
+            graph_capture: false,
+            gdn_exact_replay: false,
+            token_ids: None,
+            host_token_ids: None,
+            routed_lora_layers: None,
+            midchunk_capture: None,
+            moe_lora_route: crate::layer::MoeLoraRoute::Fold,
+        }
+    };
+}
+
+/// Everything a row-wise arm needs, wired the way the loader wires it.
+struct Fixture {
+    config: ModelConfig,
+    qkvz: Fp8Weight,
+    out_proj: Fp8Weight,
+}
+
+fn fixture(gpu: &MockGpuBackend) -> (Fixture, Qwen3SsmLayer) {
+    let config = compact_gdn();
+    let mut layer = native_fp8_gdn_layer(gpu, &config, true, true);
+    let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+    let qkvz = fp8_per_row(gpu, config.ssm_qkvz_size(), config.hidden_size);
+    let out_proj = fp8_per_row(gpu, config.hidden_size, value_dim);
+    layer.set_fp8_rowwise_prefill_weights(Some(qkvz), Some(out_proj));
+    (
+        Fixture {
+            config,
+            qkvz,
+            out_proj,
+        },
+        layer,
+    )
+}
+
+/// `in_proj_qkvz`: the arm's BF16 weight must come out of the arena, and the
+/// FIRST call must not allocate. On the real 27B that weight is the
+/// 167772160 B per layer the #917 OOM receipt names.
+#[test]
+fn rowwise_qkvz_bf16_weight_comes_from_the_ledger_not_a_fresh_alloc() {
+    let gpu = MockGpuBackend::new();
+    let (fx, layer) = fixture(&gpu);
+    let buffers = armed_arena(&fx.config, &gpu);
+    let (dispatch, derived) = (ops::GemmDispatch::defaults(), ops::DerivedWeights::new());
+    let (levers, stats) = (ops::ModelLevers::defaults(), ops::ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &fx.config, &dispatch, &derived, &levers, &stats
+    );
+
+    let (allocs, bytes) = (gpu.live_alloc_count(), gpu.live_bytes());
+    let launches = gpu.launch_count();
+    let first = layer
+        .rowwise_qkvz_bf16(&ctx, &fx.qkvz, 0)
+        .expect("first row-wise QKVZ bind");
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the row-wise QKVZ arm allocated on its FIRST call — that is the \
+         per-layer BF16 weight dequant from the #917 H100 receipt (167772160 B \
+         on the 27B this fixture shrinks)"
+    );
+    // One launch, and no second one: the dequant kernel, then a pure load.
+    // Pinned so "allocated nothing" cannot be satisfied by "did nothing".
+    assert_eq!(
+        gpu.launch_count() - launches,
+        1,
+        "expected one dequant_fp8_blockscaled_bf16 into the ledgered slab"
+    );
+    let second = layer
+        .rowwise_qkvz_bf16(&ctx, &fx.qkvz, 0)
+        .expect("second row-wise QKVZ bind");
+    assert_eq!(first, second, "the slice is per layer and must not move");
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes(), gpu.launch_count()),
+        (allocs, bytes, launches + 1),
+        "the second call must be a load, not a second dequant"
+    );
+}
+
+/// `out_proj`: same contract, and the two slices must not overlap — a bump
+/// cursor that handed both arms the same offset would pass every "allocates
+/// nothing" assertion while silently serving one weight as the other.
+#[test]
+fn rowwise_out_proj_bf16_weight_comes_from_the_ledger_not_a_fresh_alloc() {
+    let gpu = MockGpuBackend::new();
+    let (fx, layer) = fixture(&gpu);
+    let buffers = armed_arena(&fx.config, &gpu);
+    let (dispatch, derived) = (ops::GemmDispatch::defaults(), ops::DerivedWeights::new());
+    let (levers, stats) = (ops::ModelLevers::defaults(), ops::ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &fx.config, &dispatch, &derived, &levers, &stats
+    );
+
+    let (allocs, bytes) = (gpu.live_alloc_count(), gpu.live_bytes());
+    let launches = gpu.launch_count();
+    let out = layer
+        .rowwise_out_proj_bf16(&ctx, &fx.out_proj, 0)
+        .expect("first row-wise out_proj bind");
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "the row-wise out_proj arm allocated on its FIRST call — the same \
+         off-ledger BF16 weight dequant, [hidden, value_dim] x 2 B"
+    );
+    assert_eq!(gpu.launch_count() - launches, 1);
+    layer
+        .rowwise_out_proj_bf16(&ctx, &fx.out_proj, 0)
+        .expect("second row-wise out_proj bind");
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes(), gpu.launch_count()),
+        (allocs, bytes, launches + 1)
+    );
+
+    // Both arms of ONE layer, carved from one slab: disjoint, and together
+    // exactly `ssm_rowwise_w_bf16_layer_bytes`.
+    let qkvz = layer
+        .rowwise_qkvz_bf16(&ctx, &fx.qkvz, 0)
+        .expect("row-wise QKVZ bind");
+    let out_bytes = ops::dequant_fp8_bf16_bytes(&fx.out_proj);
+    assert_eq!(
+        out_bytes,
+        fx.out_proj.n as usize * fx.out_proj.k as usize * 2
+    );
+    assert_eq!(qkvz.0, out.0 + out_bytes as u64, "slices must not overlap");
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "neither arm may allocate"
+    );
+}
+
+/// The slab is the WHOLE budget: `num_ssm_layers` pairs and not one byte more,
+/// so one layer past the model's count is an error rather than a quiet
+/// `gpu.alloc` — which is precisely how the #917 leak stayed invisible.
+#[test]
+fn the_ledgered_slab_holds_exactly_every_gdn_layer_and_refuses_the_next() {
+    let gpu = MockGpuBackend::new();
+    let (fx, layer) = fixture(&gpu);
+    let buffers = armed_arena(&fx.config, &gpu);
+    let (dispatch, derived) = (ops::GemmDispatch::defaults(), ops::DerivedWeights::new());
+    let (levers, stats) = (ops::ModelLevers::defaults(), ops::ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &fx.config, &dispatch, &derived, &levers, &stats
+    );
+
+    let layer_bytes =
+        ops::dequant_fp8_bf16_bytes(&fx.qkvz) + ops::dequant_fp8_bf16_bytes(&fx.out_proj);
+    assert_eq!(
+        buffers.ssm_rowwise_w_bf16_bytes(),
+        fx.config.num_ssm_layers() * layer_bytes
+    );
+    // Every GDN layer's worth of slices, taken directly so the test does not
+    // need one layer fixture per layer. The first pair is `layer`'s; the rest
+    // stand in for its siblings, which take theirs on their own first prefill.
+    let _ = layer.rowwise_qkvz_bf16(&ctx, &fx.qkvz, 0).unwrap();
+    let _ = layer.rowwise_out_proj_bf16(&ctx, &fx.out_proj, 0).unwrap();
+    for _ in 1..fx.config.num_ssm_layers() {
+        buffers.take_ssm_rowwise_w_bf16(layer_bytes).unwrap();
+    }
+    let over = buffers.take_ssm_rowwise_w_bf16(layer_bytes);
+    assert!(
+        over.is_err(),
+        "one GDN layer past the model's count must be refused, not served \
+         from a fresh allocation"
+    );
+    assert!(format!("{:#}", over.unwrap_err()).contains("exhausted"));
+}
+
+/// End to end through BOTH real arms, with the ledger entry ABSENT — the
+/// configuration a `ATLAS_FP8_ROWWISE=0` arena would present to row-wise
+/// weights. Each arm must refuse before it reaches cuBLASLt, and neither may
+/// fall back to allocating its own BF16 twin.
+#[test]
+fn the_arms_refuse_to_run_when_the_ledger_entry_is_absent() {
+    let gpu = MockGpuBackend::new();
+    let (fx, layer) = fixture(&gpu);
+    let buffers = unarmed_arena(&fx.config, &gpu);
+    let (dispatch, derived) = (ops::GemmDispatch::defaults(), ops::DerivedWeights::new());
+    let (levers, stats) = (ops::ModelLevers::defaults(), ops::ModelStats::new());
+    let ctx = fwd_ctx!(
+        &buffers, &gpu, &fx.config, &dispatch, &derived, &levers, &stats
+    );
+    let c = &fx.config;
+    let value_dim = c.linear_num_value_heads * c.linear_value_head_dim;
+
+    let (allocs, bytes) = (gpu.live_alloc_count(), gpu.live_bytes());
+    let qkvz = layer.prefill_qkvz_proj(
+        buffers.norm_output(),
+        buffers.ssm_deinterleaved(),
+        M,
+        c.ssm_qkvz_size(),
+        c.hidden_size,
+        c.linear_num_key_heads,
+        c.linear_key_head_dim,
+        c.linear_num_value_heads / c.linear_num_key_heads.max(1),
+        c.linear_value_head_dim,
+        &ctx,
+        0,
+    );
+    let out = layer.prefill_out_proj_dispatch(
+        &ctx,
+        buffers.norm_output(),
+        buffers.hidden_states(),
+        M,
+        c.hidden_size,
+        value_dim,
+        0,
+    );
+    for (what, r) in [("in_proj_qkvz", qkvz), ("out_proj", out)] {
+        let e = format!("{:#}", r.expect_err(what));
+        assert!(
+            e.contains("row-wise") && e.contains("slab is absent"),
+            "{what}: expected the missing-ledger-entry refusal, got: {e}"
+        );
+    }
+    assert_eq!(
+        (gpu.live_alloc_count(), gpu.live_bytes()),
+        (allocs, bytes),
+        "a missing ledger entry must not be papered over with a fresh allocation"
+    );
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/rowwise_bf16.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/rowwise_bf16.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The LEDGERED BF16 dequant behind the two `ATLAS_FP8_ROWWISE` GDN prefill
+//! arms (`trait_prefill_proj.rs`'s `in_proj_qkvz`, `trait_prefill_helper.rs`'s
+//! `out_proj`).
+//!
+//! # Why these arms dequantise at all
+//!
+//! The checkpoint ships those two projections as FP8 E4M3 with a PER-ROW
+//! scale, and `cublaslt::fp8_gemm_act_weight_t_rowwise` — the only cuBLASLt
+//! entry that consumes a per-row pair — returns NOT_SUPPORTED on sm_121
+//! (measured 2026-08-15, reproduced through the block-scaled path with
+//! `ATLAS_CUBLAS_FP8=1`, so it is the GEMM and not the weights; see
+//! `ops/dispatch_proj_rowwise.rs`). The block-scaled W8A8 route the attention
+//! and default GDN arms took in #927/#928 is closed to them for the same
+//! reason from the other side: a per-row scale is not a `[N/128, K/128]` grid
+//! and the block kernels would read it as one. So BF16 it is — lossless here,
+//! since every FP8 E4M3 value is exactly representable in BF16.
+//!
+//! # Why the bytes live in the arena
+//!
+//! **#917 H100 receipt, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`.** The dequant used
+//! to be `ops::cublas_bf16_proj`'s `dequant_fp8_bf16_cached`: a lazy
+//! `gpu.alloc` memoised by weight pointer, `167772160` B for the fused
+//! `[QKV|Z]` weight PER LAYER (`[10240,5120] + [6144,5120]`, x2 B) with no
+//! `BufferSizes` entry — so `--gpu-memory-utilization` could not see it, the
+//! preflight ring fitter could not price it, and a 28-token prefill consumed
+//! 6120 MiB and died at layer 36 with `cuMemAlloc_v2 failed: status 2`. The
+//! attention arms that shared the defect were deleted in #927 and are held
+//! deleted by `qwen3_attention/prefill/alloc_tests.rs`; these two cannot be
+//! deleted, because there is no other route for a per-row checkpoint.
+//!
+//! So the same bytes are now ONE arena allocation
+//! (`BufferSizes::ssm_rowwise_w_bf16`, sized in
+//! `spark_runtime::buffers::sizes_rowwise` for `num_ssm_layers` x
+//! (`in_proj_qkvz` + `out_proj`) and armed only when `ATLAS_FP8_ROWWISE=1`, so
+//! every other recipe's ledger is unchanged). Each layer bump-carves its two
+//! slices on its FIRST prefill and remembers them here; nothing in the prefill
+//! path allocates.
+//!
+//! The by-pointer cache is gone with it. The slot below is a per-LAYER
+//! pointer, which is what the lifetime actually is — the old map was keyed on
+//! a device pointer whose recycling after a model swap is exactly the hazard
+//! `DerivedWeights` documents, and it outlived nothing useful.
+
+use anyhow::{Context, Result};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::Qwen3SsmLayer;
+use crate::layer::ForwardContext;
+use crate::layers::ops;
+use crate::weight_map::Fp8Weight;
+use spark_runtime::gpu::DevicePtr;
+
+impl Qwen3SsmLayer {
+    /// Ledgered BF16 `in_proj_qkvz` `[qkvz_size, hidden]` for the row-wise arm.
+    pub(super) fn rowwise_qkvz_bf16(
+        &self,
+        ctx: &ForwardContext,
+        fp8w: &Fp8Weight,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        self.rowwise_bf16(&self.qkvz_rowwise_bf16, ctx, fp8w, "in_proj_qkvz", stream)
+    }
+
+    /// Ledgered BF16 `out_proj` `[hidden, value_dim]` for the row-wise arm.
+    pub(super) fn rowwise_out_proj_bf16(
+        &self,
+        ctx: &ForwardContext,
+        fp8w: &Fp8Weight,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        self.rowwise_bf16(&self.out_proj_rowwise_bf16, ctx, fp8w, "out_proj", stream)
+    }
+
+    /// Dequantise `fp8w` into this layer's slice of the arena slab, once.
+    ///
+    /// `slot` is 0 until the first prefill through this projection; after that
+    /// it is the slice, and every later call is a load. `Relaxed` is enough
+    /// for the same reason the arena's cursor uses it: the scheduler drives
+    /// one forward at a time.
+    ///
+    /// ★ ALLOCATES NOTHING — that is the contract
+    /// `rowwise_alloc_tests.rs` pins, and the whole point of the change.
+    fn rowwise_bf16(
+        &self,
+        slot: &AtomicU64,
+        ctx: &ForwardContext,
+        fp8w: &Fp8Weight,
+        what: &str,
+        stream: u64,
+    ) -> Result<DevicePtr> {
+        let cached = slot.load(Ordering::Relaxed);
+        if cached != 0 {
+            return Ok(DevicePtr(cached));
+        }
+        let bytes = ops::dequant_fp8_bf16_bytes(fp8w);
+        let dst = ctx
+            .buffers
+            .take_ssm_rowwise_w_bf16(bytes)
+            .with_context(|| format!("ssm prefill: row-wise BF16 {what} weight"))?;
+        ops::dequant_fp8_bf16_into(ctx.gpu, fp8w, dst, stream)
+            .with_context(|| format!("ssm prefill: row-wise BF16 dequant of {what}"))?;
+        slot.store(dst.0, Ordering::Relaxed);
+        Ok(dst)
+    }
+}

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
@@ -133,6 +133,29 @@ impl Qwen3SsmLayer {
                 value_dim as u32,
                 stream,
             )
+        // W8A8 block-scaled cuBLASLt — 96 of the 112 `w8a16_gemm_pipelined`
+        // launches in the round-9 H100 prefill trace (68.1 ms of its 100.6 ms
+        // at 1193 tokens) were THIS projection, once per GDN layer per chunk,
+        // and nothing in `ATLAS_CUBLAS_GEMM` could reach it. See
+        // `prefill_out_w8a8.rs` for the full receipt and the clause list.
+        // Ahead of the `ATLAS_FP8_W8A8` arm below because both compute the same
+        // W8A8 arithmetic and this one is the faster implementation of it; the
+        // env lever alone (without `ssm` in `ATLAS_CUBLAS_GEMM`) still picks
+        // the in-tree kernel.
+        } else if let Some(ref fp8w) = self.out_proj_fp8w
+            && self.prefill_out_proj_w8a8_selected(ctx, k, h as u32, value_dim as u32, fp8w)
+        {
+            self.log_out_proj_prefill_route(ctx, true);
+            self.prefill_out_proj_w8a8_cublas(
+                ctx,
+                normed_out_buf,
+                fp8w,
+                out_proj_buf,
+                k,
+                h as u32,
+                value_dim as u32,
+                stream,
+            )
         } else if force_w8a8
             && let Some(ref fp8w) = self.out_proj_fp8w
             && self.per_token_group_quant_fp8_k.0 != 0
@@ -174,6 +197,10 @@ impl Qwen3SsmLayer {
         } else if let Some(ref fp8w) = self.out_proj_fp8w
             && self.w8a16_gemm_pipelined_k.0 != 0
         {
+            // The 100.6 ms / 27.31% kernel of the round-9 H100 prefill trace,
+            // 96 of whose 112 launches were this line. The counterpart log says
+            // so out loud, so "no W8A8 line" is never read as "log lost".
+            self.log_out_proj_prefill_route(ctx, false);
             ops::w8a16_gemm_pipelined(
                 ctx.gpu,
                 self.w8a16_gemm_pipelined_k,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_helper.rs
@@ -73,15 +73,19 @@ impl Qwen3SsmLayer {
     ) -> Result<()> {
         let force_w8a8 = matches!(std::env::var("ATLAS_FP8_W8A8").ok().as_deref(), Some("1"));
         // PER-ROW FP8 from the checkpoint (`ATLAS_FP8_ROWWISE=1`), dequantised
-        // once to BF16 — see the matching arm in `trait_prefill_proj.rs` for
-        // why BF16 and not the row-wise FP8 GEMM. First because it is the only
-        // arm that never re-quantises.
+        // once to BF16 into the LEDGERED arena slab — see the matching arm in
+        // `trait_prefill_proj.rs` for why BF16 and not the row-wise FP8 GEMM,
+        // and `rowwise_bf16.rs` for why the bytes are the arena's. First
+        // because it is the only arm that never re-quantises.
         if let Some(ref fp8w) = self.out_proj_fp8w_rowwise {
-            return ops::cublas_bf16_proj(
-                ctx.gpu,
-                ctx.derived,
+            // LEDGERED BF16 weight (`rowwise_bf16.rs`, #917): dequantised once
+            // per layer into `BufferSizes::ssm_rowwise_w_bf16`, so this arm
+            // allocates nothing. The predecessor cached a `gpu.alloc` by
+            // weight pointer, outside the ledger the fitter reads.
+            let w_bf16 = self.rowwise_out_proj_bf16(ctx, fp8w, stream)?;
+            return ops::cublas_bf16_proj_dense(
                 normed_out_buf,
-                fp8w,
+                w_bf16,
                 out_proj_buf,
                 k,
                 h as u32,

--- a/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
+++ b/crates/spark-model/src/layers/qwen3_ssm/trait_prefill_proj.rs
@@ -55,8 +55,9 @@ impl Qwen3SsmLayer {
             Some("1")
         );
         // PER-ROW FP8 straight from a mixed-precision checkpoint
-        // (`ATLAS_FP8_ROWWISE=1`), dequantised ONCE to BF16 and multiplied by
-        // cuBLASLt. Ahead of every arm below because it is the only one that
+        // (`ATLAS_FP8_ROWWISE=1`), dequantised ONCE to BF16 — into the
+        // LEDGERED `BufferSizes::ssm_rowwise_w_bf16` slab, see
+        // `rowwise_bf16.rs` (#917) — and multiplied by cuBLASLt. Ahead of every arm below because it is the only one that
         // never re-quantises: FP8 E4M3 is exactly representable in BF16, so
         // the checkpoint's precision survives, where the default path
         // dequantises to BF16 and then throws half of it away again by
@@ -90,11 +91,15 @@ impl Qwen3SsmLayer {
                     );
                 }
             }
-            ops::cublas_bf16_proj(
-                ctx.gpu,
-                ctx.derived,
+            // The BF16 weight comes from the LEDGERED slab, dequantised once
+            // per layer (`rowwise_bf16.rs`); this arm allocates nothing. It
+            // used to come from `ops::cublas_bf16_proj`'s by-pointer cache of
+            // `gpu.alloc`s — 167772160 B per layer with no `BufferSizes`
+            // entry, the #917 H100 OOM at layer 36.
+            let w_bf16 = self.rowwise_qkvz_bf16(ctx, fp8w, stream)?;
+            ops::cublas_bf16_proj_dense(
                 normed,
-                fp8w,
+                w_bf16,
                 proj_dst,
                 k,
                 qkvz_size as u32,

--- a/crates/spark-model/src/model/trait_impl/meta.rs
+++ b/crates/spark-model/src/model/trait_impl/meta.rs
@@ -369,6 +369,7 @@ impl TransformerModel {
             mtp_store_gen: store_gen,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            reused_prefix_tokens: 0,
             cached_prefix_blocks: 0,
             prefix_ref_tokens: Vec::new(),
             prefix_lookup_applied: false,

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -36,6 +36,7 @@ mod prefill_a;
 mod prefill_b;
 mod prefill_c;
 mod prefill_d;
+mod prefix_reuse;
 mod sequence;
 mod speculative;
 pub(in crate::model) mod ssm_fault_in;

--- a/crates/spark-model/src/model/trait_impl/prefill_a.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_a.rs
@@ -233,6 +233,14 @@ impl TransformerModel {
             }
         };
 
+        // #919: `cached_tokens` counts reused KV, not matched-then-discarded KV.
+        // The SSM-without-snapshot arm above has already zeroed `kv_write_start`.
+        seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+            prefix_match.matched_tokens,
+            kv_write_start,
+            marconi_skip,
+        );
+
         // Determine tokens to actually process
         let (proc_tokens, proc_count, seq_len_start) = if marconi_skip && kv_write_start >= n {
             // Exact match: entire prompt cached with SSM snapshot.

--- a/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/prefix_lookup.rs
@@ -369,6 +369,14 @@ impl TransformerModel {
                 0
             };
             seq.marconi_skip_to = skip_tokens;
+            // #919: report what was REUSED, not what the lookup matched. The
+            // SSM-without-snapshot and exact-leaf-bypass arms above leave
+            // `matched > 0` with `skip_tokens == 0` — a full prefill.
+            seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+                matched,
+                skip_tokens,
+                skip,
+            );
             seq.prefix_lookup_skip = skip;
             seq.prefix_lookup_applied = true;
             Ok((skip_tokens, skip))

--- a/crates/spark-model/src/model/trait_impl/prefill_c.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_c.rs
@@ -243,6 +243,12 @@ impl TransformerModel {
             (0, false)
         };
         seq.marconi_skip_to = kv_write_start;
+        // #919: `cached_tokens` counts reused KV, not matched-then-discarded KV.
+        seq.reused_prefix_tokens = crate::model::trait_impl::prefix_reuse::reused_prefix_tokens(
+            matched,
+            kv_write_start,
+            marconi_skip,
+        );
 
         // Allocate all KV blocks upfront for the full sequence.
         let blocks_needed = (total_len - 1) / bs + 1;

--- a/crates/spark-model/src/model/trait_impl/prefix_reuse.rs
+++ b/crates/spark-model/src/model/trait_impl/prefix_reuse.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT for what `usage.prompt_tokens_details.cached_tokens` reports.
+//!
+//! Atlas #919 (part 2): a chat completion reported `cached_tokens: 48` while
+//! the server log for the same request showed a full prefill and no reuse.
+//! The field was stamped from `PrefixMatch::matched_tokens` — the LOOKUP
+//! result — at `prefix_lookup.rs` / `prefill_a.rs` / `prefill_c.rs`, before the
+//! code decided whether to actually use the match. Three paths find a match,
+//! inc_ref its blocks onto the block table, and then recompute all of its KV
+//! anyway:
+//!
+//! * a hybrid-SSM model with no usable SSM snapshot
+//!   (`"…but no SSM snapshot — recomputing all KV"`),
+//! * the exact-leaf snapshot shortcut bypass (default ON,
+//!   `ATLAS_MARCONI_EXACT=1` re-enables the shortcut),
+//! * a Marconi restore declined below `marconi_min_tokens()` or by the session
+//!   gate.
+//!
+//! 48 is 3 x the default `--block-size 16`, exactly the shape a block-aligned
+//! lookup produces. So the log was right and the usage field was wrong.
+//!
+//! `matched_tokens` itself keeps its meaning — `cached_prefix_tokens` is
+//! load-bearing for block-ref accounting (`sequence.rs` release, `cache_sequence`
+//! double-bump avoidance, `forward_layers.rs` KV write floor). The reported
+//! count is a SECOND, narrower number: the tokens whose KV this request really
+//! read out of the cache instead of recomputing.
+
+/// Prompt tokens actually served from the prefix cache.
+///
+/// `matched`: `PrefixMatch::matched_tokens` from the lookup.
+/// `kv_write_start`: the position the prefill actually starts writing KV at —
+///   0 whenever the match was found but discarded.
+/// `skip`: whether the prefill took the skip path at all.
+///
+/// Never exceeds `matched`: the SSM paths can set `kv_write_start` from a
+/// snapshot depth, and a snapshot deeper than the matched prefix still only
+/// reuses the matched prefix.
+pub(crate) fn reused_prefix_tokens(matched: usize, kv_write_start: usize, skip: bool) -> usize {
+    if !skip && kv_write_start == 0 {
+        return 0;
+    }
+    kv_write_start.min(matched)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reused_prefix_tokens;
+
+    /// The reported #919 case: a 48-token block-aligned match that the SSM arm
+    /// throws away (`kv_write_start = 0`) must report 0, not 48.
+    #[test]
+    fn a_discarded_match_reports_zero_not_the_lookup_length() {
+        assert_eq!(reused_prefix_tokens(48, 0, false), 0);
+    }
+
+    /// The exact-leaf bypass finds a FULL-prompt hit and then recomputes
+    /// everything — the worst version of the bug, `cached_tokens == prompt_tokens`
+    /// on a 100% full prefill.
+    #[test]
+    fn the_exact_leaf_bypass_reports_zero() {
+        assert_eq!(reused_prefix_tokens(4593, 0, false), 0);
+    }
+
+    /// A genuine non-SSM skip reports the whole reused prefix.
+    #[test]
+    fn a_real_skip_reports_the_reused_prefix() {
+        assert_eq!(reused_prefix_tokens(48, 48, true), 48);
+    }
+
+    /// An intermediate SSM snapshot reuses only up to the snapshot depth, even
+    /// though the lookup matched further.
+    #[test]
+    fn an_intermediate_snapshot_reports_only_what_it_skipped() {
+        assert_eq!(reused_prefix_tokens(512, 256, true), 256);
+    }
+
+    /// A snapshot deeper than the matched prefix cannot inflate the count.
+    #[test]
+    fn the_report_never_exceeds_the_matched_prefix() {
+        assert_eq!(reused_prefix_tokens(256, 512, true), 256);
+    }
+
+    /// No match at all.
+    #[test]
+    fn no_match_reports_zero() {
+        assert_eq!(reused_prefix_tokens(0, 0, false), 0);
+    }
+}

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -137,11 +137,22 @@ pub struct SequenceState {
     /// Persistent paged metadata for chunked prefill, allocated lazily on the
     /// first chunk that needs paged attention.
     pub chunked_prefill_meta: Option<ChunkedPrefillPageMetadata>,
-    /// Number of prompt tokens served by the prefix cache (block-aligned).
-    /// Set by the model layer on the chunk-0 prefix-cache lookup; read by
-    /// the scheduler to populate `usage.prompt_tokens_details.cached_tokens`.
-    /// 0 when prefix caching is disabled or the prompt had no cache match.
+    /// Number of prompt tokens MATCHED by the chunk-0 prefix-cache lookup
+    /// (block-aligned). Load-bearing for block-ref accounting: `free_sequence`
+    /// release, `cache_sequence` double-bump avoidance, and the chunked-prefill
+    /// KV write floor all key off it. NOT what gets reported to clients —
+    /// a match can be found and then discarded (see `reused_prefix_tokens`).
     pub cached_prefix_tokens: usize,
+    /// Number of prompt tokens whose KV this request actually READ from the
+    /// prefix cache instead of recomputing. Stamped after the skip decision;
+    /// read by the scheduler to populate
+    /// `usage.prompt_tokens_details.cached_tokens`.
+    ///
+    /// Atlas #919: this used to be `cached_prefix_tokens`, which reports the
+    /// lookup result — so a request that matched 48 tokens and then recomputed
+    /// all of them (no SSM snapshot / exact-leaf bypass / declined Marconi
+    /// restore) advertised `cached_tokens: 48` next to a full-prefill log line.
+    pub reused_prefix_tokens: usize,
     /// Number of `block_table` entries that came FROM the prefix cache on this
     /// sequence's lookup (`matched_blocks.len()`). The cache already holds its
     /// own "+1" KV ref on each of those blocks, and eviction returns exactly ONE
@@ -298,6 +309,7 @@ impl SequenceState {
             adapter_id: 0,
             chunked_prefill_meta: None,
             cached_prefix_tokens: 0,
+            reused_prefix_tokens: 0,
             cached_prefix_blocks: 0,
             prefix_ref_tokens: Vec::new(),
             prefix_lookup_applied: false,

--- a/crates/spark-runtime/src/buffers.rs
+++ b/crates/spark-runtime/src/buffers.rs
@@ -11,14 +11,19 @@ use atlas_core::config::ModelConfig;
 
 mod accessors;
 pub mod decode_meta;
+mod rowwise_slab;
 mod sizes;
 mod sizes_q12;
 mod sizes_q2;
+mod sizes_rowwise;
 pub use decode_meta::{DECODE_META_MAX_ROWS, DECODE_META_MIN_ROWS, DecodeMetaLayout};
 pub use sizes::BufferSizes;
 pub use sizes_q2::q2_dequant_scratch_bytes;
 pub use sizes_q12::{
     Q12_SIZING_STREAMS, q12_batched_scratch_bytes, q12_batched_scratch_bytes_varlen,
+};
+pub use sizes_rowwise::{
+    ssm_rowwise_w_bf16_bytes, ssm_rowwise_w_bf16_bytes_for, ssm_rowwise_w_bf16_layer_bytes,
 };
 
 /// Pre-allocated GPU buffers for a single forward pass.
@@ -134,6 +139,15 @@ pub struct BufferArena {
     /// (`ATLAS_GGUF_NATIVE_Q2_MMQ`). Shared by every kept-packed projection;
     /// each seam quantizes its activation here then runs the packed MMQ GEMM.
     q2_act_q8: DevicePtr,
+    /// Row-wise FP8 GDN prefill BF16-weight slab (`ATLAS_FP8_ROWWISE`). One
+    /// allocation for EVERY GDN layer's dequanted `in_proj_qkvz` + `out_proj`;
+    /// `take_ssm_rowwise_w_bf16` bump-carves a layer's slice on its first
+    /// prefill. NULL unless the lever is armed. See `sizes_rowwise.rs` for the
+    /// #917 receipt this replaces.
+    ssm_rowwise_w_bf16: DevicePtr,
+    /// Bytes already carved out of `ssm_rowwise_w_bf16`. Bump-only: a slice
+    /// lives as long as the arena does, exactly like the weight it holds.
+    ssm_rowwise_w_bf16_used: std::sync::atomic::AtomicUsize,
     /// Maximum batch tokens this arena was sized for.
     max_batch_tokens: usize,
     /// Derived batched-decode metadata layout (rows = max(32, serve
@@ -154,7 +168,6 @@ impl BufferArena {
         max_batch_size: usize,
         gpu: &dyn GpuBackend,
     ) -> Result<Self> {
-        let decode_meta = DecodeMetaLayout::for_max_batch_size(max_batch_size);
         let sizes = BufferSizes::from_config(
             config,
             max_batch_tokens,
@@ -162,6 +175,24 @@ impl BufferArena {
             kv_block_size,
             max_batch_size,
         );
+        Self::from_sizes(config, sizes, max_batch_tokens, max_batch_size, gpu)
+    }
+
+    /// [`BufferArena::new`] with the ledger handed in instead of derived.
+    ///
+    /// `BufferSizes::from_config` reads the process environment for the
+    /// env-gated entries (`q2_*`, `ssm_rowwise_w_bf16`), and `set_var` is
+    /// process-global and unsafe — so a test that wants one of those arms
+    /// ARMED builds the sizes by hand and comes in here rather than racing
+    /// every other test in the binary. Production still goes through `new`.
+    pub fn from_sizes(
+        config: &ModelConfig,
+        sizes: BufferSizes,
+        max_batch_tokens: usize,
+        max_batch_size: usize,
+        gpu: &dyn GpuBackend,
+    ) -> Result<Self> {
+        let decode_meta = DecodeMetaLayout::for_max_batch_size(max_batch_size);
 
         let hidden_states = gpu.alloc(sizes.hidden_states)?;
         let residual = gpu.alloc(sizes.residual)?;
@@ -266,6 +297,12 @@ impl BufferArena {
         } else {
             DevicePtr::NULL
         };
+        // Row-wise GDN prefill BF16 weights. 0 → NULL unless ATLAS_FP8_ROWWISE.
+        let ssm_rowwise_w_bf16 = if sizes.ssm_rowwise_w_bf16 > 0 {
+            gpu.alloc(sizes.ssm_rowwise_w_bf16)?
+        } else {
+            DevicePtr::NULL
+        };
 
         tracing::info!(
             "Buffer arena: {} tokens × {:.1} MB total (attn_out={:.1}MB, ssm_deint={:.1}MB, kv_lora_rank={})",
@@ -320,6 +357,8 @@ impl BufferArena {
             lora_hact,
             lora_seq_slot,
             q2_act_q8,
+            ssm_rowwise_w_bf16,
+            ssm_rowwise_w_bf16_used: std::sync::atomic::AtomicUsize::new(0),
             max_batch_tokens,
             decode_meta,
             sizes,
@@ -390,6 +429,9 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
             lora_seq_slot,
             q2_dequant_scratch,
             q2_act_q8,
+            ssm_rowwise_w_bf16,
+            // A cursor into the slab above, not an allocation.
+            ssm_rowwise_w_bf16_used: _,
         } = self;
         // Every pointer, then NULL it: `release` must be idempotent because a
         // `Drop` backstop may call it again, and `free` already no-ops on NULL.
@@ -437,6 +479,7 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
             *lora_seq_slot,
             *q2_dequant_scratch,
             *q2_act_q8,
+            *ssm_rowwise_w_bf16,
         ];
         let mut first_error = None;
         for ptr in owned {
@@ -489,6 +532,7 @@ impl atlas_core::scope::ModelResource<dyn GpuBackend> for BufferArena {
         *lora_seq_slot = DevicePtr::NULL;
         *q2_dequant_scratch = DevicePtr::NULL;
         *q2_act_q8 = DevicePtr::NULL;
+        *ssm_rowwise_w_bf16 = DevicePtr::NULL;
         match first_error {
             Some(e) => Err(e),
             None => Ok(()),

--- a/crates/spark-runtime/src/buffers/rowwise_slab.rs
+++ b/crates/spark-runtime/src/buffers/rowwise_slab.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The row-wise FP8 GDN prefill BF16-weight slab: its size accessor and the
+//! bump carve the prefill arms take their per-layer slices from. Split from
+//! `accessors.rs` (≤500 LoC cap) rather than wedged into it, because the carve
+//! is a tiny allocator and not a getter.
+//!
+//! **WHY IT EXISTS (#917 H100 receipt, 2026-09-11).** The `ATLAS_FP8_ROWWISE`
+//! GDN arms used to get their BF16 weight from a lazy `gpu.alloc` memoised by
+//! weight pointer — `167772160` B for the fused `[QKV|Z]` weight per layer,
+//! with no `BufferSizes` entry, so `--gpu-memory-utilization` could not see it
+//! and a 28-token prefill died at layer 36 with `cuMemAlloc_v2 failed:
+//! status 2`. The bytes are the same; the difference is that they are now ONE
+//! ledgered allocation the preflight fitter prices.
+
+use super::BufferArena;
+use crate::gpu::DevicePtr;
+
+impl BufferArena {
+    /// Allocated byte size of the row-wise GDN prefill BF16-weight slab.
+    /// 0 when `ATLAS_FP8_ROWWISE` was not armed at boot.
+    pub fn ssm_rowwise_w_bf16_bytes(&self) -> usize {
+        self.sizes.ssm_rowwise_w_bf16
+    }
+
+    /// Carve the next `bytes` of the row-wise GDN prefill BF16-weight slab.
+    ///
+    /// Bump-only and never returned: each GDN layer takes its `in_proj_qkvz`
+    /// and `out_proj` slices on its FIRST prefill and holds them for the life
+    /// of the arena, because a dequanted weight is as immutable as the weight
+    /// it came from. Sized in `sizes_rowwise::ssm_rowwise_w_bf16_bytes` for
+    /// exactly `num_ssm_layers` of those pairs, so exhaustion means the sizing
+    /// and the callers disagree — a bug, reported as one rather than papered
+    /// over with a fresh allocation (that is the #917 defect this replaces).
+    ///
+    /// `Relaxed` is enough: the scheduler drives one forward at a time (the
+    /// same single-threaded invariant `cublaslt::Ctx` documents), so this is a
+    /// counter that happens to be atomic rather than a contended one.
+    pub fn take_ssm_rowwise_w_bf16(&self, bytes: usize) -> anyhow::Result<DevicePtr> {
+        use std::sync::atomic::Ordering;
+        if self.ssm_rowwise_w_bf16 == DevicePtr::NULL {
+            anyhow::bail!(
+                "row-wise GDN prefill BF16-weight slab is absent: the arena was sized without                  ATLAS_FP8_ROWWISE=1 but a row-wise prefill arm asked for {bytes} B. Both the                  loader's weight install and this ledger entry read the same lever, so they                  cannot legitimately disagree"
+            );
+        }
+        let base = self
+            .ssm_rowwise_w_bf16_used
+            .fetch_add(bytes, Ordering::Relaxed);
+        let end = base + bytes;
+        if end > self.sizes.ssm_rowwise_w_bf16 {
+            anyhow::bail!(
+                "row-wise GDN prefill BF16-weight slab exhausted: wanted {bytes} B at offset                  {base}, slab is {} B. `sizes_rowwise::ssm_rowwise_w_bf16_bytes` sizes it for                  num_ssm_layers x (in_proj_qkvz + out_proj)",
+                self.sizes.ssm_rowwise_w_bf16
+            );
+        }
+        Ok(self.ssm_rowwise_w_bf16.offset(base))
+    }
+}

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -134,6 +134,14 @@ pub struct BufferSizes {
     /// widest projection K = max(hidden, intermediate, q_heads*head_dim).
     /// 0 (→ NULL) unless the MMQ sub-flag is set.
     pub q2_act_q8: usize,
+    /// Row-wise FP8 GDN prefill BF16-weight slab (`ATLAS_FP8_ROWWISE=1`).
+    /// ONE arena allocation holding the BF16 dequant of EVERY GDN layer's
+    /// per-row `in_proj_qkvz` + `out_proj`, bump-carved one slice per layer
+    /// on that layer's first prefill and never freed. Replaces the lazy
+    /// `gpu.alloc` memoised by weight pointer that the #917 H100 receipt
+    /// caught at `167772160` B per layer outside this ledger. 0 (→ NULL)
+    /// unless the lever is armed; sizing lives in `sizes_rowwise.rs`.
+    pub ssm_rowwise_w_bf16: usize,
 }
 
 impl BufferSizes {
@@ -399,6 +407,11 @@ impl BufferSizes {
         // Sizing rationale + bounds live on `sizes_q2::q2_scratch_sizes`.
         let (q2_dequant_scratch, q2_act_q8) = super::sizes_q2::q2_scratch_sizes(config, m, h, hd);
 
+        // Row-wise FP8 GDN prefill BF16-weight slab; env-gated, 0 unless
+        // `ATLAS_FP8_ROWWISE=1`. Sizing + the #917 receipt live on
+        // `sizes_rowwise::ssm_rowwise_w_bf16_bytes`.
+        let ssm_rowwise_w_bf16 = super::sizes_rowwise::ssm_rowwise_w_bf16_bytes(config);
+
         // Dense-FFN activation-quant scratch, shared across all layers (SSOT).
         // Sized for the largest projection K = max(hidden, intermediate); the
         // dense_ffn prefill paths pass `h.max(inter)` to the requant kernels.
@@ -595,6 +608,7 @@ impl BufferSizes {
             lora_seq_slot,
             q2_dequant_scratch,
             q2_act_q8,
+            ssm_rowwise_w_bf16,
         }
     }
 
@@ -641,5 +655,6 @@ impl BufferSizes {
             + self.lora_seq_slot
             + self.q2_dequant_scratch
             + self.q2_act_q8
+            + self.ssm_rowwise_w_bf16
     }
 }

--- a/crates/spark-runtime/src/buffers/sizes.rs
+++ b/crates/spark-runtime/src/buffers/sizes.rs
@@ -315,7 +315,15 @@ impl BufferSizes {
         // q_heads*head_dim (o_proj). 1 byte/elem fp8 + one f32 per 128-block.
         // Mamba-2 out_proj contracts over d_inner (may exceed hidden), and its
         // prefill input is FP8-precast into this buffer.
-        let max_proj_k = h.max(q_heads * hd).max(mamba2_d_inner);
+        // ...and the GDN `out_proj`, which contracts over `value_dim`. It
+        // happens to equal `q_heads * hd` on Qwen3.8-27B (6144), so naming it
+        // changes no allocation there — but the W8A8 cuBLASLt arm added in
+        // #928 quantizes into this buffer, and a model whose value_dim is the
+        // widest contract would otherwise size it short and silently fall back.
+        let max_proj_k = h
+            .max(q_heads * hd)
+            .max(mamba2_d_inner)
+            .max(config.linear_num_value_heads * config.linear_value_head_dim);
         // Padded to 16 rows: `ops::cublas_fp8_proj` hands cuBLASLt `ceil16(M)`
         // and the matmul reads those phantom activation/scale rows.
         let fp8_act = m_pad * max_proj_k;
@@ -422,7 +430,12 @@ impl BufferSizes {
             hidden_states: m * h * residual_elem,
             residual: m * h * residual_elem,
             norm_output: m * max_dim * bf16,
-            qkv_output: m * qkv_dim * bf16,
+            // `m_pad`, not `m`: the cache-skip Q/K/V prefill's cuBLASLt arm
+            // WRITES `ceil16(M)` rows of `q_proj` here (readers still touch
+            // only the real M). Same headroom `ssm_qkvz` and `moe_output`
+            // already carry, and the reason is the same one (#928). ~0.4 MB on
+            // a 27B.
+            qkv_output: m_pad * qkv_dim * bf16,
             attn_output: (m * config.num_attention_heads * config.head_dim * bf16)
                 .max(m * mamba2_d_inner * bf16)
                 // MLA absorbed: attention output is [M, nq, mla_cache_dim=kv_lora+rope]
@@ -466,7 +479,11 @@ impl BufferSizes {
             // to 15 rows into the NEXT arena buffer. ~0.4 MB on a 27B.
             ssm_qkvz: (m_pad * config.ssm_qkvz_size() * bf16)
                 .max(m * config.mamba2_in_proj_size() * bf16)
-                .max(m * 2 * kv_heads * hd * bf16)
+                // `k` at row 0 and `v` at row `m`, each `ceil16(M)` rows
+                // tall on the cuBLASLt arm: the furthest byte is
+                // `(m + m_pad) * kv_dim` (#928, `prefill_qkv_w8a8.rs`). Was
+                // `m * 2 * kv_dim`, which this is never smaller than.
+                .max((m + m_pad) * kv_heads * hd * bf16)
                 .max(m * config.shared_expert_intermediate_size * bf16) // MoE shared up scratch
                 .max(256),
             ssm_ba: (m * config.ssm_ba_size() * bf16)

--- a/crates/spark-runtime/src/buffers/sizes_rowwise.rs
+++ b/crates/spark-runtime/src/buffers/sizes_rowwise.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Row-wise FP8 GDN prefill BF16-weight slab sizing, split out of `sizes.rs`
+//! (≤500 LoC cap). Env-gated — 0 (→ NULL) unless `ATLAS_FP8_ROWWISE=1`, so
+//! every other recipe's ledger is byte-identical to before this entry existed.
+//!
+//! **WHY (#917 H100 receipt, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`).** The
+//! `ATLAS_FP8_ROWWISE` GDN prefill arms dequantise their per-row FP8 weights
+//! to BF16 once and multiply with cuBLASLt, because
+//! `cublaslt::fp8_gemm_act_weight_t_rowwise` returns NOT_SUPPORTED on sm_121
+//! (measured 2026-08-15). That dequant used to be a lazy `gpu.alloc` memoised
+//! by weight pointer — `167772160` bytes for the fused `[QKV|Z]` weight PER
+//! LAYER, invisible to `--gpu-memory-utilization`, which is the same defect
+//! class that killed a 28-token prefill at layer 36 with `cuMemAlloc_v2
+//! failed: status 2`. Sizing it here makes it ONE arena allocation the
+//! preflight fitter can see (`preflight::headroom`'s `arena` term is
+//! `BufferSizes::total_bytes()`), and the arms bump-carve their slices from
+//! it instead of allocating.
+
+use atlas_core::config::ModelConfig;
+
+/// BF16 bytes ONE GDN layer's row-wise prefill arms dequantise and keep:
+/// the fused `in_proj_qkvz` `[ssm_qkvz_size, hidden]` and `out_proj`
+/// `[hidden, value_dim]`, 2 bytes per element.
+///
+/// EXACT, not an upper bound: these are the two weights
+/// `set_fp8_rowwise_prefill_weights` installs and the only two the row-wise
+/// arms dequantise. `value_dim = linear_num_value_heads * linear_value_head_dim`
+/// — the same extent `trait_prefill_block.rs` passes as the `out_proj` K.
+///
+/// Qwen3.8-27B (hidden 5120, 16x128 key heads, 48x128 value heads):
+/// `16384*5120*2 + 5120*6144*2 = 167772160 + 62914560 = 230686720` B.
+pub fn ssm_rowwise_w_bf16_layer_bytes(config: &ModelConfig) -> usize {
+    let bf16 = 2;
+    let value_dim = config.linear_num_value_heads * config.linear_value_head_dim;
+    let qkvz = config.ssm_qkvz_size() * config.hidden_size * bf16;
+    let out_proj = config.hidden_size * value_dim * bf16;
+    qkvz + out_proj
+}
+
+/// Arena bytes for the row-wise GDN prefill BF16-weight slab: the per-layer
+/// pair summed over every linear-attention layer, or 0 when the lever is off.
+///
+/// The env predicate is character for character
+/// `weight_loader::qwen35_dense::rowwise_fp8::rowwise_fp8_enabled` — `== Ok("1")`,
+/// NOT presence. The two must agree: the loader installs the per-row weights
+/// on that predicate and the arms then require this slab, so `ATLAS_FP8_ROWWISE=0`
+/// must leave BOTH off.
+pub fn ssm_rowwise_w_bf16_bytes(config: &ModelConfig) -> usize {
+    ssm_rowwise_w_bf16_bytes_for(
+        config,
+        std::env::var("ATLAS_FP8_ROWWISE").as_deref() == Ok("1"),
+    )
+}
+
+/// [`ssm_rowwise_w_bf16_bytes`] with the lever passed in, so the sizing
+/// arithmetic is pinnable at exact integers without touching the process
+/// environment.
+pub fn ssm_rowwise_w_bf16_bytes_for(config: &ModelConfig, rowwise_enabled: bool) -> usize {
+    if !rowwise_enabled {
+        return 0;
+    }
+    config.num_ssm_layers() * ssm_rowwise_w_bf16_layer_bytes(config)
+}

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -294,3 +294,89 @@ fn test_buffer_sizes_decode_meta_widening() {
     let max_blocks = 4096 / 16 + 1;
     assert!(s192.scratch >= 32768 + 24 * 192 + 192 * max_blocks * 4);
 }
+
+// ── Row-wise FP8 GDN prefill BF16-weight slab (#917) ──────────────────────
+//
+// H100, 2026-09-11, `Qwen/Qwen3.8-27B-FP8`: the `ATLAS_FP8_ROWWISE` GDN arms
+// dequantised their per-row FP8 weights to BF16 through a `gpu.alloc` memoised
+// by weight pointer — `167772160` B per layer with NO entry here, so
+// `--gpu-memory-utilization` could not see it and a 28-token prefill died at
+// layer 36 with `cuMemAlloc_v2 failed: status 2`. These pin the entry that
+// replaced it: present IFF the lever is armed, and exact at the 27B geometry.
+//
+// The lever is passed in rather than set: `set_var` is process-global and
+// unsafe, and would race every other test in this binary.
+
+/// `Qwen/Qwen3.8-27B-FP8` at the shapes `kernels/gb10/qwen3.8-27b/MODEL.toml`
+/// declares (hidden 5120, 64 layers on a 4-cycle → 48 GDN), plus the GDN head
+/// geometry `ModelConfig` reads from the checkpoint's own `config.json`
+/// (16x128 key heads, 48x128 value heads). Same fixture as
+/// `weight_loader::qwen35_dense::predicted_residency_tests::qwen38_27b`.
+fn qwen38_27b() -> ModelConfig {
+    use atlas_core::config::LayerType;
+    let mut c = ModelConfig::qwen3_next_80b_nvfp4();
+    c.hidden_size = 5120;
+    c.num_hidden_layers = 64;
+    c.linear_num_key_heads = 16;
+    c.linear_key_head_dim = 128;
+    c.linear_num_value_heads = 48;
+    c.linear_value_head_dim = 128;
+    c.full_attention_interval = 4;
+    c.layer_types = (0..64)
+        .map(|i| {
+            if (i + 1) % 4 == 0 {
+                LayerType::FullAttention
+            } else {
+                LayerType::LinearAttention
+            }
+        })
+        .collect();
+    c
+}
+
+#[test]
+fn rowwise_bf16_slab_is_sized_only_when_the_lever_is_armed() {
+    let cfg = qwen38_27b();
+    assert_eq!(
+        ssm_rowwise_w_bf16_bytes_for(&cfg, false),
+        0,
+        "an unarmed ATLAS_FP8_ROWWISE must leave the default recipe's ledger \
+         byte-identical — the arena allocates NULL for a 0-byte entry"
+    );
+
+    // in_proj_qkvz: (16*128 q + 16*128 k + 48*128 v + 48*128 z) = 16384 rows
+    // x 5120 hidden x 2 B = 167772160 — the exact per-layer figure the H100
+    // OOM receipt names. out_proj: [5120, 48*128] x 2 B = 62914560.
+    assert_eq!(cfg.ssm_qkvz_size(), 16_384);
+    let qkvz = 16_384 * 5_120 * 2;
+    let out_proj = 5_120 * (48 * 128) * 2;
+    assert_eq!(qkvz, 167_772_160);
+    assert_eq!(ssm_rowwise_w_bf16_layer_bytes(&cfg), qkvz + out_proj);
+    assert_eq!(cfg.num_ssm_layers(), 48);
+    assert_eq!(
+        ssm_rowwise_w_bf16_bytes_for(&cfg, true),
+        48 * (qkvz + out_proj),
+        "48 GDN layers x (in_proj_qkvz + out_proj) — 10.31 GiB, which is what \
+         the preflight ring fitter now prices instead of discovering at \
+         layer 36"
+    );
+}
+
+/// The entry has to reach `total_bytes()`, because THAT is what preflight's
+/// `headroom::post_load_yardstick` takes as its `arena` term. A field the
+/// sum forgets is exactly as invisible as the `gpu.alloc` it replaced.
+#[test]
+fn rowwise_bf16_slab_is_counted_in_total_bytes() {
+    let cfg = qwen38_27b();
+    let mut sizes = BufferSizes::from_config(&cfg, 64, 4096, 16, 32);
+    // Zeroed first, not assumed zero: `from_config` reads the ambient
+    // environment, and a runner that happens to export ATLAS_FP8_ROWWISE=1
+    // must not turn this into an assertion about nothing.
+    sizes.ssm_rowwise_w_bf16 = 0;
+    let before = sizes.total_bytes();
+    // A SENTINEL, not the real slab size. This test is about the sum, and
+    // reading the sizing function here would let a sizing bug that returns 0
+    // make it vacuously true — which is exactly how a term goes missing.
+    sizes.ssm_rowwise_w_bf16 = 4096;
+    assert_eq!(sizes.total_bytes(), before + 4096);
+}

--- a/crates/spark-runtime/src/buffers/tests.rs
+++ b/crates/spark-runtime/src/buffers/tests.rs
@@ -34,9 +34,14 @@ fn test_buffer_sizes_qwen3() {
     // (Was FP32 = 8192 in earlier prototypes; NVFP4 path keeps the
     // residual stream in BF16, halving the buffer size.)
     assert_eq!(sizes.hidden_states, 4096);
-    // qkv: 1 * (16*2 + 2*2) * 256 * 2 = 1 * 36 * 256 * 2 = 18432
-    // Q+gate: 16*2*256, K: 2*256, V: 2*256
-    assert_eq!(sizes.qkv_output, 18432);
+    // qkv: ceil16(1) * (16*2 + 2*2) * 256 * 2 = 16 * 36 * 256 * 2 = 294912
+    // Q+gate: 16*2*256, K: 2*256, V: 2*256 — and the row extent is the
+    // cuBLASLt M-pad, exactly as for `ssm_qkvz` / `ssm_deinterleaved` below:
+    // the cache-skip Q/K/V prefill's cuBLASLt arm hands the library ceil16(M)
+    // and WRITES the phantom rows (#928, `sizes.rs`'s `m_pad`). The 16x here
+    // is an artifact of sizing at M=1; at a real prefill arena the pad is
+    // <= 15 rows out of thousands.
+    assert_eq!(sizes.qkv_output, 294912);
     // attn: 1 * 16 * 256 * 2 = 8192
     assert_eq!(sizes.attn_output, 8192);
     // gate: 1 * 512 * 2 = 1024

--- a/crates/spark-server/src/api/chat/mod.rs
+++ b/crates/spark-server/src/api/chat/mod.rs
@@ -228,25 +228,9 @@ pub(crate) async fn chat_completions_inner(
         return ChatOutcome::Http(resp);
     }
 
-    // Tool-parser behavioral system prompt REMOVED again (2026-05-25 PM).
-    //
-    // Re-injecting the qwen3_coder `system_prompt` (with its
-    // `<parameter=content>[package]\nname = "x"</parameter>` example
-    // and `For 'Write'/'Edit' tools specifically: ...` guidance) was a
-    // mid-day attempt to give the model better multi-line content
-    // hints. Live opencode v39 session showed the opposite effect:
-    // the model emitted LITERAL `<tool_call><bash><command>` XML as
-    // CONTENT (with HTML-entity escaping like `&amp;`) because TWO
-    // tool-format guidances were competing — the chat template's
-    // `tools` argument AND my injected prompt — combined with PR 73's
-    // `qwen3_xml` parser. The model got confused which format to use
-    // and emitted free-form XML that the parser couldn't recognise.
-    //
-    // Per user's recall: the "MUCH better" state had `thinking_in_tools=true`
-    // and the chat template alone (no injection). Reverting matches
-    // that state. PR 73's qwen3_xml + native FP8 SSM + streaming
-    // byte-exact + gate-BF16 + thinking_in_tools=true is the live
-    // combination.
+    // Parser/native-template ownership is resolved by prepare_chat_prompt.
+    // Native Qwen templates provide their own instructions; fallback,
+    // custom-template, Hermes, and TSCG paths retain parser contributions.
 
     // M2 per-request LoRA routing: resolve the optional `adapter` name to a
     // pool slot ONCE here (both dispatch paths inherit it). Unset defers to the

--- a/crates/spark-server/src/api/chat/prepare.rs
+++ b/crates/spark-server/src/api/chat/prepare.rs
@@ -293,3 +293,7 @@ mod tests {
         assert_eq!(messages[0].text(), "tool instructions\n\noriginal");
     }
 }
+
+#[cfg(test)]
+#[path = "../../tokenizer/tests/native_tool_prompt.rs"]
+mod native_tool_prompt;

--- a/crates/spark-server/src/api/chat/prepare.rs
+++ b/crates/spark-server/src/api/chat/prepare.rs
@@ -54,16 +54,20 @@ pub(crate) fn prepare_chat_prompt(
         && !req.tools.is_empty()
         && !req.tool_choice.as_ref().is_some_and(|tc| tc.is_none());
 
-    // ST-995 fix: restore the parser-specific behavioral system prompt #90
-    // removed. For the hermes parser this is the canonical NousResearch
-    // function-calling prompt ("you MAY call one or more functions...
-    // don't make assumptions"), which the GDN model needs to correctly
-    // DECLINE on irrelevance prompts. With it (and compact tool-JSON)
-    // hallucination returns to ~96 (vs 30/64 without).
+    // Preserve parser-owned prompts (including Hermes and TSCG). Native
+    // Qwen checkpoint templates already render their tool instructions;
+    // adding the parser block there duplicates the schema and changes the
+    // request with unrelated behavioral guidance.
     if tools_active && let Some(ref parser) = state.tool_call_parser {
         let default_choice = crate::tool_parser::ToolChoice::Mode("auto".to_string());
         let tool_choice = req.tool_choice.as_ref().unwrap_or(&default_choice);
-        let tool_prompt = parser.system_prompt(&req.tools, tool_choice, &state.chat.prompt);
+        let tool_prompt = parser_tool_prompt(
+            parser.as_ref(),
+            &req.tools,
+            tool_choice,
+            &state.chat.prompt,
+            state.tokenizer.uses_native_qwen_tool_template(),
+        );
         inject_tool_system_prompt(&mut req.messages, tool_prompt);
     }
 
@@ -185,9 +189,32 @@ fn effective_reasoning_effort(
     }
 }
 
+/// Resolve the parser contribution independently of the native template renderer.
+pub(crate) fn parser_tool_prompt(
+    parser: &dyn crate::tool_parser::ToolCallParser,
+    tools: &[crate::tool_parser::ToolDefinition],
+    choice: &crate::tool_parser::ToolChoice,
+    levers: &crate::tool_parser::PromptLevers,
+    native_qwen_template: bool,
+) -> String {
+    if native_qwen_template && !levers.tscg && matches!(parser.name(), "qwen3_coder" | "qwen3_xml")
+    {
+        // The checkpoint template already owns the schema and XML format.
+        // Keep required/named tool-choice constraints, but do not inject a
+        // second copy or unrelated Bash/Write/Edit behavioral instructions.
+        let mut prompt = String::new();
+        crate::tool_parser::append_tool_choice_instruction(&mut prompt, choice);
+        return prompt;
+    }
+    parser.system_prompt(tools, choice, levers)
+}
+
 /// Inject a parser's behavioral prompt without changing requests for parsers
 /// whose native chat template already owns tool instructions.
-fn inject_tool_system_prompt(messages: &mut Vec<crate::ir::Message>, tool_prompt: String) {
+pub(crate) fn inject_tool_system_prompt(
+    messages: &mut Vec<crate::ir::Message>,
+    tool_prompt: String,
+) {
     if tool_prompt.is_empty() {
         return;
     }

--- a/crates/spark-server/src/cli/serve_args.rs
+++ b/crates/spark-server/src/cli/serve_args.rs
@@ -906,10 +906,15 @@ pub struct ServeArgs {
     pub profile: bool,
 
     /// Number of warmup tokens for online FP8 KV cache scale calibration.
-    /// During the first N tokens, tracks max |K| and max |V| values across
-    /// all attention layers. After N tokens, computes per-tensor scales as
-    /// max/448 (mapping the observed range to FP8 E4M3 [-448, 448]).
-    /// 0 = disabled (use static scales from checkpoint, or uncalibrated 1.0).
+    /// Tracks max |K| and max |V| over the first N observed tokens — ACROSS
+    /// requests, so a readiness probe counts toward the window but can never
+    /// close it on its own (#919) — then computes per-tensor scales as
+    /// amax*headroom/448 (mapping the observed range to FP8 E4M3 [-448, 448]).
+    /// The window's own KV is held in BF16 and requantized at the freeze, so
+    /// the write scale always equals the read scale; N is clamped to 4096 to
+    /// bound that staging. 1 = freeze on the first observe (the pre-#919
+    /// behaviour). 0 = disabled (use static scales from checkpoint, or
+    /// uncalibrated 1.0).
     /// Only applies when --kv-cache-dtype is fp8.
     /// Precedence (highest wins): this flag → MODEL.toml
     /// `[behavior].fp8_kv_calibration_tokens` → 0. An explicit value always
@@ -918,12 +923,11 @@ pub struct ServeArgs {
     #[arg(long)]
     pub fp8_kv_calibration_tokens: Option<usize>,
 
-    /// Headroom multiplier applied to the first-observe absmax when the online
-    /// FP8 KV scale freezes (calibration freezes on the FIRST observe so the
-    /// write scale always equals the read scale). The first observe sees only
-    /// the first prefill chunk, so the frozen scale covers headroom× its
-    /// observed max — later tokens whose magnitude grows don't clip, at a cost
-    /// of <1 bit of precision. Must be ≥ 1.0 (below 1.0 guarantees clipping;
+    /// Headroom multiplier applied to the accumulated absmax when the online
+    /// FP8 KV scale freezes. The calibration window only sees the first
+    /// `--fp8-kv-calibration-tokens` tokens, so the frozen scale covers
+    /// headroom× their max — later tokens whose magnitude grows don't clip, at
+    /// a cost of <1 bit of precision. Must be ≥ 1.0 (below 1.0 guarantees clipping;
     /// rejected at startup). Replaces `ATLAS_FP8_KV_HEADROOM`.
     #[arg(long, default_value_t = 2.0)]
     pub fp8_kv_headroom: f32,

--- a/crates/spark-server/src/cli/validate.rs
+++ b/crates/spark-server/src/cli/validate.rs
@@ -234,7 +234,7 @@ pub fn validate_serve_args(args: &ServeArgs) -> Result<(), String> {
     if args.fp8_kv_headroom < 1.0 {
         v.push(Violation::new(
             format!("--fp8-kv-headroom {} is below 1.0.", args.fp8_kv_headroom),
-            "the frozen FP8 KV scale covers headroom× the first-observe absmax; \
+            "the frozen FP8 KV scale covers headroom× the calibration-window absmax; \
              a multiplier under 1.0 clips the very values it was measured from.",
             "use a value ≥ 1.0 (default 2.0).",
         ));

--- a/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
+++ b/crates/spark-server/src/main_modules/serve_phases/kv_cache.rs
@@ -250,9 +250,17 @@ pub(crate) fn resolve_kv_cache_config(
                     fp8_kv_scale_count,
                 );
             } else {
+                // #919: this used to read "freezing per-tensor scales on the
+                // first observed tokens", and meant it — the freeze fired on
+                // the first observe, i.e. on the readiness probe. The window is
+                // now accumulated across requests; each attention layer logs
+                // "FP8 KV scales frozen after N tokens (requested M)" when it
+                // closes, which is the line to grep for in a serve log.
                 tracing::info!(
                     "FP8 KV cache with online calibration (checkpoint ships no k/v scales): \
-                     freezing per-tensor scales on the first observed tokens.{}",
+                     accumulating per-tensor K/V amax over the first {} observed tokens \
+                     (across requests, readiness probe included) before freezing the scales.{}",
+                    config.fp8_kv_calibration_tokens,
                     if args.fp8_kv_calibration_tokens.is_none() {
                         " (auto-enabled from MODEL.toml)"
                     } else {

--- a/crates/spark-server/src/scheduler/cached_tokens_tests.rs
+++ b/crates/spark-server/src/scheduler/cached_tokens_tests.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Atlas #919 part 2: `usage.prompt_tokens_details.cached_tokens` accounting.
+//! Logical child of `phase_promote_prefills` via `#[path]`.
+/// Atlas #919: `usage.prompt_tokens_details.cached_tokens` must report the
+/// prompt tokens whose KV was REUSED, not the prefix-cache lookup length. The
+/// lookup length lives on `cached_prefix_tokens` and is load-bearing for block
+/// refcounting, so the report sites must read `reused_prefix_tokens` instead.
+///
+/// Red before the fix: every one of these files bound `cached_prompt_tok` from
+/// `seq.cached_prefix_tokens`, which is non-zero even when the prefill
+/// recomputed every token (no SSM snapshot / exact-leaf bypass).
+#[test]
+fn cached_tokens_is_reported_from_reused_prefix_tokens() {
+    for (name, src) in [
+        (
+            "phase_promote_prefills.rs",
+            include_str!("phase_promote_prefills.rs"),
+        ),
+        ("prefill_a_step.rs", include_str!("prefill_a_step.rs")),
+        ("prefill_b_step.rs", include_str!("prefill_b_step.rs")),
+    ] {
+        let compact: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            !compact.contains("cached_prompt_tok=p.seq.cached_prefix_tokens")
+                && !compact.contains("cached_prompt_tok=seq.cached_prefix_tokens"),
+            "{name} still reports the prefix-cache LOOKUP length as cached_tokens (#919)"
+        );
+        assert!(
+            compact.contains("cached_prompt_tok=p.seq.reused_prefix_tokens")
+                || compact.contains("cached_prompt_tok=seq.reused_prefix_tokens"),
+            "{name} must report the tokens actually reused from the prefix cache"
+        );
+    }
+}

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -57,6 +57,8 @@ mod prefill_a_step_params;
 mod prefill_b_step;
 #[cfg(test)]
 mod prefill_fifo_tests;
+#[cfg(test)]
+mod prefill_timing_tests;
 mod repetition;
 mod rollback;
 mod sample_step;

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -93,7 +93,7 @@ pub(super) fn promote_completed_prefills(
         let use_legacy_tool_call =
             p.require_tool_call && p.grammar_state.is_none() && tool_call_start_token.is_some();
         let now = Instant::now();
-        let cached_prompt_tok = p.seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = p.seq.reused_prefix_tokens as u32;
         let immediate_finish =
             !spontaneous_think && (p.eos_tokens.contains(&first) || p.max_tokens <= 1);
 
@@ -249,3 +249,7 @@ fn build_active_seq_from_prefill(
         adaptive: crate::adaptive_sampler::AdaptiveSamplingState::new(temperature),
     }
 }
+
+#[cfg(test)]
+#[path = "cached_tokens_tests.rs"]
+mod cached_tokens_tests;

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -83,6 +83,9 @@ pub fn start_chunked_prefill(
     let req_prompt_logprobs = req.prompt_logprobs();
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
+    // Scheduler-service TTFT includes grammar compilation and mask warmup.
+    // HTTP handling/queue time precedes this clock; decode_start stays unchanged.
+    let request_start = Instant::now();
     let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
     let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
@@ -118,7 +121,6 @@ pub fn start_chunked_prefill(
         ),
     };
 
-    let request_start = Instant::now();
     let total = prompt_tokens.len();
     let chunk_len = total.min(max_prefill_tokens);
     let is_last = chunk_len >= total;

--- a/crates/spark-server/src/scheduler/prefill_a_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_a_step.rs
@@ -189,7 +189,7 @@ pub fn start_chunked_prefill(
             req_require_tool_call && grammar_state.is_none() && tool_call_start_token.is_some();
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         let mut a = ActiveSeq {
             seq,
             session_hash: req_session_hash,
@@ -527,7 +527,7 @@ pub fn start_chunked_prefill(
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
 
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         if !spontaneous_think && (eos_tokens.contains(&first) || max_tokens <= 1) {
             let mut a = ActiveSeq {
                 seq,

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -68,6 +68,9 @@ pub fn prefill_request(
     let req_top_logprobs = req.top_logprobs();
     let req_timeout_at = req.timeout_at();
     let grammar_spec = req.take_grammar_spec();
+    // Match the chunked path: include grammar preparation once in service TTFT,
+    // while retaining the existing exclusion of HTTP handling and queue time.
+    let request_start = Instant::now();
     let mut grammar_state = compile_grammar_state(grammar_engine, &grammar_spec, eos_tokens);
     let (prompt_tokens, max_tokens, mut sink, image_pixels, temperature, cancel_flag) = match req {
         InferenceRequest::Streaming {
@@ -103,7 +106,6 @@ pub fn prefill_request(
         ),
     };
 
-    let request_start = Instant::now();
     tracing::info!(
         "Prefilling: {} prompt tokens, max_tokens={max_tokens}",
         prompt_tokens.len(),

--- a/crates/spark-server/src/scheduler/prefill_b_step.rs
+++ b/crates/spark-server/src/scheduler/prefill_b_step.rs
@@ -160,7 +160,7 @@ pub fn prefill_request(
             req_require_tool_call && grammar_state.is_none() && tool_call_start_token.is_some();
         let tool_request = grammar_state.is_some() || use_legacy_tool_call;
         let now = Instant::now();
-        let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+        let cached_prompt_tok = seq.reused_prefix_tokens as u32;
         let mut a = ActiveSeq {
             seq,
             session_hash: req_session_hash,
@@ -358,7 +358,7 @@ pub fn prefill_request(
     let tool_request = grammar_state.is_some() || use_legacy_tool_call;
 
     let now = Instant::now();
-    let cached_prompt_tok = seq.cached_prefix_tokens as u32;
+    let cached_prompt_tok = seq.reused_prefix_tokens as u32;
 
     if !spontaneous_think && (eos_tokens.contains(&first) || max_tokens <= 1) {
         let mut a = ActiveSeq {

--- a/crates/spark-server/src/scheduler/prefill_timing_tests.rs
+++ b/crates/spark-server/src/scheduler/prefill_timing_tests.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The scheduler-service TTFT clock must include grammar preparation.
+//! Exercise the real deferred-prefill entry point without GPU work. A parser
+//! records the instant its real grammar compile begins; request_start must
+//! precede that instant, including a cache hit. No wall-time threshold/sleep.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::api::InferenceRequest;
+use crate::api::inference_types::GrammarSpec;
+use crate::grammar::{GrammarEngine, GrammarError};
+use crate::tool_parser::{
+    IncomingToolCall, PromptLevers, ToolCallParser, ToolChoice, ToolDefinition,
+};
+use xgrammar::CompiledGrammar;
+
+struct ObservedParser(Arc<Mutex<Option<Instant>>>);
+
+impl ToolCallParser for ObservedParser {
+    fn name(&self) -> &str {
+        "observed-grammar"
+    }
+    fn system_prompt(&self, _: &[ToolDefinition], _: &ToolChoice, _: &PromptLevers) -> String {
+        unreachable!("request is already tokenized")
+    }
+    fn format_tool_calls(&self, _: &[IncomingToolCall]) -> String {
+        unreachable!("request is already tokenized")
+    }
+    fn compile_tool_grammar(
+        &self,
+        engine: &mut GrammarEngine,
+        _: &[ToolDefinition],
+        _: bool,
+    ) -> Option<Result<CompiledGrammar, GrammarError>> {
+        *self.0.lock().unwrap() = Some(Instant::now());
+        Some(engine.compile_ebnf("root ::= \"x\"", "root"))
+    }
+}
+
+fn request(grammar_spec: Option<GrammarSpec>) -> InferenceRequest {
+    let (response_tx, _rx) = tokio::sync::oneshot::channel();
+    InferenceRequest::Blocking {
+        prompt_tokens: Arc::new(vec![0]),
+        session_hash: 0,
+        adapter_slot: -1,
+        src_lang_id: 0,
+        tgt_lang_id: 0,
+        num_beams: 1,
+        length_penalty: 1.0,
+        early_stopping: false,
+        image_pixels: vec![],
+        max_tokens: 2,
+        min_tokens: 0,
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        top_n_sigma: 0.0,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+        dry_multiplier: 0.0,
+        dry_base: 0.0,
+        dry_allowed_length: 0,
+        lz_penalty: 0.0,
+        logit_bias: vec![],
+        stop_tokens: vec![],
+        enable_thinking: false,
+        thinking_budget: None,
+        repetition_detection: None,
+        require_tool_call: false,
+        tools_present: grammar_spec.is_some(),
+        suppress_tool_call: false,
+        disable_mtp: true,
+        grammar_spec,
+        seed: Some(42),
+        top_logprobs: None,
+        prompt_logprobs: None,
+        echo: false,
+        timeout_at: None,
+        response_tx,
+    }
+}
+
+#[test]
+fn deferred_prefill_clock_includes_cold_and_cached_grammar_preparation() {
+    let marker = Arc::new(Mutex::new(None));
+    let mut engine = Some(GrammarEngine::new(&["x".to_string()], &[]).unwrap());
+    for cached in [false, true] {
+        let spec = GrammarSpec::ToolCall {
+            tools: vec![],
+            parser: Arc::new(ObservedParser(Arc::clone(&marker))),
+            use_triggers: true,
+        };
+        let result = super::prefill_a_step::start_chunked_prefill(
+            &super::sched_ctx::SchedCtx::for_test(),
+            None,
+            None,
+            None,
+            None,
+            &super::lifecycle_tests::StubModel,
+            request(Some(spec)),
+            &[],
+            1,
+            0,
+            0,
+            &mut engine,
+            0,
+            true,
+            None,
+            None,
+        )
+        .unwrap();
+        let super::emit_step::StartPrefillResult::InProgress(prefill) = result else {
+            panic!("deferred prefill unexpectedly performed inference");
+        };
+        assert!(
+            prefill.grammar_state.is_some(),
+            "real grammar must be prepared"
+        );
+        let compiled_at = marker.lock().unwrap().unwrap();
+        assert!(
+            prefill.request_start <= compiled_at,
+            "TTFT origin excluded grammar preparation (cached={cached})"
+        );
+    }
+}

--- a/crates/spark-server/src/tokenizer.rs
+++ b/crates/spark-server/src/tokenizer.rs
@@ -62,9 +62,9 @@ fn normalize_tool_call_arguments(messages: &[serde_json::Value]) -> Vec<serde_js
 
 /// Wraps a HuggingFace tokenizer with Jinja chat template support.
 mod chat_impl;
-mod chat_render;
+pub(crate) mod chat_render;
 mod deepseek_v4;
-mod jinja_helpers;
+pub(crate) mod jinja_helpers;
 mod message_preprocess;
 
 pub(crate) use message_preprocess::{

--- a/crates/spark-server/src/tokenizer.rs
+++ b/crates/spark-server/src/tokenizer.rs
@@ -82,6 +82,8 @@ pub struct ChatTokenizer {
     eos_token_id: u32,
     supports_thinking: bool,
     chat_encoding: ChatEncoding,
+    /// Checkpoint Qwen tool instructions own schema rendering (no override selected).
+    native_qwen_tool_template: bool,
     /// Compiled Jinja chat template (from tokenizer_config.json).
     #[allow(dead_code)]
     chat_template: String,

--- a/crates/spark-server/src/tokenizer/chat_impl.rs
+++ b/crates/spark-server/src/tokenizer/chat_impl.rs
@@ -90,13 +90,16 @@ impl ChatTokenizer {
         } else {
             super::jinja_helpers::load_override_template(model_type, repo_root)
         };
-        let chat_template = if let Some(override_tmpl) = override_tmpl {
-            override_tmpl
+        let (chat_template, checkpoint_template) = if let Some(override_tmpl) = override_tmpl {
+            (override_tmpl, false)
         } else if let Some(config_tmpl) = super::jinja_helpers::load_config_template(model_dir)? {
-            config_tmpl
+            (config_tmpl, true)
         } else {
             tracing::warn!("No chat template found — using default ChatML");
-            super::jinja_helpers::default_chatml_template(supports_thinking)
+            (
+                super::jinja_helpers::default_chatml_template(supports_thinking),
+                false,
+            )
         };
 
         let jinja_env = super::jinja_helpers::build_jinja_env(&chat_template)?;
@@ -116,16 +119,29 @@ impl ChatTokenizer {
             ChatEncoding::Jinja
         };
 
+        let native_qwen_tool_template = checkpoint_owns_qwen_tool_prompt(
+            model_type,
+            checkpoint_template,
+            openai_jinja_env.is_some(),
+        ) && jinja_env
+            .get_template("chat")?
+            .undeclared_variables(false)
+            .contains("tools");
         tracing::info!("Loaded tokenizer from {}", tokenizer_path.display());
         Ok(Self {
             tokenizer,
             eos_token_id,
             supports_thinking,
             chat_encoding,
+            native_qwen_tool_template,
             chat_template,
             jinja_env,
             openai_jinja_env,
         })
+    }
+
+    pub(crate) fn uses_native_qwen_tool_template(&self) -> bool {
+        self.native_qwen_tool_template
     }
 
     /// Returns a borrowed reference to the underlying HF tokenizer (for
@@ -446,4 +462,19 @@ impl ChatTokenizer {
         }
         out
     }
+}
+
+/// Only the known Qwen checkpoint templates own XML tool instructions.
+/// Custom overrides and ChatML fallback retain parser-provided instructions.
+fn checkpoint_owns_qwen_tool_prompt(
+    model_type: &str,
+    checkpoint: bool,
+    openai_override: bool,
+) -> bool {
+    checkpoint
+        && !openai_override
+        && matches!(
+            model_type,
+            "qwen3_5" | "qwen3_5_moe" | "qwen3_6" | "qwen3_6_moe"
+        )
 }

--- a/crates/spark-server/src/tokenizer/jinja_helpers.rs
+++ b/crates/spark-server/src/tokenizer/jinja_helpers.rs
@@ -412,7 +412,7 @@ pub(super) fn default_chatml_template(supports_thinking: bool) -> String {
 
 /// Convert Python Jinja2 syntax to minijinja-compatible syntax.
 /// Handles: slice reversal, string methods, etc.
-pub(super) fn convert_python_jinja_to_minijinja(template: &str) -> String {
+pub(crate) fn convert_python_jinja_to_minijinja(template: &str) -> String {
     let mut t = template.to_string();
 
     // messages[::-1] → messages | reverse

--- a/crates/spark-server/src/tokenizer/tests.rs
+++ b/crates/spark-server/src/tokenizer/tests.rs
@@ -7,7 +7,6 @@ use serde_json::json;
 
 mod laguna;
 mod mistral_effort;
-mod native_tool_prompt;
 mod qwen_dense;
 mod qwen_dense_parity;
 

--- a/crates/spark-server/src/tokenizer/tests.rs
+++ b/crates/spark-server/src/tokenizer/tests.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Extracted piecewise from `tokenizer.rs` (500-LoC cap).
-
 use super::*;
 
 mod deepseek_v4;
@@ -9,6 +7,7 @@ use serde_json::json;
 
 mod laguna;
 mod mistral_effort;
+mod native_tool_prompt;
 mod qwen_dense;
 mod qwen_dense_parity;
 

--- a/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
+++ b/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
@@ -4,10 +4,10 @@
 //! 1135 tokens and vLLM as 320. Test the production parser contribution and
 //! render core against the pinned checkpoint template, without loading a GPU.
 
-use super::super::chat_render::{RenderFlags, render_chat};
-use super::super::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
 use crate::api::chat::prepare::{inject_tool_system_prompt, parser_tool_prompt};
 use crate::ir::{ContentPart, Message, Role};
+use crate::tokenizer::chat_render::{RenderFlags, render_chat};
+use crate::tokenizer::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
 use crate::tool_parser::{
     HermesParser, PromptLevers, Qwen3CoderParser, Qwen3XmlParser, ToolCallParser, ToolChoice,
     ToolChoiceFunction, ToolDefinition,
@@ -41,7 +41,7 @@ fn tools() -> Vec<ToolDefinition> {
 fn render(messages: &[Message], style: ToolJsonStyle) -> String {
     // Qwen/Qwen3.6-35B-A3B-FP8 @ 95a723d08a9490559dae23d0cff1d9466213d989.
     let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
-    let converted = super::super::jinja_helpers::convert_python_jinja_to_minijinja(raw);
+    let converted = crate::tokenizer::jinja_helpers::convert_python_jinja_to_minijinja(raw);
     let env = build_jinja_env_with(&converted, style).unwrap();
     let messages: Vec<_> = messages
         .iter()
@@ -162,7 +162,7 @@ fn native_qwen_tool_prompt_preserves_user_system_message() {
 
 #[test]
 fn native_qwen_tool_prompt_ownership_tracks_actual_template_selection() {
-    use super::super::ChatTokenizer;
+    use crate::tokenizer::ChatTokenizer;
     let root = tempfile::tempdir().unwrap();
     let model = root.path().join("model");
     let repo = root.path().join("repo");

--- a/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
+++ b/crates/spark-server/src/tokenizer/tests/native_tool_prompt.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! H100 rental reproduction: the same get_weather request reached Atlas as
+//! 1135 tokens and vLLM as 320. Test the production parser contribution and
+//! render core against the pinned checkpoint template, without loading a GPU.
+
+use super::super::chat_render::{RenderFlags, render_chat};
+use super::super::jinja_helpers::{ToolJsonStyle, build_jinja_env_with};
+use crate::api::chat::prepare::{inject_tool_system_prompt, parser_tool_prompt};
+use crate::ir::{ContentPart, Message, Role};
+use crate::tool_parser::{
+    HermesParser, PromptLevers, Qwen3CoderParser, Qwen3XmlParser, ToolCallParser, ToolChoice,
+    ToolChoiceFunction, ToolDefinition,
+};
+use serde_json::json;
+
+fn user() -> Message {
+    Message {
+        role: Role::User,
+        content: vec![ContentPart::Text(
+            "What is the weather in Reykjavik over the next three days? Use the tool.".into(),
+        )],
+        tool_calls: Vec::new(),
+        tool_call_id: None,
+        name: None,
+        reasoning: None,
+        tool_error: false,
+    }
+}
+
+fn tools() -> Vec<ToolDefinition> {
+    serde_json::from_value(json!([{"type":"function","function":{
+        "name":"get_weather","description":"Look up the current weather for a city.",
+        "parameters":{"type":"object","properties":{
+            "city":{"type":"string","description":"City name."},
+            "days":{"type":"integer","description":"Forecast horizon in days."}},
+            "required":["city","days"]}}}]))
+    .unwrap()
+}
+
+fn render(messages: &[Message], style: ToolJsonStyle) -> String {
+    // Qwen/Qwen3.6-35B-A3B-FP8 @ 95a723d08a9490559dae23d0cff1d9466213d989.
+    let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
+    let converted = super::super::jinja_helpers::convert_python_jinja_to_minijinja(raw);
+    let env = build_jinja_env_with(&converted, style).unwrap();
+    let messages: Vec<_> = messages
+        .iter()
+        .map(|m| {
+            json!({
+                "role": if m.role == Role::System {"system"} else {"user"},
+                "content": m.text(),
+            })
+        })
+        .collect();
+    let tools: Vec<_> = tools()
+        .iter()
+        .map(|t| serde_json::to_value(t).unwrap())
+        .collect();
+    render_chat(&env, &messages, Some(&tools), RenderFlags::default()).unwrap()
+}
+
+#[test]
+fn native_qwen_tool_prompt_has_one_instruction_source() {
+    let original = vec![user()];
+    let mut messages = original.clone();
+    let contribution = parser_tool_prompt(
+        &Qwen3CoderParser,
+        &tools(),
+        &ToolChoice::Mode("auto".into()),
+        &PromptLevers::OFF,
+        true,
+    );
+    inject_tool_system_prompt(&mut messages, contribution);
+    let actual = render(&messages, ToolJsonStyle::Compact);
+    let native = render(&original, ToolJsonStyle::Compact);
+    let hf = render(&original, ToolJsonStyle::HfSpaced);
+    println!(
+        "RENDER_RECEIPT={}",
+        json!({"actual":actual,"native_compact":native,"native_hf_spaced":hf})
+    );
+    assert_eq!(
+        actual.matches("# Tools").count(),
+        1,
+        "duplicate tool instructions"
+    );
+    assert_eq!(
+        actual, native,
+        "parser must not duplicate checkpoint tool instructions"
+    );
+    assert_eq!(
+        messages, original,
+        "client messages must not gain an unrelated system block"
+    );
+}
+
+#[test]
+fn native_qwen_tool_prompt_keeps_required_and_named_choices() {
+    for parser in [&Qwen3CoderParser as &dyn ToolCallParser, &Qwen3XmlParser] {
+        for choice in [
+            ToolChoice::Mode("required".into()),
+            ToolChoice::Specific {
+                function: ToolChoiceFunction {
+                    name: "get_weather".into(),
+                },
+            },
+        ] {
+            let prompt = parser_tool_prompt(parser, &tools(), &choice, &PromptLevers::OFF, true);
+            assert!(
+                prompt.contains("MUST call"),
+                "tool choice enforcement retained"
+            );
+            assert!(
+                !prompt.contains("# Tools"),
+                "schema belongs to native template"
+            );
+            if matches!(choice, ToolChoice::Specific { .. }) {
+                assert!(prompt.contains("'get_weather'"));
+            }
+        }
+    }
+}
+
+#[test]
+fn native_qwen_tool_prompt_preserves_fallback_tscg_and_other_parsers() {
+    let choice = ToolChoice::Mode("auto".into());
+    for parser in [
+        &Qwen3CoderParser as &dyn ToolCallParser,
+        &Qwen3XmlParser,
+        &HermesParser,
+    ] {
+        for (native, tscg) in [(false, false), (false, true), (true, true)] {
+            let levers = PromptLevers::new(tscg);
+            assert_eq!(
+                parser_tool_prompt(parser, &tools(), &choice, &levers, native),
+                parser.system_prompt(&tools(), &choice, &levers)
+            );
+        }
+    }
+    assert_eq!(
+        parser_tool_prompt(&HermesParser, &tools(), &choice, &PromptLevers::OFF, true),
+        HermesParser.system_prompt(&tools(), &choice, &PromptLevers::OFF)
+    );
+}
+
+#[test]
+fn native_qwen_tool_prompt_preserves_user_system_message() {
+    let mut messages = vec![
+        Message::synthetic_system("User supplied system policy".into()),
+        user(),
+    ];
+    let before = messages.clone();
+    let contribution = parser_tool_prompt(
+        &Qwen3CoderParser,
+        &tools(),
+        &ToolChoice::Mode("auto".into()),
+        &PromptLevers::OFF,
+        true,
+    );
+    inject_tool_system_prompt(&mut messages, contribution);
+    assert_eq!(messages, before);
+}
+
+#[test]
+fn native_qwen_tool_prompt_ownership_tracks_actual_template_selection() {
+    use super::super::ChatTokenizer;
+    let root = tempfile::tempdir().unwrap();
+    let model = root.path().join("model");
+    let repo = root.path().join("repo");
+    std::fs::create_dir_all(&model).unwrap();
+    std::fs::create_dir_all(repo.join("jinja-templates/openai")).unwrap();
+    tokenizers::Tokenizer::new(tokenizers::models::wordlevel::WordLevel::default())
+        .save(model.join("tokenizer.json"), false)
+        .unwrap();
+    let load =
+        |kind| ChatTokenizer::from_model_dir(&model, 0, true, kind, Some(&repo), false).unwrap();
+    // No template is the ChatML fallback, even for a known Qwen model type.
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+    std::fs::write(
+        model.join("tokenizer_config.json"),
+        json!({"chat_template":"{{ messages }}"}).to_string(),
+    )
+    .unwrap();
+    assert!(
+        !load("qwen3_6_moe").uses_native_qwen_tool_template(),
+        "a custom checkpoint template without tools needs parser instructions"
+    );
+    let raw = include_str!("../../../test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja");
+    std::fs::write(
+        model.join("tokenizer_config.json"),
+        json!({"chat_template":raw}).to_string(),
+    )
+    .unwrap();
+    for kind in ["qwen3_5", "qwen3_5_moe", "qwen3_6", "qwen3_6_moe"] {
+        assert!(load(kind).uses_native_qwen_tool_template(), "{kind}");
+    }
+    assert!(!load("nemotron_h").uses_native_qwen_tool_template());
+    let custom = repo.join("jinja-templates/qwen3_6_moe.jinja");
+    std::fs::write(&custom, "{{ messages }}").unwrap();
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+    std::fs::remove_file(custom).unwrap();
+    std::fs::write(
+        repo.join("jinja-templates/openai/qwen3_6_moe.jinja"),
+        "{{ messages }}",
+    )
+    .unwrap();
+    assert!(!load("qwen3_6_moe").uses_native_qwen_tool_template());
+}

--- a/crates/spark-server/src/tool_parser.rs
+++ b/crates/spark-server/src/tool_parser.rs
@@ -54,43 +54,6 @@ fn is_normalized_tool_name(name: &str) -> bool {
     !name.is_empty() && !name.contains(':')
 }
 
-/// Normalize a model-emitted function name to the client-visible tool name.
-///
-/// This keeps existing parser salvage behaviour (`Bash=Bash` -> `Bash`,
-/// `name="Write"` -> `Write`) and adds namespace stripping for colon-prefixed
-/// names (`namespace:tool` -> `tool`). Dot characters are preserved because
-/// some callers use them in actual tool names; only `:` is treated as the
-/// namespace delimiter.
-fn normalize_tool_name(raw: &str) -> String {
-    let mut name = raw.trim().trim_matches('"').trim_matches('\'').to_string();
-
-    if name.starts_with("name=") || name.starts_with("name =") {
-        name = name
-            .trim_start_matches("name")
-            .trim_start_matches('=')
-            .trim()
-            .trim_matches('"')
-            .trim_matches('\'')
-            .to_string();
-    }
-
-    if let Some(eq_pos) = name.find('=') {
-        name = name[..eq_pos].trim().to_string();
-    }
-
-    if let Some(colon) = name.rfind(':') {
-        let head = &name[..colon];
-        let tail = &name[colon + 1..];
-        let head_is_namespace =
-            !head.is_empty() && head.chars().all(is_tool_name_or_namespace_char);
-        if head_is_namespace && is_tool_name_component(tail) {
-            name = tail.to_string();
-        }
-    }
-
-    name
-}
-
 // ── Request types (from OpenAI-compatible clients) ──
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -495,6 +458,7 @@ pub use bare_json::*;
 pub use deepseek_v4_dsml::*;
 pub use gemma4::*;
 use helpers_a::*;
+pub(crate) use helpers_b::append_tool_choice_instruction;
 use helpers_b::*;
 pub use hermes::*;
 pub use minimax_xml::*;

--- a/crates/spark-server/src/tool_parser/helpers_a.rs
+++ b/crates/spark-server/src/tool_parser/helpers_a.rs
@@ -348,3 +348,40 @@ fn append_repaired_member(out: &mut String, member: &str, first: &mut bool) -> b
     out.push_str(&val_quoted);
     true
 }
+
+/// Normalize a model-emitted function name to the client-visible tool name.
+///
+/// This keeps existing parser salvage behaviour (`Bash=Bash` -> `Bash`,
+/// `name="Write"` -> `Write`) and adds namespace stripping for colon-prefixed
+/// names (`namespace:tool` -> `tool`). Dot characters are preserved because
+/// some callers use them in actual tool names; only `:` is treated as the
+/// namespace delimiter.
+pub(super) fn normalize_tool_name(raw: &str) -> String {
+    let mut name = raw.trim().trim_matches('"').trim_matches('\'').to_string();
+
+    if name.starts_with("name=") || name.starts_with("name =") {
+        name = name
+            .trim_start_matches("name")
+            .trim_start_matches('=')
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
+    }
+
+    if let Some(eq_pos) = name.find('=') {
+        name = name[..eq_pos].trim().to_string();
+    }
+
+    if let Some(colon) = name.rfind(':') {
+        let head = &name[..colon];
+        let tail = &name[colon + 1..];
+        let head_is_namespace =
+            !head.is_empty() && head.chars().all(is_tool_name_or_namespace_char);
+        if head_is_namespace && is_tool_name_component(tail) {
+            name = tail.to_string();
+        }
+    }
+
+    name
+}

--- a/crates/spark-server/src/tool_parser/helpers_b.rs
+++ b/crates/spark-server/src/tool_parser/helpers_b.rs
@@ -162,7 +162,7 @@ pub(super) fn gemma4_to_json(native: &str) -> String {
 }
 
 /// Shared tool_choice instruction appended to all system prompts.
-pub(super) fn append_tool_choice_instruction(prompt: &mut String, tool_choice: &ToolChoice) {
+pub(crate) fn append_tool_choice_instruction(prompt: &mut String, tool_choice: &ToolChoice) {
     match tool_choice {
         ToolChoice::Mode(s) if s == "required" => {
             prompt.push_str(

--- a/crates/spark-server/test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja
+++ b/crates/spark-server/test_data/chat_templates/qwen3.6-35b-a3b-fp8.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
+++ b/kernels/gb10/qwen3.6-35b-a3b/BENCH.toml
@@ -449,15 +449,46 @@ max = 0.0
 # restored from anchors 992-1152). The floor of 1 is a DEFINITION, not a
 # measurement: it distinguishes "the restore path ran" from "prefix caching
 # was off and the gate replayed against a cold engine" — the configuration
-# under which this gate once returned a green PASS proving nothing. Ratchet
-# toward the observed anchor scale (~992 on this checkpoint) after the first
-# recorded run that carries this metric; do not guess a higher floor before
-# then.
+# under which this gate once returned a green PASS proving nothing.
+#
+# ★ RATCHETED 2026-09-11, 1.0 -> 900.0, discharging this comment's own
+# instruction to "ratchet toward the observed anchor scale after the first
+# recorded run that carries this metric". That condition was met 54 runs ago:
+# EVERY passing record carrying the metric reads exactly 1026.0 — 54 of 54,
+# zero variance, across four weeks and three checkpoint-config generations.
+# The floor of 900.0 sits ~12% under that invariant, which is margin for a
+# different anchor scale rather than for noise; there is no noise to cover.
+#
+# The one record that does not read 1026 is 2026-08-15-d4c00509b7, which reads
+# 0 — a FAIL whose reference round never ran (rounds 0). That is the vacuity
+# case this bound exists for, and it confirms the bound catches it. What 1.0
+# could not catch is the case in between: a server caching a handful of tokens
+# rather than a real anchor would have passed a floor of 1 while proving as
+# little as the cold engine did.
 [benchmarks.metrics.min_cached_prompt_tokens]
-min = 1.0
+min = 900.0
 
 [benchmarks.metrics.sum_wall_s]
-max = 1200.0
+# The blowup detector, not a perf gate. The ceiling of 200.0 replaces 1200.0
+# as of 2026-09-11, discharging the entry note's "generous pending the first
+# recorded run; ratchet after measurement, never to the best".
+#
+# Measured on THIS entry's pinned instrument (disable_thinking = "true",
+# ssm_cache_slots = "256"): 54 passing records spanning 75.8 to 114.4 s, in
+# three levels — ~110-114 (2026-08-15 to 08-23), ~82-85 (08-23 onward) and
+# 75.8-76.6 on 09-08, the same f9fd8ca43 step the decode floor records. 200.0
+# is 1.75x the worst of them, so it is not drawn near the best.
+#
+# ★ Three older records read 306.8 / 320.8 / 321.4 and are NOT the basis: they
+# predate the disable_thinking pin, so they measured thinking-on generation —
+# roughly 3x the work — and check_record would refuse them against this
+# baseline in any case. A ceiling drawn to cover them would have to be 400+,
+# which is a ceiling for an instrument this entry no longer serves.
+#
+# What 200.0 is sized to catch: one round hanging to the 300 s request timeout
+# takes the sum past 300 on its own, and a uniform 50% slowdown lands near 170.
+# Both fail. The superseded 1200.0 caught neither, and nothing said so.
+max = 200.0
 
 # --- vision-fidelity -------------------------------------------------------
 # Vision models only. This gate is declared on the three targets that ship a

--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -220,9 +220,53 @@ measured without proof of speculative engagement is the 2026-08-15 decode \
 flip-flop all over again."""
 
 [benchmarks.metrics.server_decode_tok_s]
-# Median-of-3 server decode rate. The floor of 22.7 is the bound in force —
-# an effective floor of 22.2 tok/s once noise 0.5 is applied by
+# Median-of-3 server decode rate. The floor of 25.0 is the bound in force —
+# an effective floor of 24.5 tok/s once noise 0.5 is applied by
 # scoring::compare.
+#
+# ★ RATCHETED 2026-09-11, 22.7 -> 25.0, from a fresh 12-run set on this
+# entry's own instrument and on dgx2 (spark-43fa) — the SLOWEST box, which is
+# where the superseded bar was drawn from too, so the basis is comparable:
+#
+#     26.3 26.1 26.1 26.2 26.1 26.1 26.1 26.1 26.1 26.1 26.1 26.1
+#     n=12  mean 26.125  sigma 0.062  range 26.1-26.3
+#
+# sigma is quantization-limited (the gate reports one decimal), so the true
+# spread is at most this. 24.5 sits ~26 sigma below the mean, and ~6.2% below
+# it — wider than the mean-minus-5% the sweeps use, so this is a deliberately
+# conservative ratchet rather than the tightest the data allows (that would be
+# 25.3).
+#
+# ★ WHY THE LEVEL MOVED. It is a STEP, not drift: records from 2026-08-23 to
+# 09-07 read 22.4-23.5 and records from 09-08 onward read 26.1-26.3, with
+# accept_len_mean 2.6826 unchanged across the whole span — so this is a
+# wall-clock change, not better speculation.
+#
+# ★ THE CAUSE IS NOT #968, AND AN EARLIER DRAFT OF THIS NOTE SAID IT WAS.
+# Three things in this repository refute it, and they are recorded here so the
+# wrong story is not re-derived:
+#   * f9fd8ca43's own message states "C=1 IS IDENTICAL, AND THAT IS THE
+#     DIAGNOSTIC — parent 18.5 / with bug 18.5". The bug it fixed only bites
+#     when admissions interleave, so it cannot move a serial rung.
+#   * The campaign measured AT f9fd8ca43 reads 22.58 here and C1 18.42 on the
+#     sweep — both PRE-step values, at the very commit credited with the step.
+#     That record was committed in ac736e938 and dropped in 3cfe4d8c45, which
+#     is the only reason "every record from 09-08 reads 26.1-26.3" looked true.
+#     `git show ac736e938:.benchmarks/decode-floor/2026-09-08-f9fd8ca431.json`.
+#   * The DFlash2 ladder stepped on the same day, and that gate is
+#     conflicts_with = "speculative", so an mtp-carry fix cannot reach it.
+#
+# The leading candidate is 7dd531f59 (#965, the GLM-5.3-Flash port), the only
+# code change on the first-parent path through this window; it rewrote the
+# dense_gemv M=1 sites that a 248K-vocab BF16 lm head leans on, which fits a
+# gain that is large serially and vanishes above C=2. STATED AS A CANDIDATE,
+# NOT A FINDING: no A/B across 7dd531f59^ has been run, and this note has
+# already been wrong once about the cause.
+#
+# What the bar does NOT depend on: the step is measured, reproduced 15 times,
+# and 24.5 sits far above the entire pre-step band whatever moved it. The
+# attribution matters for knowing what to protect, not for whether to protect
+# it.
 #
 # ★ RATCHETED 2026-09-06, 21.0 -> 22.7, and this is the FIRST time this
 # entry's own ">=10-run set on this same instrument" rule has actually been
@@ -264,10 +308,10 @@ flip-flop all over again."""
 # and therefore the only box that can certify, the margin is ~1.5 tok/s.
 # Re-cut this floor if a second box is ever registered and is slower.
 #
-# noise 0.5 covers the run-to-run band (observed 0.2 peak-to-peak over the ten
-# runs) and stays under the 5% validate_noise cap (5% of 22.7 = 1.135).
+# noise 0.5 covers the run-to-run band (observed 0.2 peak-to-peak over the
+# twelve runs) and stays under the 5% validate_noise cap (5% of 25.0 = 1.25).
 # Ratchet only from a fresh >=10-run set on this same instrument.
-min = 22.7
+min = 25.0
 noise = 0.5
 [benchmarks.metrics.output_tokens]
 # The driver emits the MINIMUM completion_tokens across the 3 runs, so this

--- a/scripts/check_cross_hardware.py
+++ b/scripts/check_cross_hardware.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Cross-hardware kernel interference (CHKI): who else compiles the bytes you changed?
+
+`kernels/<hw>/` LOOKS like one tree per hardware. It is not. strix is 7 real files and
+105 symlinks, 97 of them into `kernels/gb10/common/`; strix-hip is 22 real and 87
+symlinks. So an edit to a gb10 file silently changes what AMD compiles, and the only
+signal has ever been a compile failure:
+
+  d584c0c50  `__syncwarp()` added to gb10/common/w4a16_gemv.cu, which is symlinked into
+             strix and strix-hip; hipcc rejects it. Caught ONLY because the windows-hip
+             release leg failed. A performance-only effect would have been invisible.
+  17fe989ec  A Strix workaround left inside gb10 common device code invalidated 27
+             targets' benchmark records and forced a full GPU re-measurement.
+
+`gate/taxon.rs::hardware_of()` cannot see any of this — it is a path prefix. This script
+resolves the three real sharing mechanisms (symlinks, `common/` fan-out, `[model]
+kernel_source` redirects, plus symlinked KERNEL.toml/MODEL.toml) and says which hardware
+actually consumes each changed path.
+
+WHY IT IS FAIL-CLOSED, unlike classify-diff.sh: that script decides what to SKIP and must
+fail open. This one decides a VERDICT. "Cannot see the inputs" (rc 2) is as red as a
+violation (rc 1) — the same doctrine as campaign-guard.sh's exit 2.
+
+WHAT IT CANNOT DECIDE, and hands to the oracle
+(.claude/skills/oracle_pre_commit_cross_hardware_check): whether a hunk sits inside a
+`#if defined(__SCALE__)` arm the other hardware never compiles; whether a `cfg!(atlas_scale)`
+host site pairs with a device constant you moved; and whether a textually-shared change is
+performance-relevant to a hardware with no benchmark record and no CI box. Reach is provable;
+harm is not.
+"""
+import argparse, json, os, subprocess, sys, tempfile
+from pathlib import Path
+
+HW_SOURCE_EXT = {"gb10": ".cu", "metal": ".metal", "strix": ".cu", "strix-hip": ".cu"}
+CONFIG_NAMES = {"HARDWARE.toml", "KERNEL.toml", "MODEL.toml"}
+AMD_TOKENS = ("__SCALE__", "__HIPCC__", "__HIP_DEVICE_COMPILE__", "__HIP_PLATFORM")
+
+
+def git(*a, cwd=None, check=True):
+    r = subprocess.run(["git", *a], cwd=cwd, capture_output=True, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(a)}: {r.stderr.strip()}")
+    return r.stdout
+
+
+def hardware_of(path):
+    p = Path(path).parts
+    return p[1] if len(p) > 1 and p[0] == "kernels" else None
+
+
+def kernel_source(model_dir):
+    """`[model] kernel_source = "other"` redirects where a model's quant dirs are read from."""
+    mt = model_dir / "MODEL.toml"
+    if not mt.exists():
+        return None
+    for line in mt.read_text(errors="replace").splitlines():
+        s = line.split("#", 1)[0].strip()
+        if s.startswith("kernel_source"):
+            v = s.split("=", 1)[1].strip().strip('"').strip("'")
+            return v or None
+    return None
+
+
+def quoted_includes(path):
+    """Quoted #includes, resolved LEXICALLY against the file's own directory.
+
+    Lexical, not canonical, because nvcc is handed the SYMLINK path (build.rs passes the
+    read_dir entry and sets no -I), so `#include "x.cuh"` inside a symlinked .cu resolves
+    against the LINKING hardware's dir. That is how strix-hip's real prefill_paged_compute.cuh
+    (BR64 32) shadows gb10's (BR64 64) even though the .cu including it is a symlink.
+    """
+    out = []
+    try:
+        txt = Path(path).read_text(errors="replace")
+    except OSError:
+        return out
+    for line in txt.splitlines():
+        s = line.strip()
+        if s.startswith("//") or not s.startswith("#include"):
+            continue
+        rest = s[len("#include"):].strip()
+        if not rest.startswith('"'):
+            continue
+        end = rest.find('"', 1)
+        if end > 1:
+            out.append(rest[1:end])
+    return out
+
+
+def build_index(root):
+    """realpath -> set of (hw, model, quant) targets that consume it."""
+    kroot = root / "kernels"
+    missing = [h for h in HW_SOURCE_EXT if not (kroot / h).is_dir()]
+    if missing:
+        raise RuntimeError(f"hardware tree(s) absent from {kroot}: {', '.join(missing)} "
+                           f"— refusing to scan a tree I cannot index")
+    consumers, targets = {}, []
+    for hw, ext in HW_SOURCE_EXT.items():
+        hwdir = kroot / hw
+        if not (hwdir / "HARDWARE.toml").exists():
+            continue
+        common = hwdir / "common"
+        for model_dir in sorted(p for p in hwdir.iterdir() if p.is_dir() and p.name != "common"):
+            if not (model_dir / "MODEL.toml").exists():
+                continue
+            src_dir = model_dir
+            ks = kernel_source(model_dir)
+            if ks:
+                cand = hwdir / ks
+                if not (cand / "MODEL.toml").exists():
+                    # unresolved redirect: fail closed, this model reaches everything on hw
+                    src_dir = hwdir
+                else:
+                    src_dir = cand
+            for quant_dir in sorted(p for p in src_dir.iterdir() if p.is_dir()):
+                t = (hw, model_dir.name, quant_dir.name)
+                targets.append(t)
+                # stem-keyed merge: common first, the model's quant dir SHADOWS it
+                merged = {}
+                for d in (common, quant_dir):
+                    if d.is_dir():
+                        for f in sorted(d.glob(f"*{ext}")):
+                            merged[f.stem] = f
+                seen = set()
+                for f in list(merged.values()):
+                    stack = [f]
+                    while stack:
+                        cur = stack.pop()
+                        rp = os.path.realpath(cur)
+                        if rp in seen:
+                            continue
+                        seen.add(rp)
+                        consumers.setdefault(rp, set()).add(t)
+                        for inc in quoted_includes(cur):
+                            cand = Path(cur).parent / inc
+                            if cand.exists():
+                                stack.append(cand)
+                for cfg in (hwdir / "HARDWARE.toml", common / "KERNEL.toml",
+                            model_dir / "MODEL.toml", quant_dir / "KERNEL.toml"):
+                    if cfg.exists():
+                        consumers.setdefault(os.path.realpath(cfg), set()).add(t)
+    return consumers, targets
+
+
+def changed_paths(root, base, head, three_dot, worktree):
+    if worktree:
+        spec = [base]
+    else:
+        spec = [f"{base}...{head}"] if three_dot else [f"{base}..{head}"] if head else [base]
+    out = git("diff", "--name-status", "--no-renames", *spec, "--", "kernels/", cwd=root)
+    rows = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            rows.append((parts[0][0], parts[-1]))
+    return rows
+
+
+def symlink_via(root, realpath_target):
+    """Every symlink under kernels/ that resolves to this file, for the operator."""
+    via = []
+    kroot = root / "kernels"
+    for dirpath, dirnames, filenames in os.walk(kroot):
+        for n in list(dirnames) + filenames:
+            p = Path(dirpath) / n
+            if p.is_symlink() and os.path.realpath(p) == realpath_target:
+                via.append((str(p.relative_to(root)), os.readlink(p)))
+    return via
+
+
+def trailers(root, base, head):
+    """`Hardware:` and `CHKI-Verdict:` over BASE..HEAD, plus PR_BODY if present."""
+    hw, verdict = set(), ""
+    try:
+        body = git("log", "--format=%B", f"{base}..{head or 'HEAD'}", cwd=root, check=False)
+    except Exception:
+        body = ""
+    body += "\n" + os.environ.get("PR_BODY", "")
+    for line in body.splitlines():
+        s = line.strip()
+        if s.lower().startswith("hardware:"):
+            hw |= {t.strip() for t in s.split(":", 1)[1].split(",") if t.strip()}
+        elif s.lower().startswith("chki-verdict:"):
+            verdict = s.split(":", 1)[1].strip()
+    return hw, verdict
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--base")
+    ap.add_argument("--head")
+    ap.add_argument("--merge-base", action="store_true", help="three-dot diff (pull_request)")
+    ap.add_argument("--worktree", action="store_true", help="include uncommitted changes")
+    ap.add_argument("--paths", nargs="*", help="attribution only; never fails on R1")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-selftest", action="store_true")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    try:
+        if not args.no_selftest:
+            selftest()
+        consumers, targets = build_index(root)
+    except Exception as e:
+        print(f"cross-hardware: CANNOT SEE INPUTS — {e}", file=sys.stderr)
+        return 2
+
+    attribution_only = args.paths is not None
+    if attribution_only:
+        rows = [("M", p) for p in args.paths]
+    else:
+        if not args.base:
+            print("cross-hardware: no base given", file=sys.stderr)
+            return 2
+        try:
+            rows = changed_paths(root, args.base, args.head, args.merge_base, args.worktree)
+        except Exception as e:
+            print(f"cross-hardware: CANNOT SEE INPUTS — {e}", file=sys.stderr)
+            return 2
+
+    declared, verdict_trailer = (set(), "") if attribution_only else trailers(root, args.base, args.head)
+    results, structural = [], []
+
+    for status, rel in rows:
+        owner = hardware_of(rel)
+        if owner is None:
+            continue
+        ap_ = root / rel
+        rp = os.path.realpath(ap_) if ap_.exists() else str(ap_)
+        reach = consumers.get(rp, set())
+        reach_hw = sorted({t[0] for t in reach})
+        leak = sorted(set(reach_hw) - {owner})
+
+        # S1: a NEW symlink that crosses hardware is never allowed.
+        if status in ("A", "T") and ap_.is_symlink():
+            tgt_hw = hardware_of(os.path.relpath(os.path.realpath(ap_), root))
+            if tgt_hw and tgt_hw != owner:
+                structural.append(("S1", rel, f"new cross-hardware symlink -> {tgt_hw}"))
+
+        if attribution_only:
+            v = "ATTRIBUTION"
+        elif not leak:
+            v = "OK"
+        elif not declared:
+            v = f"CHKI (undeclared: {', '.join(leak)})"
+        elif not (set(reach_hw) | {owner}) <= declared:
+            miss = sorted((set(reach_hw) | {owner}) - declared)
+            v = f"CHKI (unnamed: {', '.join(miss)})"
+        else:
+            v = f"DECLARED ({', '.join(leak)})"
+        results.append({"path": rel, "status": status, "owner": owner,
+                        "reach_hw": reach_hw, "targets": len(reach),
+                        "via": [f"{a} -> {b}" for a, b in symlink_via(root, rp)] if leak else [],
+                        "verdict": v})
+
+    # S4: dangling symlinks anywhere under kernels/
+    for dirpath, dirnames, filenames in os.walk(root / "kernels"):
+        for n in list(dirnames) + filenames:
+            p = Path(dirpath) / n
+            if p.is_symlink() and not p.exists():
+                structural.append(("S4", str(p.relative_to(root)), f"dangling -> {os.readlink(p)}"))
+
+    bad = [r for r in results if r["verdict"].startswith("CHKI")]
+    declared_rows = [r for r in results if r["verdict"].startswith("DECLARED")]
+    needs_verdict = bool(declared_rows) and not verdict_trailer
+
+    if args.json:
+        print(json.dumps({"base": args.base, "head": args.head,
+                          "trailers": {"hardware": sorted(declared), "verdict": verdict_trailer},
+                          "paths": results,
+                          "structural": [{"rule": a, "path": b, "detail": c} for a, b, c in structural],
+                          "verdict": "OK" if not (bad or structural or needs_verdict) else "CHKI"},
+                         indent=2))
+    else:
+        print(f"cross-hardware reach: {len(results)} changed kernel path(s)")
+        for r in results:
+            print(f"  {r['path']:<58} {r['owner']:<10} {','.join(r['reach_hw']) or '-':<22} "
+                  f"{r['targets']:>4}  {r['verdict']}")
+            for v in r["via"]:
+                print(f"      via: {v}")
+        for a, b, c in structural:
+            print(f"  {a} {b}: {c}")
+        print(f"Hardware trailer: {', '.join(sorted(declared)) or '(none)'}    "
+              f"CHKI-Verdict: {verdict_trailer or '(none)'}")
+        if attribution_only:
+            print("verdict: ATTRIBUTION (no pass/fail in --paths mode)")
+        elif bad or structural or needs_verdict:
+            print("verdict: CHKI")
+            print("next: /oracle_pre_commit_cross_hardware_check, then ONE of")
+            print("  (a) Hardware: <every reached hw>  +  CHKI-Verdict: benign -- <proof>")
+            print("  (b) parameterize in kernels/<hw>/HARDWARE.toml AND add the reader in")
+            print("      crates/atlas-kernels/build.rs in the SAME change (only `vendor` and")
+            print("      `arch` are read today; a key with no reader is decoration)")
+            print("  (c) separate kernel in the intended tree, pinned to base bytes, NO symlink")
+        else:
+            print("verdict: OK")
+
+    if attribution_only:
+        return 0
+    return 1 if (bad or structural or needs_verdict) else 0
+
+
+def selftest():
+    """RED/GREEN fixtures. A rule that cannot fire is a rule that is not a check."""
+    with tempfile.TemporaryDirectory() as td:
+        r = Path(td); k = r / "kernels"
+        for hw, vendor in (("gb10", "nvidia"), ("strix", "amd")):
+            (k / hw / "common").mkdir(parents=True)
+            (k / hw / "HARDWARE.toml").write_text(f'[hardware]\nname="{hw}"\nvendor="{vendor}"\narch="x"\n')
+            (k / hw / "m1" / "q").mkdir(parents=True)
+            (k / hw / "m1" / "MODEL.toml").write_text("[model]\n")
+        (k / "gb10" / "common" / "shared.cu").write_text("// shared\n")
+        (k / "strix" / "common" / "shared.cu").symlink_to("../../gb10/common/shared.cu")
+        (k / "gb10" / "common" / "own.cu").write_text("// gb10 only\n")
+        for hw in ("metal", "strix-hip"):
+            (k / hw / "common").mkdir(parents=True)
+            (k / hw / "HARDWARE.toml").write_text(f'[hardware]\nname="{hw}"\nvendor="x"\narch="y"\n')
+        cons, _ = build_index(r)
+        shared_rp = os.path.realpath(k / "gb10" / "common" / "shared.cu")
+        hw_reach = {t[0] for t in cons.get(shared_rp, set())}
+        assert hw_reach == {"gb10", "strix"}, f"RED fixture: symlink reach was {hw_reach}"
+        own_rp = os.path.realpath(k / "gb10" / "common" / "own.cu")
+        assert {t[0] for t in cons.get(own_rp, set())} == {"gb10"}, "GREEN fixture: own.cu leaked"
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> Same-repo restack of #998 (was `TheTom:pr/prefill-proj-w8a8`). Commits unchanged. Opened on `Avarok-Cybersecurity/atlas` so Graphite/GH can stack.

> **Stacked on #994** (which is itself stacked on #984 → #986 → #987 → #988 → #989). This PR's own content is the **last** of the twenty-two commits here; the twenty-one below it belong to those six PRs. Review this PR alone with `git diff cac361d7c..`, or just the commit titled `spark-model: route the remaining W8A16 prefill projections through the W8A8 cuBLASLt arm (#928)`. Merge order: **#984 → #986 → #987 → #988 → #989 → #994 → this**. Base is `main` rather than a stack branch so this PR does not become unreviewable if any of them is rebased.
>
> Why #994 is in the base, in one line: it supplies `ops::cublas_fp8_proj_prequant`, the k-major VEC128 activation-scale transpose and the per-family `ATLAS_CUBLAS_GEMM` scoping (via #989) that this PR's two new arms are built out of, and it owns `prefill_w8a8.rs` and `cache_skip_qkv.rs` in the shape this diff extends — including the source comment in `cache_skip_qkv.rs` that says, in #994, that the chunk-0 Q/K/V chain *cannot* take cuBLASLt. **This PR is the answer to that comment.** See **Conflicts** below.

## Summary

**The largest single kernel in an H100 prefill is 100.6 ms of W8A16 GEMM that no route change had ever reached — and it is not what the round-9 report said it was.**

nsys, 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8`, native FP8, 1193-token prompt, C=1: the prefill is **368.263 ms** of GPU-busy union, and `w8a16_gemm_pipelined` is **100.582 ms over 112 launches (27.31%)**, with `w8a16_gemm_t_m128` a further **12.012 ms over 32**. Round 9 read those 112 launches as the dense FFN's prefill GEMM. **Resolving them by grid geometry says otherwise:** they are the SSM `out_proj` (96 launches, 68.1 ms) and the attention `q_proj` of prefill chunk 0 (16 launches, 32.5 ms), with the `t_m128` 32 being that same chunk's `k_proj`/`v_proj`. The dense FFN is on `nvjet…` cuBLASLt lines at both chunk widths in the very same trace — #987 had already moved it.

So **112.6 ms — 30.6% of the prefill — is two projection sites that the `ssm` and `attn` cuBLASLt scopes were already armed for and simply did not reach.** One had no cuBLASLt arm at all and read a stale `ATLAS_FP8_W8A8=1` env var instead of the dispatch flag; the other documented its own exclusion in the source, because cuBLASLt writes `ceil16(M)` rows and its padded rows would cross into the next projection's region of a shared buffer.

This PR gives both sites the arm, under those same existing scopes, with per-region phantom-row accounting instead of a staging copy. **Measured on 1×H100, same binary, arms toggled by the two kill switches: 1193-token TTFT 371.6 → 267.9 ms (−27.9%)** and 4593-token **1,171.7 → 890.3 ms (−24.0%)**, with **C=1 TPOT unchanged at 17.86 ms** as the built-in null check and coherency 4/4.

Refs #928 and #917.

## What was wrong

nsys, 1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8, recipe `ATLAS_CUBLAS_GEMM=ffn,ssm,attn ATLAS_LM_HEAD_M16_TC=1`, C=1, `--cuda-graph-trace=node`, 2026-09-11 (run record `nsys-r9-prefill`). Prefill = first kernel of the drive segment to the end of its first `argmax_bf16_batch`; `%busy` is against the GPU-busy union, which matches the independently measured TTFT to **0.3%** (368.263 ms union vs 369.3 ms ladder p50).

| # | kernel | count | µs | % of busy |
|---|---|---|---|---|
| 1 | `w8a16_gemm_pipelined` | 112 | **100 581.9** | **27.31** |
| 2 | `gated_delta_rule_chunk_delta_h_vfused` | 96 | 97 830.3 | 26.57 |
| 3 | `nvjet_sm90_qqtst_128x128_128x6_1x2_h_bz_coopA_algo2…` | 176 | 32 462.8 | 8.82 |
| 7 | `w8a16_gemm_t_m128` | 32 | **12 012.2** | **3.26** |

**The kernels do not carry a label, so the sites were resolved from the launchers' own grid formulas** — `w8a16_gemm_pipelined` launches `(ceil(N/32), ceil(M/128))`, `w8a16_gemm_n128_m128` launches `(ceil(N/128), ceil(M/128))` — against a prompt the scheduler served as two chunks of **1168 + 25** tokens:

| launches | grid | shape | site | µs |
|---|---|---|---|---|
| 48 | 160×10 | N=5120 K=6144 M=1168 | **SSM `out_proj`, chunk 0** | 54 119.7 |
| 16 | 384×10 | N=12288 K=5120 M=1168 | **attn `q_proj`, chunk 0** | 32 466.8 |
| 48 | 160×1 | N=5120 K=6144 M=25 | **SSM `out_proj`, chunk 1** | 13 995.4 |
| 32 | 8×10 | N=1024 K=5120 M=1168 | **attn `k_proj`+`v_proj`, chunk 0** | 12 012.2 |

48 = the GDN layer count, 16 = the attention layer count. **112 launches, 112.6 ms, two sites.**

**🪤 This supersedes the round-9 report's reading of the same 100.6 ms as the dense FFN's prefill GEMM, and the mechanism of that error is worth naming**: the inference came from a `log:ffn_w8a16_prefill` route line, and that line is emitted under a log-once latch — it records what the *first* observation selected, not what the steady state runs. The trace itself shows the FFN's gate/up/down on `nvjet…` cuBLASLt lines at both chunk widths. The fix for that class of mistake is in this diff: **both new route lines are emitted from both arms**, so the absence of a W8A8 line can never be ambiguous between "not armed" and "log lost".

The two sites were excluded for two different reasons, and only one of them was ever written down:

- **`prefill_out_proj_dispatch` had no cuBLASLt arm at all.** Its only W8A8 arm was gated on a bare `ATLAS_FP8_W8A8=1` environment read — not `ctx.dispatch.fp8_blockscaled_prefill`, not any `ATLAS_CUBLAS_GEMM` family. So a serve that armed `ssm` moved `in_proj_qkvz` to cuBLASLt and left **the same layer's other GEMM** on W8A16, where FP8 weight bytes buy memory and none of the FLOPs. At M=1193 that kernel runs at **65.5 TFLOP/s**.
- **`cache_skip_one_proj` documented its own exclusion in place.** The chain writes q/k/v into back-to-back regions of two arena buffers — `q` alone in `qkv_output`, `k` at `ssm_qkvz + 0`, `v` at `ssm_qkvz + num_tokens*kv_dim` — and cuBLASLt writes `ceil16(M)` rows, so `k`'s padded rows land inside `v`'s region. That is a real hazard, and it is what this PR has to answer rather than hand-wave.

Only **chunk 0** was affected on the attention side: the *later* chunks of the same prefill go through `paged_qkv.rs`, whose W8A8 arm the same trace does show (`fp8_gemm_t_blockscaled`, 48 launches at M=25). The split was never "attention has no W8A8" — it was "chunk 0 has no W8A8".

## What the fix does

Both sites take the pattern the dense-FFN, QKVZ and `o_proj` prefill arms already use, under the existing `ctx.dispatch.cublas.ssm` / `.attn` scopes: one `per_token_group_quant_fp8` over the normed input, one `fp8_act_scale_to_kmajor` into the VEC128 layout cuBLASLt documents (#989), then `nvjet` against the checkpoint's own FP8 bytes and its 128×128 FP32 block scales, FP32 epilogue. **No dequant, no weight twin, no device allocation** — every buffer is arena scratch that already exists. **The W8A16 kernels remain the fallback and are what an un-armed serve runs byte for byte.**

**🪤 The phantom rows are the whole difficulty, and the answer is per-region accounting, not a staging copy.** cuBLASLt is handed `ceil16(M)`, and those pad rows **are written**. Per region:

- **`q` is alone in `qkv_output`.** It needs `ceil16(M) * q_proj_dim` BF16 of room; `sizes.rs` now allocates `m_pad` rather than `m` there (~0.4 MB on a 27B). Readers still touch only the real `M`.
- **`k` runs before `v` on the same stream**, so `k`'s pad rows (`M..ceil16(M)`, at most 15) land in `v`'s region and are then **overwritten by `v`'s own real write**. The selector carries an **`m >= 16` clause** precisely so that `ceil16(M) − M <= 15 < M` holds and `v`'s real rows cover every one of them. No reader ever sees `k`'s pad.
- **`v`'s own pad is the only one that survives**, at the tail, so the buffer must hold `(M + ceil16(M)) * kv_dim` BF16. That is the extent `ssm_qkvz` is both **checked against at dispatch** and sized for in `sizes.rs`.

Both buffers are bounds-checked at dispatch; **if either is too small the whole chain declines to the W8A16 kernels** rather than writing past its end. A staging buffer plus copy was the alternative and was rejected: it would have cost a full `[M, kv_dim]` D2D per projection per attention layer per chunk.

**The three projections also share one activation quantization** instead of one each — `paged_qkv.rs` re-quantizes per projection, which the same trace shows as three `per_token_group_quant_fp8` launches per attention layer.

`sizes.rs` also gains `linear_num_value_heads * linear_value_head_dim` in the `max_proj_k` fold. It happens to equal `q_heads * head_dim` (6144) on Qwen3.8-27B so it changes no allocation there, but the SSM `out_proj` arm quantizes into that buffer, and a model whose `value_dim` were the widest contraction would otherwise size it short and silently fall back.

**Kill switches:** `ATLAS_SSM_OUT_W8A16_ONLY` and `ATLAS_ATTN_QKV_W8A16_ONLY`, both **presence** (any value, including empty), `OnceLock`-cached — matching `ATLAS_FFN_W8A16_ONLY`, whose spelling was chosen because an escape hatch reached for mid-incident must not have `=0` mean "on". Nothing reads the environment per step; every selector is a pure function of the prefill row count, the resolved `GemmDispatch`, and handles and capacities fixed at model build.

**🪤 NUMERICS, stated plainly.** These projections move from W8A16 (BF16 activation × E4M3 weight) to W8A8 (dynamic per-token 1×128 E4M3 activation quant × the checkpoint's 128×128 weight scales, FP32 epilogue) — **the same arithmetic the dense-FFN, QKVZ and `o_proj` prefills already use, and vLLM's.** It is a deliberate precision trade, not a defect, and the measurements below sit exactly on the E4M3 floor.

## Oracle and evidence

### Microtest — `native_fp8_prefill_proj_w8a8_microtest`

1×H100 80 GB, 2026-09-11, at the four real Qwen3.8-27B prefill shapes, M ∈ {64, 1193}, 10 reps, `MT_EXIT=0`. Gates **`cosine >= 0.999`, `rel_rms <= 3.0e-2`** — a quantisation-noise tolerance, not a bit gate, because the E4M3 activation-quant floor is ~2–2.6e-2 and a bit gate on a deliberate precision change would be meaningless. Reference is the W8A16 kernel each site actually ships (`pipelined` for `out_proj`/`q_proj`, `t_m128` for `k`/`v`).

```
rows [64, 1193], cuBLASLt M pad reaches 1200
```

| M | projection | ref | cosine | rel_rms | phantom rows |
|---|---|---|---|---|---|
| 64 | ssm `out_proj` N=5120 K=6144 | pipelined | 0.999677 | 2.5444e-2 | — (pad = 64) |
| 64 | attn `q_proj` N=12288 K=5120 | pipelined | 0.999679 | 2.5335e-2 | — |
| 64 | attn `k_proj` N=1024 K=5120 | t_m128 | 0.999680 | 2.5319e-2 | — |
| 64 | attn `v_proj` N=1024 K=5120 | t_m128 | 0.999681 | 2.5291e-2 | — |
| 1193 | ssm `out_proj` | pipelined | 0.999680 | 2.5322e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `q_proj` | pipelined | 0.999680 | 2.5323e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `k_proj` | t_m128 | 0.999680 | 2.5303e-2 | `1193..1200` finite, `max_abs=0.000` |
| 1193 | attn `v_proj` | t_m128 | 0.999680 | 2.5310e-2 | `1193..1200` finite, `max_abs=0.000` |

**The deviation is flat in M and pinned at the E4M3 floor (cosine 0.999677–0.999681, rel_rms 2.529e-2–2.544e-2) — which is the thing that says this is activation quantisation and not an indexing bug.** And the phantom rows are finite with `max_abs=0.000` in the gap region, i.e. the write extent is where the argument above says it is.

**Three negative controls, all refused, so the harness is shown able to fail before it is believed:**

```
KNOWN_BAD guard:     refused: route wrote outside its extent at byte 0
KNOWN_BAD nonfinite: refused: nonfinite projection output (phantom rows included)
KNOWN_BAD value:     refused: cosine 0.316981 < 0.999
```

Timing, µs per projection, 10 reps:

| projection | M=64 W8A16 → W8A8 | **M=1193 W8A16 → W8A8** | **M=1193 speedup** |
|---|---|---|---|
| ssm `out_proj` N=5120 K=6144 | 267.6 → 25.0 | **1 145.2 → 127.8** | **8.96×** |
| attn `q_proj` N=12288 K=5120 | 291.8 → 37.3 | **2 066.0 → 168.1** | **12.29×** |
| attn `k_proj` N=1024 K=5120 | 369.5 → 24.7 | **370.3 → 54.7** | **6.77×** |
| attn `v_proj` N=1024 K=5120 | 372.7 → 24.4 | **370.2 → 55.0** | **6.73×** |

In TFLOP/s the story is one line: **the W8A16 tier runs these prefill shapes at 33.8–72.7 TFLOP/s while cuBLASLt W8A8 runs the identical work at 228–893** — and the small-N `k`/`v` pair, which was a *regression* at the decode widths in #994, is a 6.7× win here because at M=1193 there is finally enough work to fill a tile.

**The microtest and the serving trace agree on the baseline, independently.** `out_proj` at M=1193 measures 1 145.2 µs here; nsys measured 48 launches at M=1168 for 54 119.7 µs = **1 127.5 µs each** (1.6% apart). `q_proj` 2 066.0 µs here vs 32 466.8/16 = **2 029.2 µs** (1.8%). `k`/`v` 370.3/370.2 µs here vs 12 012.2/32 = **375.4 µs** (1.4%). That agreement is what licenses the grid-geometry attribution above — three independent shapes, all within 2%.

### Serving ladder — diagnostic single-H100 evidence

1×H100 80 GB, `Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`, native FP8, 2026-09-11 round 11. **Same binary in both cells** — the control differs only by `ATLAS_SSM_OUT_W8A16_ONLY=1 ATLAS_ATTN_QKV_W8A16_ONLY=1`, verified live in `/proc/<pid>/environ`. Recipe otherwise frozen: bs16, ring auto, batched GDN, head band 16, `ATLAS_CUBLAS_GEMM=ffn,ssm,attn`, `ATLAS_LM_HEAD_M16_TC=1`, `ATLAS_FFN_NO_BATCH16=1`. Temp 0 / seed 42, thinking off, frozen ladder, 1 warmup + 3 recorded reps, rep spread 0.00–0.35%, **0 errors in every rep**.

**The route lines are the A/B, verbatim from the two boot logs, and only the two new ones move:**

```
A  [atlas] SSM out_proj prefill: W8A8 block-scaled via cuBLASLt … ATLAS_SSM_OUT_W8A16_ONLY restores W8A16. This arm allocates nothing.
B  [atlas] SSM out_proj prefill: W8A16 (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `ssm` to ATLAS_CUBLAS_GEMM; see #917/#928.

A  [atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A8 block-scaled via cuBLASLt, activation quantized once for all three …
B  [atlas] attention Q/K/V prefill (chunk 0, cache-skip): W8A16 (BF16 act x FP8 weight). W8A8 cuBLASLt not selected — add `attn` …

A and B, identical:  [atlas] SSM QKVZ prefill: W8A8 block-scaled via cuBLASLt …
A and B, identical:  [atlas] attention prefill: W8A8 block-scaled via cuBLASLt …
```

**1193-token prompt / 256 output**

| cell | tok/s agg C=1 | **TTFT p50 C=1** | TPOT C=1 | tok/s agg C=16 | **TTFT p50 C=16** | TPOT C=16 |
|---|---|---|---|---|---|---|
| control (arms off) | 51.96 | 371.6 ms | 17.86 ms | 366.37 | 3 142.5 ms | 31.48 ms |
| **this PR** | **53.06** | **267.9 ms** | **17.86 ms** | **429.46** | **2 283.8 ms** | **28.44 ms** |
| | +2.1% | **−27.9%** | **0.00%** | **+17.2%** | **−27.3%** | −9.7% |

**4593-token prompt / 512 output**

| cell | tok/s agg C=1 | **TTFT p50 C=1** | TPOT C=1 | tok/s agg C=16 | **TTFT p50 C=16** | TPOT C=16 |
|---|---|---|---|---|---|---|
| control (arms off) | 43.77 | 1 171.7 ms | 20.60 ms | 263.73 | 9 928.3 ms | 41.27 ms |
| **this PR** | **44.84** | **890.3 ms** | **20.60 ms** | **309.09** | **7 511.5 ms** | **37.07 ms** |
| | +2.4% | **−24.0%** | **0.00%** | **+17.2%** | **−24.3%** | −10.2% |

**🪤 Read the control row carefully — it is assembled from two cells, and the reason is stated rather than smoothed over.** The kill-switch cell measured on this binary is the **1193 / C=1** row (51.96 tok/s, 371.6 ms, 17.86 ms TPOT); the remaining three rows are the previous round's cell at the identical recipe on the previous build (`r10-XY-919`, which itself reproduces round 9's XY to within rep spread across all twelve cells). **What licenses splicing them is that the one cell measured both ways agrees to 0.1%**: kill-switch 51.96 tok/s / 371.6 ms against `r10-XY` 51.91 / 371.2. That is the evidence that the switches restore the prior binary's behaviour, and it is a same-recipe cross-build agreement, not an assumption. The C=16 and 4593-token control cells were **not** re-measured with the kill switches on this build.

**The arithmetic closes to 3%, and that is the strongest single result here.** The four kernel families this PR replaces are 112.59 ms of the 368.26 ms short prefill. Feeding the microtest's measured W8A8 timings back through the same launch counts — 48 × 127.8 + 16 × 168.1 + 32 × 54.85 + 48 × 25.0 — predicts **≈11.8 ms** in their place, i.e. a **≈100.8 ms** saving. **Measured TTFT delta: 103.7 ms.** A prefill-only change, predicted from a kernel microtest, landing within 3% of an independently measured end-to-end latency is the check that says the attribution, the microtest and the serve are all describing the same thing.

**The null check passes exactly.** This PR touches prefill only; **C=1 TPOT is 17.86 ms in both cells** on the short shape and **20.60 ms in both** on the long one. Steady-state decode is untouched to four digits, which is what a prefill-only change must show.

**C=16 TPOT moves anyway, and the reason is not decode.** At 16 concurrent requests the ladder's TPOT window contains the *other* sequences' prefill chunks interleaved with decode steps, so a cheaper prefill shortens it (31.48 → 28.44 ms short, 41.27 → 37.07 ms long). That is scheduling, not arithmetic, and the C=1 rows above are the control that shows it.

**Memory is flat and no coherency gate is paid.** Both cells: **73 829 MiB at ready** and **+6 MiB** across the gates; +24 MiB across this PR's full two-shape ladder. KV identical in both (`13.6 GB → 22205 blocks → 355 280 max KV tokens`), ring identical (`8 slots × 16 seqs × 151.5 MB/seq = 18.94 GB`). **Coherency gate 4/4 PASS in both** (`passed: true`; `'391' OK; 'Tokyo' OK; 'rotaregirfer' OK`), 16-way concurrent arithmetic probe **16/16 correct in both** — and its wall time is a free side-measurement that tracks the result: **1.47 s (control) → 0.97 s (this PR)**.

The `sizes.rs` growth is real but below the resolution of the memory poll: `qkv_output` goes from `m` to `m_pad` rows and `ssm_qkvz` gains `(m + m_pad)` over `2m` in one `max` term — ~0.4 MB each on a 27B, against 73.8 GB resident. Both cells report the same MiB at ready.

### Scope of the evidence — read this before citing the ladder

- **Diagnostic single-H100 evidence, not a perf gate.** One box, one model (`Qwen/Qwen3.8-27B-FP8` rev `017b9c7a`), one quantization, one recipe. Nothing here is a claim about GB10 or a released number.
- **The arms require `ATLAS_CUBLAS_GEMM` to name `ssm` and `attn`.** They are not on by default; an unset or `ffn`-only serve runs today's W8A16 kernels byte for byte. The per-family scoping that makes `ssm,attn` expressible is #989's.
- **Three of the four control cells are the previous build's**, as stated above, bridged by a 0.1% agreement on the one cell measured both ways. A full four-cell kill-switch control on this binary is owed and is not here.
- **The numerics change is real and default-on once the lever is set.** ~2.5e-2 relative RMS at cosine ~0.99968 against W8A16 — the E4M3 floor, and the same trade three other prefill families already take. The two `_W8A16_ONLY` switches are the off switches.
- **The `m >= 16` clause is load-bearing, not a tuning knob.** Below it the k/v overlap argument does not hold, and the selector declines. It is unit-tested as a clause, not left to a comment.
- **The round-9 report's dense-FFN attribution of this kernel is superseded by this PR's grid-geometry resolution**, corroborated by the three-shape microtest agreement above. Anyone citing round 9 §"Reading the prefill" item 3 should read this section instead.

**Host dispatch tests** pin both selectors clause by clause without building a `ForwardContext`: selected at prefill M with the scope armed and not without, the kill switch, the `m` floor, the scale format, the shape and per-region capacity clauses, and the missing-handle declines — plus the buffer-extent arithmetic the phantom-row argument rests on, as an SSOT shared by the selector and the test.

## Test plan

All on Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, in an isolated worktree against this branch fetched from the fork.

- [x] `cargo test -p spark-model --features cuda prefill` — **98 passed, 0 failed, 4 ignored**
- [x] `cargo test -p spark-model --features cuda w8a8` — **56 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda ssm` — **156 passed, 0 failed**
- [x] `cargo test -p spark-model --features cuda attn` — **15 passed, 0 failed, 1 ignored**
- [x] `cargo test -p spark-model --features cuda cublas` — **6 passed, 0 failed**
- [x] `cargo build -p spark-model --examples --features cuda,gpu-examples` — clean (builds the new microtest)
- [x] `cargo clippy -p spark-model -p spark-runtime -p spark-server --tests --features cuda,nccl -- -D warnings` — clean, **0 warnings emitted**
- [x] `cargo fmt --all -- --check` — clean
- [x] `python3 scripts/check_kernel_shadows.py` — `kernel shadow structure: OK (4 hardware trees scanned: gb10, metal, strix, strix-hip)`
- [x] **No `.cu` files touched** — confirmed, `git diff --name-only` over this PR's commit is 11 files, all `.rs`/`.toml`, `CU_COUNT=0`. No kernel source changes, so no PTX gate is owed.
- [x] Tested against real hardware — the H100 microtest, the two-cell ladder, the coherency gates and the 16-way probes above (2026-09-11)

## GB10 perf-gate records

This diff touches `crates/`, a PERF_PATH, so `record_covers` invalidates every committed `.benchmarks/` record on landing and a GB10 re-measure is owed before merge.

**Almost all of this PR is inert on an un-armed GB10 serve, and one part is not.** The two W8A8 arms need `ATLAS_CUBLAS_GEMM` to name `ssm`/`attn`, which no GB10 recipe does today, so on GB10 both sites keep running the same W8A16 kernels they run now. **The exception is `crates/spark-runtime/src/buffers/sizes.rs`**, which grows `qkv_output` to `m_pad` rows and adds one term to each of the `ssm_qkvz` and `max_proj_k` folds **unconditionally, on every target**. That is ~0.4 MB each on a 27B-class model and is pure allocation arithmetic — no kernel, no route — but it is the part of this PR a GB10 re-measure actually exercises, and the part to watch if a GB10 fit is close to its ceiling.

No `kernels/` file is touched, so no PTX gate applies.

## Conflicts

Cherry-picked from `fix/prefill-last-w8a16-gemm` on the fork with an `-x` provenance line, onto #994's branch. **It applied with no conflict at all and nothing was adapted** — the two new modules are new files, and the three edited call sites (`cache_skip_qkv.rs`, `trait_prefill_helper.rs`, `sizes.rs`) are exactly the shapes #994 leaves behind. The `crates/spark-model/Cargo.toml` `[[example]]` stanza for `native_fp8_prefill_proj_w8a8_microtest` is a pure addition alongside #994's own.

One thing a reviewer of #994 should know: **this PR deletes the comment in `cache_skip_qkv.rs` that #994 added saying that chain cannot take cuBLASLt.** That comment was correct when it was written — it is the exclusion this PR's per-region accounting is the answer to — and the two should be read together.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
