### PR TITLE
xgrammar: bound parallel cold mask preparation, and keep the serial default (#918)

### DIFF
--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -144,12 +144,9 @@ impl GrammarEngine {
 
     fn from_tokenizer_info(tokenizer_info: TokenizerInfo) -> Result<Self, GrammarError> {
         let vocab_size = tokenizer_info.vocab_size();
-        // Bound cold mask preparation without occupying the shared sampling
-        // pool. All workers join before prefill; warm masks remain cached.
-        let threads = std::thread::available_parallelism()
-            .map_err(|e| GrammarError::Compilation(format!("grammar CPU count: {e}")))?
-            .get()
-            .min(4) as i32;
+        // Restore the historical serial default: four-worker native-tool
+        // preparation has not improved cold latency in the measured workload.
+        // The compiler still supports bounded parallel preparation for callers.
         // Cache enabled with an explicit memory budget.
         // ★ NOT -1 (unlimited). `CacheKey::Schema` is keyed by the full tool
         // schema, so agentic traffic mints a distinct compiled grammar per
@@ -158,9 +155,8 @@ impl GrammarEngine {
         // above any realistic hot set (tens of schemas) while bounding the
         // tail. `-1` remains available as an explicit opt-in for callers that
         // genuinely want every grammar pinned.
-        let compiler =
-            GrammarCompiler::new(&tokenizer_info, threads, true, GRAMMAR_CACHE_BUDGET_BYTES)
-                .map_err(GrammarError::Compilation)?;
+        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, GRAMMAR_CACHE_BUDGET_BYTES)
+            .map_err(GrammarError::Compilation)?;
         Ok(Self {
             compiler,
             vocab_size,

--- a/crates/spark-server/src/grammar/engine.rs
+++ b/crates/spark-server/src/grammar/engine.rs
@@ -144,7 +144,13 @@ impl GrammarEngine {
 
     fn from_tokenizer_info(tokenizer_info: TokenizerInfo) -> Result<Self, GrammarError> {
         let vocab_size = tokenizer_info.vocab_size();
-        // Single compilation thread, cache enabled, no memory limit.
+        // Bound cold mask preparation without occupying the shared sampling
+        // pool. All workers join before prefill; warm masks remain cached.
+        let threads = std::thread::available_parallelism()
+            .map_err(|e| GrammarError::Compilation(format!("grammar CPU count: {e}")))?
+            .get()
+            .min(4) as i32;
+        // Cache enabled with an explicit memory budget.
         // ★ NOT -1 (unlimited). `CacheKey::Schema` is keyed by the full tool
         // schema, so agentic traffic mints a distinct compiled grammar per
         // request; unbounded, that grew host RSS ~100 MB/min under BFCL and is
@@ -152,8 +158,9 @@ impl GrammarEngine {
         // above any realistic hot set (tens of schemas) while bounding the
         // tail. `-1` remains available as an explicit opt-in for callers that
         // genuinely want every grammar pinned.
-        let compiler = GrammarCompiler::new(&tokenizer_info, 1, true, GRAMMAR_CACHE_BUDGET_BYTES)
-            .map_err(GrammarError::Compilation)?;
+        let compiler =
+            GrammarCompiler::new(&tokenizer_info, threads, true, GRAMMAR_CACHE_BUDGET_BYTES)
+                .map_err(GrammarError::Compilation)?;
         Ok(Self {
             compiler,
             vocab_size,

--- a/crates/spark-server/src/grammar/tests/mod.rs
+++ b/crates/spark-server/src/grammar/tests/mod.rs
@@ -10,6 +10,7 @@ mod engine_state;
 mod gemma4_required;
 mod minimax;
 mod misc;
+mod native_prewarm;
 mod parallel_calls;
 mod param_key_constraint;
 mod poolside;

--- a/crates/spark-server/src/grammar/tests/native_prewarm.rs
+++ b/crates/spark-server/src/grammar/tests/native_prewarm.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Explicit CPU diagnostic using an already-present Qwen tokenizer. Never downloads.
+
+use super::*;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use xgrammar::compiler::{CompiledGrammar, CompiledGrammarImpl, RuleLevelCache};
+use xgrammar::matcher::GrammarMatcher;
+
+fn fresh(source: &CompiledGrammar, threads: usize) -> CompiledGrammar {
+    let s = source.inner();
+    CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: threads,
+        grammar: Arc::clone(&s.grammar),
+        tokenizer_info: s.tokenizer_info.clone(),
+        mask_cache: Mutex::new(Default::default()),
+        tag_slice: Arc::clone(&s.tag_slice),
+        rule_cache: Some(RuleLevelCache::new(1024 * 1024 * 1024 / 3)),
+        decomposition: s.decomposition.clone(),
+    }))
+}
+
+#[test]
+#[ignore = "CPU diagnostic: requires QWEN_TOKENIZER_JSON pointing to existing pinned tokenizer"]
+fn native_qwen_prewarm_exactness_and_cpu_timing() {
+    let path = std::env::var("QWEN_TOKENIZER_JSON").expect("explicit existing tokenizer path");
+    let tokenizer = tokenizers::Tokenizer::from_file(path).unwrap();
+    let stop = tokenizer.token_to_id("<|im_end|>").unwrap() as i32;
+    let end = tokenizer.token_to_id("<|endoftext|>").unwrap() as i32;
+    assert_eq!([stop, end], [248046, 248044]);
+    let mut engine = GrammarEngine::from_tokenizer(&tokenizer, Some(248320), &[stop, end]).unwrap();
+    let tools: Vec<ToolDefinition> = serde_json::from_value(serde_json::json!([{
+        "type":"function", "function": {"name":"get_weather",
+        "description":"Look up the current weather for a city.",
+        "parameters":{"type":"object","properties":{
+            "city":{"type":"string","description":"City name."},
+            "days":{"type":"integer","description":"Forecast horizon in days."}},
+            "required":["city","days"]}}
+    }]))
+    .unwrap();
+    let output = "<tool_call>\n<function=get_weather>\n<parameter=city>\nReykjavik\n</parameter>\n<parameter=days>\n3\n</parameter>\n</function>\n</tool_call>";
+    let ids = tokenizer.encode(output, false).unwrap().get_ids().to_vec();
+    for auto in [true, false] {
+        let started = Instant::now();
+        let source = engine
+            .compile_qwen3_coder_tool_grammar(&tools, auto, "</parameter>")
+            .unwrap();
+        println!(
+            "native compile auto={auto} ms={:.3}",
+            started.elapsed().as_secs_f64() * 1000.0
+        );
+        if let Ok(dir) = std::env::var("QWEN_GRAMMAR_EXPORT_DIR") {
+            std::fs::write(
+                format!("{dir}/native-{auto}.ebnf"),
+                xgrammar::grammar::print_grammar(source.grammar()),
+            )
+            .unwrap();
+            std::fs::write(
+                format!("{dir}/output-ids.json"),
+                serde_json::to_string(&ids).unwrap(),
+            )
+            .unwrap();
+        }
+        for rep in 0..1 {
+            let serial = fresh(&source, 1);
+            let parallel = fresh(&source, 4);
+            let start = Instant::now();
+            let n_serial = serial.compile_top_k_masks(512);
+            let serial_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let start = Instant::now();
+            let n_parallel = parallel.compile_top_k_masks(512);
+            let parallel_ms = start.elapsed().as_secs_f64() * 1000.0;
+            assert_eq!(n_serial, n_parallel);
+            assert_eq!(
+                *serial.inner().mask_cache.lock().unwrap(),
+                *parallel.inner().mask_cache.lock().unwrap(),
+                "adaptive masks differ before sampling"
+            );
+            let mut a = GrammarMatcher::new(serial, None, false, -1);
+            let mut b = GrammarMatcher::new(parallel, None, false, -1);
+            let mut am = vec![0; 248320usize.div_ceil(32)];
+            let mut bm = am.clone();
+            let mut fill_seconds = 0.0;
+            for &id in &ids {
+                am.fill(0);
+                bm.fill(0);
+                let start = Instant::now();
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                fill_seconds += start.elapsed().as_secs_f64();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert_eq!(am, bm, "next-token masks differ");
+                assert_ne!(
+                    am[id as usize / 32] & (1 << (id % 32)),
+                    0,
+                    "native continuation rejected"
+                );
+                assert!(a.accept_token(id as i32, false));
+                assert!(b.accept_token(id as i32, false));
+                a.rollback(1);
+                b.rollback(1);
+                am.fill(0);
+                bm.fill(0);
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert_eq!(am, bm, "rollback masks differ");
+                assert!(a.accept_token(id as i32, false));
+                assert!(b.accept_token(id as i32, false));
+            }
+            println!(
+                "native auto={auto} rep={rep} masks={n_serial} serial_ms={serial_ms:.3} parallel_ms={parallel_ms:.3} fill_ms_per_token={:.3} tokens={}",
+                fill_seconds * 1000.0 / ids.len() as f64,
+                ids.len()
+            );
+            // Both paths reject the same malformed function name in required mode.
+            if !auto {
+                a.reset();
+                b.reset();
+                assert!(!a.accept_string("<tool_call>\n<function=unknown>", false));
+                assert!(!b.accept_string("<tool_call>\n<function=unknown>", false));
+            }
+        }
+    }
+}

--- a/crates/xgrammar/examples/native_prewarm_profile.rs
+++ b/crates/xgrammar/examples/native_prewarm_profile.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! CPU-only timing of grammar exported from Atlas's native tool compiler.
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use xgrammar::compiler::{CompiledGrammar, CompiledGrammarImpl, GrammarCompiler, RuleLevelCache};
+use xgrammar::matcher::GrammarMatcher;
+use xgrammar::tokenizer::TokenizerInfo;
+
+fn fresh(source: &CompiledGrammar, threads: usize) -> CompiledGrammar {
+    let s = source.inner();
+    CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: threads,
+        grammar: Arc::clone(&s.grammar),
+        tokenizer_info: s.tokenizer_info.clone(),
+        mask_cache: Mutex::new(Default::default()),
+        tag_slice: Arc::clone(&s.tag_slice),
+        rule_cache: Some(RuleLevelCache::new(1024 * 1024 * 1024 / 3)),
+        decomposition: s.decomposition.clone(),
+    }))
+}
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("existing CPU fixture directory");
+    let raw = std::fs::read_to_string(format!("{dir}/qwen-tokenizer.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let mut vocab = vec![String::new(); 248320];
+    for (tok, id) in json["model"]["vocab"].as_object().unwrap() {
+        vocab[id.as_u64().unwrap() as usize] = tok.clone();
+    }
+    for tok in json["added_tokens"].as_array().unwrap() {
+        vocab[tok["id"].as_u64().unwrap() as usize] = tok["content"].as_str().unwrap().to_owned();
+    }
+    let stop = vocab.iter().position(|t| t == "<|im_end|>").unwrap() as i32;
+    let end = vocab.iter().position(|t| t == "<|endoftext|>").unwrap() as i32;
+    assert_eq!([stop, end], [248046, 248044]);
+    let meta = xgrammar::detect_metadata_from_hf(&raw).unwrap();
+    let info = TokenizerInfo::new(
+        &vocab,
+        meta.vocab_type,
+        None,
+        Some(vec![stop, end]),
+        meta.add_prefix_space,
+    );
+    let ids: Vec<i32> =
+        serde_json::from_str(&std::fs::read_to_string(format!("{dir}/output-ids.json")).unwrap())
+            .unwrap();
+    for auto in [true, false] {
+        let ebnf = std::fs::read_to_string(format!("{dir}/native-{auto}.ebnf")).unwrap();
+        let compiler = GrammarCompiler::new(info.clone(), 1, true, -1);
+        let start = Instant::now();
+        let source = compiler.compile_grammar_from_ebnf(&ebnf, "root").unwrap();
+        println!(
+            "compile auto={auto} ms={:.3}",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+        if std::env::args().nth(2).as_deref() == Some("--warm-only") {
+            let warmed = fresh(&source, 4);
+            let count = warmed.compile_top_k_masks(512);
+            let started = Instant::now();
+            for _ in 0..100 {
+                assert_eq!(warmed.compile_top_k_masks(512), count);
+            }
+            println!(
+                "warm auto={auto} selected={count} us_per_call={:.3}",
+                started.elapsed().as_secs_f64() * 1e6 / 100.0
+            );
+            continue;
+        }
+        for rep in 0..3 {
+            let serial = fresh(&source, 1);
+            let parallel = fresh(&source, 4);
+            let start = Instant::now();
+            let n_serial = serial.compile_top_k_masks(512);
+            let serial_ms = start.elapsed().as_secs_f64() * 1000.0;
+            let start = Instant::now();
+            let n_parallel = parallel.compile_top_k_masks(512);
+            let parallel_ms = start.elapsed().as_secs_f64() * 1000.0;
+            assert_eq!(n_serial, n_parallel);
+            assert!(
+                *serial.inner().mask_cache.lock().unwrap()
+                    == *parallel.inner().mask_cache.lock().unwrap(),
+                "adaptive mask/state sets differ"
+            );
+            let mut a = GrammarMatcher::new(serial, None, false, -1);
+            let mut b = GrammarMatcher::new(parallel, None, false, -1);
+            let mut am = vec![0; 248320usize.div_ceil(32)];
+            let mut bm = am.clone();
+            let mut fill_seconds = 0.0;
+            let mut positions = Vec::new();
+            for (position, &id) in ids.iter().enumerate() {
+                am.fill(0);
+                bm.fill(0);
+                let start = Instant::now();
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                let fill_us = start.elapsed().as_secs_f64() * 1e6;
+                fill_seconds += fill_us / 1e6;
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert!(am == bm, "next-token masks differ");
+                assert_ne!(am[id as usize / 32] & (1 << (id % 32)), 0);
+                let start = Instant::now();
+                assert!(a.accept_token(id, false));
+                let accept_us = start.elapsed().as_secs_f64() * 1e6;
+                positions.push(serde_json::json!({"position":position,"token_id":id,"token":String::from_utf8_lossy(&info.decoded_vocab()[id as usize]),"fill_us":fill_us,"accept_us":accept_us}));
+                assert!(b.accept_token(id, false));
+                a.rollback(1);
+                b.rollback(1);
+                am.fill(0);
+                bm.fill(0);
+                a.fill_next_token_bitmask(&mut am, 0, false).unwrap();
+                b.fill_next_token_bitmask(&mut bm, 0, false).unwrap();
+                assert!(am == bm, "rollback masks differ");
+                assert!(a.accept_token(id, false));
+                assert!(b.accept_token(id, false));
+            }
+            println!(
+                "auto={auto} rep={rep} masks={n_serial} serial_ms={serial_ms:.3} parallel_ms={parallel_ms:.3} fill_ms_per_token={:.3} tokens={}",
+                fill_seconds * 1000.0 / ids.len() as f64,
+                ids.len()
+            );
+            println!(
+                "positions {}",
+                serde_json::json!({"auto":auto,"rep":rep,"positions":positions})
+            );
+            if !auto {
+                a.reset();
+                b.reset();
+                assert!(!a.accept_string("<tool_call>\n<function=unknown>", false));
+                assert!(!b.accept_string("<tool_call>\n<function=unknown>", false));
+            }
+        }
+    }
+}

--- a/crates/xgrammar/src/compiler/compile.rs
+++ b/crates/xgrammar/src/compiler/compile.rs
@@ -38,9 +38,8 @@ use super::rule_cache::RuleLevelCache;
 /// `GrammarCompiler` entry points guarantee this.
 ///
 /// Adaptive token masks are NOT computed here — they are compiled
-/// lazily on first matcher lookup (XGrammar-2 JIT). `_max_threads` is
-/// retained for API parity but is now unused: there is no eager
-/// per-state mask loop left to parallelize.
+/// lazily on first matcher lookup (XGrammar-2 JIT). `max_threads` is
+/// retained on the result to bound explicit `compile_top_k_masks` prewarming.
 ///
 /// `rule_cache` is the optional cross-grammar [`RuleLevelCache`] (passed
 /// from the [`super::GrammarCompiler`] so it is shared across every
@@ -49,7 +48,7 @@ use super::rule_cache::RuleLevelCache;
 pub(super) fn compile_optimized_grammar(
     mut grammar: GrammarData,
     tokenizer_info: &TokenizerInfo,
-    _max_threads: usize,
+    max_threads: usize,
     rule_cache: Option<RuleLevelCache>,
 ) -> CompiledGrammar {
     debug_assert!(
@@ -64,6 +63,7 @@ pub(super) fn compile_optimized_grammar(
     if tokenizer_info.vocab_size() == 0 {
         let decomposition = decompose_static_regions(&grammar);
         return CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+            prewarm_max_threads: max_threads,
             grammar: Arc::new(grammar),
             tokenizer_info: tokenizer_info.clone(),
             mask_cache: Mutex::new(AHashMap::new()),
@@ -101,6 +101,7 @@ pub(super) fn compile_optimized_grammar(
     // The mask cache starts empty and is populated lazily; on a miss the
     // lazy path consults `rule_cache` before recomputing.
     CompiledGrammar::from_impl(Arc::new(CompiledGrammarImpl {
+        prewarm_max_threads: max_threads,
         grammar: Arc::new(grammar),
         tokenizer_info: tokenizer_info.clone(),
         mask_cache: Mutex::new(AHashMap::new()),

--- a/crates/xgrammar/src/compiler/compiled_grammar.rs
+++ b/crates/xgrammar/src/compiler/compiled_grammar.rs
@@ -36,6 +36,8 @@ use super::rule_cache::{RuleLevelCache, RuleMaskKey};
 /// `CompiledGrammar::Impl`.
 #[derive(Debug)]
 pub struct CompiledGrammarImpl {
+    /// Maximum synchronous prewarm workers, inherited from the compiler.
+    pub prewarm_max_threads: usize,
     /// The optimized, FSM-accelerated grammar (shared — the lazy
     /// `MaskGenerator` needs an `Arc<GrammarData>`).
     pub grammar: Arc<GrammarData>,
@@ -302,10 +304,10 @@ impl CompiledGrammar {
     /// OVERLAPPED MASK GENERATION (Tier 2, "configurable JIT").
     ///
     /// Eagerly compute the `k` most-expensive adaptive-token masks,
-    /// populating the lazy JIT cache so they are already warm before
-    /// the matcher needs them. Atlas's scheduler calls this during
-    /// prefill — while the GPU is busy with the prompt — so the first
-    /// decode steps never pay a cold mask-computation stall.
+    /// populating the lazy JIT cache before the matcher needs them. Uses
+    /// at most the compiler's `max_threads`, including the caller, and
+    /// joins all workers before returning. Atlas calls this synchronously
+    /// before prompt prefill; no GPU overlap is implied.
     ///
     /// COST RANKING. A state's mask cost is dominated by the breadth of
     /// its first-character scan: every distinct first byte the state can
@@ -360,10 +362,31 @@ impl CompiledGrammar {
         // the list is small (one entry per scanable FSM state).
         ranked.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.0));
         let take = k.min(ranked.len());
-        for &(_, canonical, is_root) in &ranked[..take] {
+        let pending = self.uncached_masks(&ranked[..take]);
+        super::prewarm::for_each_bounded(&pending, self.pimpl.prewarm_max_threads, &|&(
+            _,
+            canonical,
+            is_root,
+        )| {
             self.get_or_compute_mask(canonical, is_root);
-        }
+        });
         take
+    }
+
+    pub(super) fn uncached_masks(
+        &self,
+        selected: &[(usize, ParserState, bool)],
+    ) -> Vec<(usize, ParserState, bool)> {
+        let cache = self
+            .pimpl
+            .mask_cache
+            .lock()
+            .expect("mask_cache mutex poisoned");
+        selected
+            .iter()
+            .copied()
+            .filter(|(_, state, _)| !cache.contains_key(state))
+            .collect()
     }
 
     /// Shared-pointer access to the inner state — used by the matcher.

--- a/crates/xgrammar/src/compiler/compiler.rs
+++ b/crates/xgrammar/src/compiler/compiler.rs
@@ -81,9 +81,8 @@ pub struct GrammarCompiler {
 impl GrammarCompiler {
     /// Construct a compiler bound to `tokenizer_info`.
     ///
-    /// * `max_threads` — retained for API parity. Mask computation is
-    ///   now lazy (XGrammar-2 JIT), so there is no eager parallel loop
-    ///   to bound; the value is recorded but unused. Must be >= 1.
+    /// * `max_threads` — bounds explicit top-k mask prewarming. Lazy
+    ///   matcher lookups still compute only the requested mask. Must be >= 1.
     /// * `cache_enabled` — whether to cache compiled grammars.
     /// * `cache_limit_bytes` — memory budget, ENFORCED by LRU eviction on
     ///   both tiers. `-1` means unlimited, which is now an explicit opt-in

--- a/crates/xgrammar/src/compiler/mod.rs
+++ b/crates/xgrammar/src/compiler/mod.rs
@@ -70,6 +70,7 @@ mod grammar_cache;
 mod mask;
 mod mask_gen;
 pub mod mask_snapshot;
+mod prewarm;
 mod rule_cache;
 
 pub use coalesce::{Forced, analyze_bitmask};

--- a/crates/xgrammar/src/compiler/prewarm.rs
+++ b/crates/xgrammar/src/compiler/prewarm.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Bounded synchronous work dispatch for selected grammar masks.
+
+pub(super) fn for_each_bounded<T: Sync>(
+    items: &[T],
+    max_threads: usize,
+    work: &(impl Fn(&T) + Sync),
+) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    assert!(max_threads > 0);
+    let workers = max_threads.min(items.len());
+    if workers <= 1 {
+        items.iter().for_each(work);
+        return;
+    }
+    let next = AtomicUsize::new(0);
+    let run = || {
+        while let Some(item) = items.get(next.fetch_add(1, Ordering::Relaxed)) {
+            work(item);
+        }
+    };
+    std::thread::scope(|scope| {
+        for _ in 1..workers {
+            // Under host thread pressure, finish the same work with fewer
+            // workers. The caller also drains the queue; no job is dropped.
+            if std::thread::Builder::new()
+                .spawn_scoped(scope, &run)
+                .is_err()
+            {
+                break;
+            }
+        }
+        run();
+    }); // All selected masks are complete before the caller can sample.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
+
+    #[test]
+    fn bounded_workers_overlap_and_complete_each_job_once() {
+        let seen: Vec<_> = (0..16).map(|_| AtomicUsize::new(0)).collect();
+        let entered = (Mutex::new(0usize), Condvar::new());
+        let active = AtomicUsize::new(0);
+        let peak = AtomicUsize::new(0);
+        for_each_bounded(&(0..16).collect::<Vec<_>>(), 4, &|&index| {
+            let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+            peak.fetch_max(now, Ordering::SeqCst);
+            let mut count = entered.0.lock().unwrap();
+            *count += 1;
+            entered.1.notify_all();
+            // Only the first wave waits. A serial implementation times out
+            // and fails the overlap oracle rather than hanging the suite.
+            if *count < 4 {
+                let _ = entered
+                    .1
+                    .wait_timeout_while(count, Duration::from_secs(1), |n| *n < 4)
+                    .unwrap();
+            }
+            seen[index].fetch_add(1, Ordering::SeqCst);
+            active.fetch_sub(1, Ordering::SeqCst);
+        });
+        assert!(
+            peak.load(Ordering::SeqCst) > 1,
+            "selected masks are still computed serially"
+        );
+        assert!(peak.load(Ordering::SeqCst) <= 4, "worker bound exceeded");
+        assert_eq!(
+            active.load(Ordering::SeqCst),
+            0,
+            "returned before joining workers"
+        );
+        assert!(seen.iter().all(|n| n.load(Ordering::SeqCst) == 1));
+    }
+
+    #[test]
+    fn one_worker_keeps_serial_order_and_empty_work_does_nothing() {
+        let seen = Mutex::new(Vec::new());
+        for_each_bounded(&[3, 2, 1], 1, &|n| seen.lock().unwrap().push(*n));
+        assert_eq!(*seen.lock().unwrap(), [3, 2, 1]);
+        for_each_bounded::<usize>(&[], 4, &|_| panic!("empty work executed"));
+    }
+}

--- a/crates/xgrammar/src/compiler/prewarm.rs
+++ b/crates/xgrammar/src/compiler/prewarm.rs
@@ -25,7 +25,7 @@ pub(super) fn for_each_bounded<T: Sync>(
             // Under host thread pressure, finish the same work with fewer
             // workers. The caller also drains the queue; no job is dropped.
             if std::thread::Builder::new()
-                .spawn_scoped(scope, &run)
+                .spawn_scoped(scope, run)
                 .is_err()
             {
                 break;

--- a/crates/xgrammar/src/compiler/tests/tier2_tests.rs
+++ b/crates/xgrammar/src/compiler/tests/tier2_tests.rs
@@ -181,3 +181,49 @@ fn compile_top_k_masks_empty_vocab_warms_nothing() {
         .unwrap();
     assert_eq!(cg.compile_top_k_masks(5), 0);
 }
+
+#[test]
+fn parallel_prewarm_preserves_every_selected_mask() {
+    // One optimized grammar fixes FSM numbering; both compiles have fresh
+    // caches, so equality cannot pass by reusing the reference's masks.
+    let grammar = optimized("root ::= \"yes\" | \"no\" | \"abc\"\n");
+    let info = small_tokenizer();
+    let serial = compile_optimized_grammar(grammar.clone(), &info, 1, None);
+    let parallel = compile_optimized_grammar(grammar, &info, 4, None);
+    assert_eq!(
+        serial.compile_top_k_masks(512),
+        parallel.compile_top_k_masks(512)
+    );
+    assert_eq!(
+        *serial.inner().mask_cache.lock().unwrap(),
+        *parallel.inner().mask_cache.lock().unwrap(),
+        "parallel preparation changed a selected state or adaptive mask"
+    );
+}
+
+#[test]
+fn already_warm_masks_schedule_no_worker_jobs() {
+    let c = compiler(4);
+    let cg = c
+        .compile_grammar_from_ebnf("root ::= \"yes\" | \"no\"\n", "root")
+        .unwrap();
+    let selected_count = cg.compile_top_k_masks(512);
+    let selected: Vec<_> = cg
+        .inner()
+        .mask_cache
+        .lock()
+        .unwrap()
+        .keys()
+        .map(|state| (1, *state, state.rule_id == cg.grammar().root_rule_id()))
+        .collect();
+    assert!(!selected.is_empty());
+    assert!(
+        cg.uncached_masks(&selected).is_empty(),
+        "warm masks would still spawn worker jobs"
+    );
+    assert_eq!(
+        cg.compile_top_k_masks(512),
+        selected_count,
+        "selected count changed on a warm request"
+    );
+}


### PR DESCRIPTION
> Same-repo restack of #1011 (was `TheTom:pr/xgrammar-cold-mask-prewarm`). Commits unchanged. Opened on `Avarok-Cybersecurity/atlas` so Graphite/GH can stack.

## Summary

`CompiledGrammar::compile_top_k_masks` prepared its selected masks **one at a time, on the calling thread**. Cold tool-call latency is dominated by that walk, and there was no way to measure what a wider walk would buy — the shape was not a parameter.

This makes the walk a **bounded** parallel one: `prewarm::for_each_bounded`, with the worker count carried on the compiler (`prewarm_max_threads`) and inherited by every grammar it compiles. It ships an `xgrammar` example that drives the knob so the trade can be measured on a real vocabulary.

**The default is unchanged — and that is deliberate, not an oversight.** `GrammarEngine` sets one thread. Four-worker preparation did **not** improve cold latency on the measured workload: the cold cost is the compile and the top-k mask build, not the walk over pending masks, and the workers contend on the same rule cache. The capability stays on the compiler because it is the caller's choice and because the profiling example needs it to re-run the experiment on a different vocabulary.

Refs #918.

### Stack

```
main
 └─ #999  pr/918-grammar-mask-cache   (grammar mask cache, Fixes #918)
     └─ THIS PR  pr/xgrammar-cold-mask-prewarm
```

**Base branch is `main`, so the GitHub diff includes #999.** This PR's three commits are at the tip. It stacks because both touch `compiler/mod.rs`, `compiler/compiler.rs`, `compiled_grammar.rs` and `grammar/engine.rs`, and because #999's mask cache is what makes "already warm" a state worth testing for.

## What was wrong

`compile_top_k_masks` selected its states and then walked them serially. Two consequences:

1. **No knob, so no measurement.** "Would parallel mask preparation help the 3.4 s cold tool-call?" could not be answered without writing the dispatch first. The honest way to answer it is to build the bounded dispatch, measure, and then *report the result* — including when the result is "no".
2. **Nothing asserted that a parallel walk is order-independent.** Mask preparation mutates a shared cache keyed by FSM state. That it is safe to do out of order is a real property and it was untested, because there was no parallel path.

## What the fix does

### `compiler/prewarm.rs` — `for_each_bounded`

A scoped work-stealing walk over a slice, bounded by `max_threads`:

- `workers = max_threads.min(items.len())`, and `workers <= 1` takes the plain serial `for_each` — no thread, no atomic, no scope, for the case that is now the default.
- Jobs are claimed with one `AtomicUsize::fetch_add`, so no item runs twice.
- **`spawn_scoped` failure is not an error.** Under host thread pressure it breaks out of the spawn loop and the calling thread drains the queue itself. Fewer workers, same work, no job dropped — a prewarm that fails because the host is busy would be a worse outcome than a slow one.
- `thread::scope` returns only when every worker has finished, so **all selected masks are complete before the caller can sample**.

### Wiring

`Compiler::new` takes `max_threads`; `compile.rs` stamps it onto each `CompiledGrammar` as `prewarm_max_threads`; `compiled_grammar.rs` hands it to `for_each_bounded`. One value, set at compiler construction, inherited — not a second global.

### The default goes back to serial

`GrammarEngine::from_tokenizer_info` sets one compilation thread, with the comment recording *why*: the measurement did not support four. That is the third commit, and it is the point of the PR as much as the dispatch is.

## Oracle and evidence

`crates/xgrammar/src/compiler/tests/tier2_tests.rs`:

- **`parallel_prewarm_preserves_every_selected_mask`** — the correctness pin. It compiles **one** optimized grammar (so FSM state numbering is fixed) twice, with 1 and 4 workers, **both with fresh caches**, then asserts both the selected count *and* the full `mask_cache` contents are equal. Compiling twice from fresh is what stops the equality passing by the parallel run reusing the serial run's masks.
- **`already_warm_masks_schedule_no_worker_jobs`** — `uncached_masks` must be empty on a warm grammar, so a repeat request spawns nothing. This is the interaction with #999's cache.

`crates/xgrammar/src/compiler/prewarm.rs` tests: jobs overlap when workers are available (a condvar rendezvous, not a sleep), every job runs exactly once, and the serial path is taken at `workers <= 1`.

`crates/xgrammar/examples/native_prewarm_profile.rs` is the measurement harness that produced the "no improvement" verdict, kept in-tree so the verdict can be re-tested rather than believed.

**No new latency number is claimed here.** The #918 cold/warm tool-call timings belong to #999's mask cache, which is the change that actually moved them. This PR's own measured result is negative and is reflected in the default.

## Test plan

Spark 1 (GB10), CPU-only, `ATLAS_SKIP_BUILD=1`, `--jobs 8`, private `CARGO_TARGET_DIR`, isolated worktree against this branch fetched from the fork.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p xgrammar -p spark-server --features cuda --all-targets --jobs 8 -- -D warnings` — **clean, rc=0**
- [x] `cargo test -p xgrammar` — **834 + 2 + 1 passed, 0 failed** (#999 base: 830 + 2 + 1 → **+4**)
- [x] `cargo test -p spark-server --bins --features cuda -- prewarm` — **4 passed, 0 failed, 1 ignored** (2471 filtered). The ignored one is `native_qwen_prewarm_exactness_and_cpu_timing`, a CPU diagnostic gated on `QWEN_TOKENIZER_JSON` pointing at a pinned tokenizer — it is `#[ignore]` on purpose and adds no pass to the count.
- [x] `cargo test -p spark-server --bins --features cuda` — **2461 passed, 0 failed, 13 ignored** (#999 base: 2461 passed / 12 ignored → **+0 passing, +1 ignored diagnostic**)
- [x] File-size cap — **0 violations**
- [x] No `kernels/` change, no `crates/spark-model` change.

## GB10 perf-gate records

Touches `crates/` (a PERF_PATH), so committed `.benchmarks/` records are invalidated on landing. The default path is **unchanged** (one worker → the serial `for_each`), so this is a formality rather than a re-measure with a new shape.

## What is NOT claimed

- **Parallel prewarm is not claimed to be faster.** It was measured and it was not, on the workload that motivated it. The default is serial. The dispatch ships because the knob is what makes the question answerable again on a different vocabulary, and it ships with its own correctness pin.
- No claim about a vocabulary other than the measured one.
- `for_each_bounded` bounds worker *count*, not wall time. It has no deadline and no cancellation.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
