### PR TITLE
spark-server: batch fresh prompts into one varlen prefill step and never drop a response on fallback

### DIFF
--- a/PREFILL-BATCHING-ATTRIBUTION.md
+++ b/PREFILL-BATCHING-ATTRIBUTION.md
@@ -160,3 +160,86 @@ projection GEMM at a sixth of the arithmetic intensity it could have") is
 refuted by measurement: the M=1168 GEMMs are already at full efficiency on an
 H100. Varlen repackages the GDN work; it does not reduce it. The lever stays
 default OFF, and the C=16 gap to vLLM is not a prefill-batching deficit.
+
+## 6. The slot fix held; the SCHEDULING of the waves was the loss (#1002, H100 round 15)
+
+Round 15 rebuilt at `8a6f50b61` with #1002's slot-aliasing fix in. **Every
+structural check passes**: cell V15 logged **0 `SSM pool slot SHARED`, 0
+`release_slot … already free`, 0 content-loop / fuzzy / SimHash stops, 16/16
+responses at the full 256 tokens**, and every `Captured CUDA graph … slots=`
+list carries distinct real slots (index 16 is the padding sentinel). Against
+round 13's cell V — 24 content-loop fires, 2 fuzzy stops, 5 SimHash stops, 6/16
+probe responses cut at 49 tokens — that is a clean reversal. On the LONG shape
+`deferral SKIPPED` fires and the numbers land on the no-lever cell's exactly
+(398.34 vs 401.28 tok/s, 4 115.2 vs 4 118.8 ms TTFT): round 13's +83% TTFT
+regression is gone, replaced by a null.
+
+**And the lever was still a loss on the SHORT shape, for a scheduling reason,
+not a kernel one.** Whenever the 16-stream varlen batching engaged:
+
+| | A15 (no lever) | **V15 (engaged)** | Δ |
+|---|---:|---:|---:|
+| `1024x256` C=16 aggregate | 513.86 | **427.53** | **−16.8%** |
+| TTFT p50 | 1 359.4 ms | **4 141.2 ms** | **3.05×** |
+| TTFT p99 | 2 504.5 ms | 4 142.2 ms | +65% |
+| **TPOT** | 25.90 ms | **21.28 ms** | **−17.8%** |
+| e2e p50 | 7.97 s | 9.57 s | +20% |
+
+**TPOT moved the right way by 17.8%** — batching the prefill up front genuinely
+removes the prefill/decode interference round 11 traced — so the batching works.
+What did not work was that **p50 = p99**: `16 streams -> 3 wave(s)` ran
+back-to-back inside ONE tick. Promotion is a phase, not a callback: a stream's
+first token reaches its client in `promote_completed_prefills`, after
+`continue_in_progress_prefills` returns, and decode runs later still in the
+tick's own decode step. So a stream that finished in wave 1 waited for waves 2
+and 3 before anyone heard from it, and every TTFT in the burst landed on the
+slowest.
+
+**The fix is ONE WAVE PER TICK** (`prefill_waves::waves_this_tick`), not a
+second guard condition. Wave 1 runs, its finished streams are promoted at the
+end of that tick, decode interleaves from the next one, and the streams that did
+not fit re-plan next tick — where they batch among themselves, because the
+planner is re-run from the live geometry every tick. On the round-15 shape:
+sixteen 1193-token prompts plan 7 / 7 / 2, seven prefill on tick 1, and on tick
+2 those seven stand first in FIFO order and their tails complete as one
+175-token forward before any further head wave is issued.
+
+The alternative — promoting inside the wave loop — buys nothing here.
+`promote_completed_prefills` removes from `prefilling`, which invalidates the
+wave indices mid-loop, and decode still would not run until the prefill phase
+returned; the promoted stream's token would leave at the same wall time. The
+tick boundary is where the scheduler already interleaves, so that is where the
+cut belongs.
+
+FAIRNESS is unchanged in kind. The planner is first-fit in FIFO order, so wave 1
+always contains stream 0: the head of the queue advances exactly one chunk per
+tick, which is the guarantee the single-stream `prefilling.first_mut()` path
+gives — and it now carries everyone who fits with it. With the flag OFF the
+planner returns one wave holding every stream and this cap returns it whole, so
+that path stays byte-identical. Pinned in `prefill_waves_tick_tests`.
+
+**Why engagement varied burst to burst, and what is done about it.** Round 15
+saw two of four otherwise identical short-shape bursts engage (427 tok/s) and
+two not (514 tok/s — the no-lever numbers), a 17.52% rep spread that is not
+measurement noise. The planner is not the source: `plan_prefill_waves` is a pure
+function of the geometries. The ADMISSION is: it requires `active.is_empty()`
+and two chunk-0s co-admitted in the SAME tick, and a burst whose first request
+has already been promoted to decode by the time the rest arrive fails the first
+test. That is arrival timing against the scheduler's tick period — **inherent,
+not pinnable** — so `varlen_admission` now returns the one input that decided
+each verdict and `phase_start_prefills` logs it per burst:
+
+```
+Varlen prefill admission: defer=false reason="decode already active this tick (arrival timing)" new_reqs=9 prefilling=0 active=7 smallest_chunk0=[1193, 1193] cap=8192
+```
+
+A run's engagement is now readable from its serve log instead of inferred from
+its throughput. The `deferral SKIPPED` line is unchanged and still fires on the
+long shape.
+
+**The lever stays default OFF.** §5's finding stands: `M=8176` (7 prompts fused)
+measured **190.4 µs/token against 188.8 µs/token at M=1168** — 0.8% WORSE —
+so varlen repackages the GDN work rather than reducing it. This change removes
+the TTFT collapse that made the lever a 16.8% aggregate loss on top of that; it
+does not make batching pay, and the C=16 gap to vLLM is still not a
+prefill-batching deficit.

--- a/PREFILL-BATCHING-ATTRIBUTION.md
+++ b/PREFILL-BATCHING-ATTRIBUTION.md
@@ -98,3 +98,65 @@ max_batch_tokens) = 8192`. Sixteen whole 1193-token prompts pack 6 per wave
 (`--prefill-varlen-batch`, legacy `ATLAS_PREFILL_VARLEN=1`, default OFF) until
 the H100 A/B; the boot route line prints the resolved chunk-zero decision beside
 it, and `ATLAS_NO_TAIL_SPLIT=1` stays the A/B for the split itself.
+
+## 5. Why the lever then degenerated its output (#1002, H100 round 13)
+
+Phase-2 attribution. The lever now engages as §1-§4 describe — `16 streams ->
+3 wave(s), M per wave [50, 8176, 8176] (cap 8192)`, `Q12 kernel-batched prefill
+dispatched (fused large-M) n=7 total_tokens=8176`, every response carrying
+tokens and a `finish_reason`. And cell V logged **24 content-loop-watchdog
+fires, 2 fuzzy-repetition stops and 5 SimHash stops against ZERO on cells A, D,
+T1 and T2** — same binary, same prompts, temp 0, seed 42 — with 6/16 probe
+responses cut at 49 tokens.
+
+**Not the varlen kernel path. The scheduler hands two live sequences one SSM
+pool slot.** A sequence claims its slot at admission, so a stream parked in
+`prefilling` owns one; `compact_survivors_into_range` derived its free targets
+from the DECODING set alone. Varlen is the first configuration that parks
+slot-owning streams there (`want_varlen_defer`: 96 deferrals on cell V, zero on
+A/D/T1), so the per-tick compaction migrated an active survivor onto a
+prefilling stream's slot — visible in the log 30 ms apart as
+`slots=Some([0, 7])` then `slots=Some([0, 1])`. `compact_sequence` calls
+`ssm_pool.claim_specific` and discards its false return, so the collision is
+silent, and two sequences then share one GDN `h_state`/`conv_state`.
+
+It outlives the burst: both owners release that index, `release_slot`'s only
+guard was a `debug_assert` (a no-op in the shipped `--release` binary), and the
+duplicated free-list entry makes `claim_slot` issue it to two fresh sequences
+for the life of the process. That is why the 16-way probe four minutes later —
+**with varlen not engaging at all**, every prefill logging `Prefilled (single
+chunk)` — still decoded at `slots=[0, 0, 0, 1, 1, 2, 2, 3, ...]` and lost 6/16
+responses. Duplicate REAL slots appear in 16 of cell V's 24 batched-decode
+captures and in none of any other cell's in this campaign.
+
+**The `50`-token wave is not a truncated chunk 0.** `[50, 8176, 8176]` is two
+25-token TAILS (from streams that arrived one tick early, their heads dispatched
+as the `2336` forward) plus fourteen 1168-token heads: `2 x 25 + 14 x 1168 =
+16402`. The budget can never shrink a chunk 0 — `plan_stream_chunk` budgets
+against `max_prefill_tokens` and the WAVE cap belongs to the planner, which
+opens a new wave rather than trimming a member. Pinned in `prefill_waves_tests`
+alongside a tick-by-tick replay of the burst's arrival pattern.
+
+**The long shape's +83% TTFT was deferral with no batching.** 4593 pre-splits
+to `4576 + 17` and `2 x 4576 = 9152 > 8192`, so the planner emitted 14 waves for
+16 streams; waves run back-to-back inside one tick, so no stream is promoted
+until all of them have run and every TTFT collapses onto the p99 (7 524.7 ->
+13 756.1 ms while p99 barely moved). `varlen_defer_pays` now declines the
+deferral when the two smallest chunk-0s cannot share a wave.
+
+**And a watchdog stop is no longer only a `"length"`.** The wire
+`finish_reason` still reports `"length"` for every non-timeout guard — that
+mapping is a measured contract, and minting a new enum value hard-fails typed
+clients — but the guard's name now rides beside it in the `stop_reason`
+extension field, on the streaming chunk and the blocking choice alike (the
+round-13 probe ran `stream=false`).
+
+**Still open after this:** the batching itself does not pay. nsys on cell V
+measured `M=8176` (7 prompts fused) at **190.4 us/token against 188.8 us/token
+at M=1168** — 0.8% WORSE — with total prefill busy moving 8 000.5 -> 7 925.2 ms
+(-0.9%) for the same 38 176 tokens, and total GDN prefill identical at 54% of
+prefill either way. Round 11's arithmetic-intensity hypothesis (§1, "every
+projection GEMM at a sixth of the arithmetic intensity it could have") is
+refuted by measurement: the M=1168 GEMMs are already at full efficiency on an
+H100. Varlen repackages the GDN work; it does not reduce it. The lever stays
+default OFF, and the C=16 gap to vLLM is not a prefill-batching deficit.

--- a/PREFILL-BATCHING-ATTRIBUTION.md
+++ b/PREFILL-BATCHING-ATTRIBUTION.md
@@ -1,0 +1,100 @@
+# Why concurrent prefills ran one at a time (#927, H100)
+
+Phase-1 attribution for the batched (varlen) prefill lever. **Headline: the
+scheduler was already co-admitting all sixteen streams; the serialisation is one
+crate down, and the documented fix could not engage because four sites disagreed
+about one boolean.**
+
+## Anchors (measured, 1xH100, Qwen/Qwen3.8-27B-FP8, round 11 cells A and E)
+
+nsys over two back-to-back 16-way bursts of 1193-token prompts,
+`--max-prefill-tokens 8192` (`prefill_budget=8192, max_batch_tokens=8196`).
+`rms_norm_residual` launches once per layer per forward, `GrdX` = that forward's
+token count; all 576 detected forwards have exactly 64. **64 prefill chunks for
+32 requests, strictly `1168, 25, 1168, 25, …`.**
+
+| forward `GrdX` | count | busy ms | ms/forward | **µs/token** |
+|---|---|---|---|---|
+| 1168 (prompt head) | 32 | 7064.4 | 220.76 | 189.0 |
+| 25 (prompt tail) | 32 | 936.2 | 29.26 | **1170.2** |
+
+A 16-row decode step costs 1234.5 µs/token — the tail chunk is per-token
+indistinguishable from decode. Window: PREFILL 8.0 s (39.8%), DECODE 10.1 s
+(50.2%), IDLE 2.0 s (10.0%). C=16 TTFT p50 2.28 s / p99 4.22 s (vLLM 1.05 / 1.17,
+same box). Budget at 2048 or 24576 moved the aggregate ±0.4% — **the budget was
+never binding**, which is what sent this to the trace.
+
+## 1. Why the default path prefills one prompt per step
+
+Not the scheduler. `continue_in_progress_prefills` takes
+`can_batch_prefill_only` (N≥2 prefilling, no active decode, not EP) and hands ALL
+sixteen streams to `Model::prefill_batch_chunk` in one call. The serialisation is
+inside that call: `prefill_batch_chunk_dispatch` asks `kernel_batched_eligible`
+first, and that predicate rejects any batch with `chunk_start == 0` unless
+`allow_chunk_zero` — false with neither `ATLAS_PREFILL_CODISPATCH` nor
+`--prefill-varlen-batch` set. A burst of fresh prompts is all chunk 0, so it falls
+through to the per-stream loop: sixteen sequential forwards at M=1193 instead of
+one at M≈7000, every projection GEMM at a sixth of the arithmetic intensity it
+could have. The `seq_len_start > 0` precondition exists because the
+batched attention kernels are **paged-only** and chunk 0 historically took the
+non-paged `prefill_attention_with_cache_skip` arm. VARLEN v1 lifted that (chunk-0
+streams get a forced paged upload in `batch_kernel.rs`), so the precondition was
+already stale — for three of its four readers.
+
+## 2. Why `--prefill-varlen-batch` returned empty 200s instead
+
+Four sites decide chunk-zero co-admission. Three read `codispatch || varlen`:
+`check_kernel_batched_eligible`, the paged-upload force, and
+`prefill_attention_paged_attn_batched`. The fourth,
+`Qwen3AttentionLayer::prefill_inner`, read `codispatch` **alone**. Admission said
+yes; the layer said no — at layer 0, with Phase A already done (KV blocks
+allocated, prefix reservations taken, hidden staged for every member).
+
+```
+ERROR ...run_batched_prefill: Batched prefill error (wave of 6 streams, 6
+prefilling): prefill_inner: batched mode requires seq_len_start > 0 (paged
+path); got seq_len_start=0. Caller must fall back to per-stream for this chunk.
+```
+
+The error asked the caller to fall back. The caller did not: it pushed
+`(i, None)` for every member and `promote_completed_prefills` freed each sequence
+while **dropping its `ResponseSink`**. The SSE body was already committed with a
+200, so sixteen clients got a stream ending after the role delta — no content, no
+`finish_reason`, no usage frame, `err=0`. 3/3 reps; a recheck gave one clean rep
+at 438 tok/s (2% ahead of the default) and one dropping 3 of 16. Filed separately
+as Avarok-Cybersecurity/atlas#1000 — silent truncation is a bug on its own.
+
+## 3. What chunk 0 needed
+
+Nothing structural. KV writes go through `slot_stacked` per token; RoPE reads
+`positions_stacked`, so positions start at 0 with no special case; the paged
+batched kernel takes `q_offset = 0` with per-stream `cu_seqlens` / `kv_lens` and
+masks causally relative to it; GDN is per-request under `cu_seqlens`, each over
+its own `h_state`, whose fresh value is the zeroed one `alloc_state` returns. The
+fix is the predicate, not the plumbing: one function,
+`ops::prefill_batched_chunk_zero_allowed`, read by all four sites, with a
+source-scanning test that fails if any re-derives the disjunction.
+
+## 4. The 25-token tails
+
+`prefill_chunk_dispatch` splits a prompt's FINAL chunk once at
+`((total-1)/bs)*bs - bs` = 1168 for a 1193-token prompt at `bs=16`, to land an SSM
+tail checkpoint a later turn's block-floored prefix match can use. It is
+unconditional on hybrid-SSM models with the prefix cache active and must stay so:
+a shape differing cold vs warm flips a temperature-0 argmax (Puzzle-75B: "17
+barrels" cold, "15 barrels" warm). The batched path does not split, so a whole prompt handed to it would take a
+different shape than the same prompt takes per-stream. `Model::prefill_tail_cut`
+reports the cut and the scheduler pre-splits there under VARLEN: geometry stays
+identical per sequence, and the tails BATCH — sixteen tails of one burst share
+`chunk_start = 1168`, so the planner puts all of them in one forward instead of
+sixteen standalone passes. Ragged lengths give different cuts and so separate
+tail waves; pairing a tail with another prompt's head is not available, because a
+batch must share `chunk_start` (it sets `effective_seq_len_start`) and
+`is_last_chunk` (finalize_last and save_checkpoint cannot dispatch together).
+**Admission arithmetic:** `wave_cap = min(--max-prefill-tokens,
+max_batch_tokens) = 8192`. Sixteen whole 1193-token prompts pack 6 per wave
+(6×1193 = 7158; a seventh is 8351) → 3 dispatches, not 16; pre-split heads pack 7
+(7×1168 = 8176). Both pinned in `prefill_waves::tests`. The lever stays opt-in
+(`--prefill-varlen-batch`, legacy `ATLAS_PREFILL_VARLEN=1`, default OFF) until
+the H100 A/B; the boot route line prints the resolved chunk-zero decision beside
+it, and `ATLAS_NO_TAIL_SPLIT=1` stays the A/B for the split itself.

--- a/crates/spark-model/Cargo.toml
+++ b/crates/spark-model/Cargo.toml
@@ -89,6 +89,10 @@ workspace = true
 # NOTE: the ARM-2 Leg-2 native-MXFP4 (E8M0) numeric gate lives as a real
 # `#[ignore]`d integration test — see crates/spark-model/tests/arm2_leg2_*.rs.
 [[example]]
+name = "native_prefill_varlen_batch_microtest"
+required-features = ["cuda", "gpu-examples"]
+
+[[example]]
 name = "kda_gate_microtest"
 required-features = ["cuda", "gpu-examples"]
 

--- a/crates/spark-model/examples/native_prefill_varlen_batch_microtest.rs
+++ b/crates/spark-model/examples/native_prefill_varlen_batch_microtest.rs
@@ -282,8 +282,9 @@ fn main() -> Result<()> {
         let last_row = hi - NQ * HD;
         let last_unequal = (last_row..hi).filter(|&i| a[i] != b_out[i]).count();
         println!(
-            "seq {b}: len={:4}  blocks={:3}  unequal={unequal}/{}  last-position unequal={last_unequal}/{}",
+            "seq {b}: len={:4} blocks={:3}  unequal={unequal}/{}  last-position unequal={last_unequal}/{}",
             LENS[b],
+            tables[b].len(),
             hi - lo,
             NQ * HD,
         );

--- a/crates/spark-model/examples/native_prefill_varlen_batch_microtest.rs
+++ b/crates/spark-model/examples/native_prefill_varlen_batch_microtest.rs
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! CHUNK-ZERO batched (varlen) prefill attention vs the per-stream path (#927).
+//!
+//! The H100 round-11 nsys trace showed a 16-way burst of 1193-token prompts
+//! prefilled STRICTLY one prompt at a time — 64 forwards for 32 requests, with
+//! `--max-prefill-tokens 8192` (six prompts would have fit) never binding. The
+//! documented fix, `--prefill-varlen-batch`, could not engage because the
+//! attention layer refused `seq_len_start == 0`: the wave that would fix the
+//! serialisation was exactly the wave it declined.
+//!
+//! With that guard now reading the same predicate as admission, a co-arriving
+//! burst of FRESH prompts goes through `inferspark_prefill_paged_batched` with
+//! `q_offset = 0` and per-stream `cu_seqlens` / `kv_lens`. This microtest is the
+//! receipt that doing so changes nothing per sequence.
+//!
+//! CONTRACT (gated, exit 1 on failure):
+//!   1. BITS. For each of four RAGGED synthetic sequences at chunk 0, the
+//!      batched kernel's output must equal the single-stream kernel's output on
+//!      the same Q/K/V BYTE FOR BYTE. Both arms run the same
+//!      `prefill_paged_compute.cuh` body at BR=32 with the same per-accumulator
+//!      operand order; only `blockIdx.z` and the Q/O base offset differ. So the
+//!      question is not "how close" — anything but `unequal = 0` is a bug.
+//!      (Documented exception, none expected here: at `chunk_len >= 256` the
+//!      dispatcher selects the BR=64 twin on both arms, which re-brackets the
+//!      online-softmax rescale across a wider row tile. This test stays under
+//!      256 so both arms are BR=32 and the comparison is exact.)
+//!   2. KV. The K/V pool is byte-identical before and after both arms — the
+//!      chunk-0 batched path READS the pages a fresh sequence just wrote, it
+//!      must not write them again. A per-sequence digest is compared, so a
+//!      cross-stream write lands on a different sequence's digest and is named.
+//!   3. EXTENT. Guard bands either side of every output buffer are untouched,
+//!      and stream `b`'s packed output region is written only by stream `b`
+//!      (checked by running the batch twice with one stream's Q perturbed and
+//!      asserting only that stream's rows move).
+//!
+//! Run (H100 / any CUDA box with the kernels built):
+//!   cargo run --release -p spark-model --features cuda,gpu-examples \
+//!     --example native_prefill_varlen_batch_microtest
+
+use anyhow::{Result, ensure};
+use half::bf16;
+use spark_model::layers::ops;
+use spark_runtime::cuda_backend::AtlasCudaBackend;
+use spark_runtime::gpu::{DevicePtr, GpuBackend, KernelHandle};
+
+/// Qwen3.8-27B attention geometry (`kernels/hopper/qwen3.8-27b/MODEL.toml`).
+const NQ: usize = 24;
+const NKV: usize = 4;
+const HD: usize = 256;
+/// KV paging granularity — the same 16 the serve uses, so the block tables the
+/// two arms walk are the production shape.
+const BS: usize = 16;
+/// Four ragged fresh prompts. Deliberately not multiples of `BS` (a real burst
+/// is never block-aligned) and all < 256 so both arms take the BR=32 kernel.
+const LENS: [usize; 4] = [96, 163, 208, 49];
+const GUARD: usize = 256; // bytes of sentinel either side of every buffer
+const SENTINEL: u8 = 0x5a;
+
+struct Lcg(u64);
+impl Lcg {
+    fn next_f32(&mut self) -> f32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        // [-1, 1), coarse on purpose: bf16 has 8 mantissa bits, so a finer
+        // source would only be rounded away and would hide nothing.
+        (((self.0 >> 40) as f32) / ((1u32 << 23) as f32)) * 2.0 - 1.0
+    }
+}
+
+/// Allocate `bytes` with sentinel guard bands, returning the payload pointer.
+fn alloc_guarded(gpu: &dyn GpuBackend, bytes: usize) -> Result<(DevicePtr, DevicePtr, usize)> {
+    let total = bytes + 2 * GUARD;
+    let base = gpu.alloc(total)?;
+    gpu.memset(base, SENTINEL, total)?;
+    Ok((base.offset(GUARD), base, total))
+}
+
+fn check_guards(gpu: &dyn GpuBackend, base: DevicePtr, total: usize, name: &str) -> Result<()> {
+    let mut head = vec![0u8; GUARD];
+    let mut tail = vec![0u8; GUARD];
+    gpu.copy_d2h(base, &mut head)?;
+    gpu.copy_d2h(base.offset(total - GUARD), &mut tail)?;
+    ensure!(
+        head.iter().all(|&b| b == SENTINEL) && tail.iter().all(|&b| b == SENTINEL),
+        "{name}: a kernel wrote outside its buffer",
+    );
+    Ok(())
+}
+
+fn upload_bf16(gpu: &dyn GpuBackend, data: &[bf16]) -> Result<(DevicePtr, DevicePtr, usize)> {
+    let bytes: Vec<u8> = data
+        .iter()
+        .flat_map(|x| x.to_bits().to_le_bytes())
+        .collect();
+    let (p, base, total) = alloc_guarded(gpu, bytes.len())?;
+    gpu.copy_h2d(&bytes, p)?;
+    Ok((p, base, total))
+}
+
+fn upload_u32(gpu: &dyn GpuBackend, data: &[u32]) -> Result<DevicePtr> {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    let p = gpu.alloc(bytes.len().max(4))?;
+    gpu.copy_h2d(&bytes, p)?;
+    Ok(p)
+}
+
+fn upload_u64(gpu: &dyn GpuBackend, data: &[u64]) -> Result<DevicePtr> {
+    let bytes: Vec<u8> = data.iter().flat_map(|x| x.to_le_bytes()).collect();
+    let p = gpu.alloc(bytes.len().max(8))?;
+    gpu.copy_h2d(&bytes, p)?;
+    Ok(p)
+}
+
+fn download_bf16(gpu: &dyn GpuBackend, p: DevicePtr, n: usize) -> Result<Vec<u16>> {
+    let mut raw = vec![0u8; n * 2];
+    gpu.copy_d2h(p, &mut raw)?;
+    Ok(raw
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
+}
+
+/// FNV-1a over raw bytes — a digest, not a checksum with pretensions.
+fn digest(bytes: &[u8]) -> u64 {
+    let mut h = 0xcbf2_9ce4_8422_2325u64;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x1000_0000_01b3);
+    }
+    h
+}
+
+struct Kernels {
+    single: KernelHandle,
+    batched: KernelHandle,
+}
+
+fn main() -> Result<()> {
+    let gpu = AtlasCudaBackend::new(0, &atlas_kernels::ptx_modules())?;
+    let stream = gpu.default_stream();
+    let k = Kernels {
+        single: gpu.kernel("prefill_paged", "inferspark_prefill_paged")?,
+        batched: gpu.kernel(
+            "inferspark_prefill_paged_batched",
+            "inferspark_prefill_paged_batched",
+        )?,
+    };
+
+    let n = LENS.len();
+    let total_tokens: usize = LENS.iter().sum();
+    let max_len = *LENS.iter().max().unwrap();
+    let inv_sqrt_d = 1.0f32 / (HD as f32).sqrt();
+
+    // ── Paged K/V pool ────────────────────────────────────────────────────
+    // One shared pool, each sequence owning a disjoint run of blocks — the
+    // layout a fresh burst gets from the block manager. Blocks are handed out
+    // INTERLEAVED across sequences so a kernel that walks a block table
+    // linearly (rather than through it) reads someone else's pages and the
+    // comparison below says so.
+    let blocks_per: Vec<usize> = LENS.iter().map(|&l| l.div_ceil(BS)).collect();
+    let total_blocks: usize = blocks_per.iter().sum();
+    let block_elems = BS * NKV * HD;
+    let mut rng = Lcg(0x5eed_1234_5678_9abc);
+    let k_pool_host: Vec<bf16> = (0..total_blocks * block_elems)
+        .map(|_| bf16::from_f32(rng.next_f32()))
+        .collect();
+    let v_pool_host: Vec<bf16> = (0..total_blocks * block_elems)
+        .map(|_| bf16::from_f32(rng.next_f32()))
+        .collect();
+    let (k_pool, k_base, k_total) = upload_bf16(&gpu, &k_pool_host)?;
+    let (v_pool, v_base, v_total) = upload_bf16(&gpu, &v_pool_host)?;
+
+    // Interleaved block assignment: the sequences take blocks round-robin, so
+    // a sequence's pages are NOT contiguous. A kernel that walks the pool
+    // linearly instead of through the block table then reads another
+    // sequence's K/V and the bit comparison below names it.
+    let mut tables: Vec<Vec<u32>> = vec![Vec::new(); n];
+    let mut blk = 0u32;
+    loop {
+        let mut progressed = false;
+        for (b, table) in tables.iter_mut().enumerate() {
+            if table.len() < blocks_per[b] {
+                table.push(blk);
+                blk += 1;
+                progressed = true;
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    assert_eq!(blk as usize, total_blocks);
+
+    let table_ptrs_host: Vec<u64> = tables
+        .iter()
+        .map(|t| upload_u32(&gpu, t).map(|p| p.0))
+        .collect::<Result<Vec<_>>>()?;
+    let table_devs: Vec<DevicePtr> = table_ptrs_host.iter().map(|&p| DevicePtr(p)).collect();
+    let block_table_ptrs = upload_u64(&gpu, &table_ptrs_host)?;
+
+    // ── Q, packed by cu_seqlens ───────────────────────────────────────────
+    let q_host: Vec<bf16> = (0..total_tokens * NQ * HD)
+        .map(|_| bf16::from_f32(rng.next_f32()))
+        .collect();
+    let (q, q_base, q_total) = upload_bf16(&gpu, &q_host)?;
+
+    let mut cu = vec![0u32; n + 1];
+    for b in 0..n {
+        cu[b + 1] = cu[b] + LENS[b] as u32;
+    }
+    let cu_seqlens = upload_u32(&gpu, &cu)?;
+    // Chunk 0: every token this sequence has is the chunk it just wrote, so
+    // its KV extent IS its length.
+    let kv_lens = upload_u32(&gpu, &LENS.map(|l| l as u32))?;
+
+    let kv_before: Vec<u64> = (0..n)
+        .map(|b| seq_kv_digest(&k_pool_host, &v_pool_host, &tables[b], block_elems))
+        .collect();
+
+    // ── Arm A: per-stream, one call per sequence ──────────────────────────
+    let (out_single, os_base, os_total) = alloc_guarded(&gpu, total_tokens * NQ * HD * 2)?;
+    for b in 0..n {
+        let off = cu[b] as usize * NQ * HD * 2;
+        ops::prefill_attention_paged(
+            &gpu,
+            k.single,
+            q.offset(off),
+            k_pool,
+            v_pool,
+            out_single.offset(off),
+            table_devs[b],
+            LENS[b] as u32,
+            LENS[b] as u32,
+            0, // q_offset — CHUNK ZERO, the case that used to be refused
+            NQ as u32,
+            NKV as u32,
+            HD as u32,
+            BS as u32,
+            0, // sliding_window
+            inv_sqrt_d,
+            stream,
+        )?;
+    }
+    gpu.synchronize(stream)?;
+
+    // ── Arm B: one batched call over all four ─────────────────────────────
+    let (out_batched, ob_base, ob_total) = alloc_guarded(&gpu, total_tokens * NQ * HD * 2)?;
+    ops::prefill_attention_paged_batched(
+        &gpu,
+        k.batched,
+        q,
+        k_pool,
+        v_pool,
+        out_batched,
+        block_table_ptrs,
+        n as u32,
+        cu_seqlens,
+        kv_lens,
+        max_len as u32, // q_len is the MAX: it bounds the grid's Q-tile dim only
+        max_len as u32,
+        0, // q_offset — chunk zero
+        NQ as u32,
+        NKV as u32,
+        HD as u32,
+        BS as u32,
+        0,
+        inv_sqrt_d,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+
+    // ── 1. BITS ───────────────────────────────────────────────────────────
+    let a = download_bf16(&gpu, out_single, total_tokens * NQ * HD)?;
+    let b_out = download_bf16(&gpu, out_batched, total_tokens * NQ * HD)?;
+    let mut failures = 0usize;
+    for b in 0..n {
+        let lo = cu[b] as usize * NQ * HD;
+        let hi = cu[b + 1] as usize * NQ * HD;
+        let unequal = (lo..hi).filter(|&i| a[i] != b_out[i]).count();
+        let last_row = hi - NQ * HD;
+        let last_unequal = (last_row..hi).filter(|&i| a[i] != b_out[i]).count();
+        println!(
+            "seq {b}: len={:4}  blocks={:3}  unequal={unequal}/{}  last-position unequal={last_unequal}/{}",
+            LENS[b],
+            hi - lo,
+            NQ * HD,
+        );
+        if unequal != 0 {
+            failures += 1;
+        }
+    }
+    ensure!(
+        failures == 0,
+        "batched chunk-0 prefill attention diverges from the per-stream path \
+         on {failures}/{n} sequences — the two arms run the same BR=32 body, so \
+         this is a bug, not a tolerance question",
+    );
+
+    // ── 2. KV untouched ───────────────────────────────────────────────────
+    let k_after = download_bf16(&gpu, k_pool, k_pool_host.len())?;
+    let v_after = download_bf16(&gpu, v_pool, v_pool_host.len())?;
+    let k_after: Vec<bf16> = k_after.into_iter().map(bf16::from_bits).collect();
+    let v_after: Vec<bf16> = v_after.into_iter().map(bf16::from_bits).collect();
+    for b in 0..n {
+        let after = seq_kv_digest(&k_after, &v_after, &tables[b], block_elems);
+        ensure!(
+            after == kv_before[b],
+            "seq {b}: K/V pages changed across the prefill arms — the chunk-0 \
+             batched path must READ the pages the sequence just wrote, never \
+             rewrite them (a cross-stream write shows up here as the WRONG \
+             sequence's digest moving)",
+        );
+    }
+    println!("KV pool: {n}/{n} per-sequence digests unchanged");
+
+    // ── 3. Extent ─────────────────────────────────────────────────────────
+    check_guards(&gpu, k_base, k_total, "k_pool")?;
+    check_guards(&gpu, v_base, v_total, "v_pool")?;
+    check_guards(&gpu, q_base, q_total, "q")?;
+    check_guards(&gpu, os_base, os_total, "out_single")?;
+    check_guards(&gpu, ob_base, ob_total, "out_batched")?;
+
+    // Stream isolation: perturb ONE sequence's Q and re-run the batch. Only
+    // that sequence's packed rows may move. This is what catches a kernel that
+    // indexes Q/O at `b * max_len` (the uniform layout) on a buffer packed by
+    // `cu_seqlens` — the exact defect the varlen geometry exists to avoid, and
+    // one that a same-length fixture cannot see.
+    let victim = 1usize;
+    let mut q_perturbed = q_host.clone();
+    let lo = cu[victim] as usize * NQ * HD;
+    q_perturbed[lo] = bf16::from_f32(q_host[lo].to_f32() + 1.0);
+    let bytes: Vec<u8> = q_perturbed
+        .iter()
+        .flat_map(|x| x.to_bits().to_le_bytes())
+        .collect();
+    gpu.copy_h2d(&bytes, q)?;
+    ops::prefill_attention_paged_batched(
+        &gpu,
+        k.batched,
+        q,
+        k_pool,
+        v_pool,
+        out_batched,
+        block_table_ptrs,
+        n as u32,
+        cu_seqlens,
+        kv_lens,
+        max_len as u32,
+        max_len as u32,
+        0,
+        NQ as u32,
+        NKV as u32,
+        HD as u32,
+        BS as u32,
+        0,
+        inv_sqrt_d,
+        stream,
+    )?;
+    gpu.synchronize(stream)?;
+    let perturbed = download_bf16(&gpu, out_batched, total_tokens * NQ * HD)?;
+    for b in 0..n {
+        let lo = cu[b] as usize * NQ * HD;
+        let hi = cu[b + 1] as usize * NQ * HD;
+        let moved = (lo..hi).any(|i| perturbed[i] != b_out[i]);
+        if b == victim {
+            ensure!(
+                moved,
+                "perturbing seq {b}'s Q changed nothing — the harness is inert"
+            );
+        } else {
+            ensure!(
+                !moved,
+                "perturbing seq {victim}'s Q moved seq {b}'s output — the batched \
+                 path is crossing stream boundaries in the packed layout",
+            );
+        }
+    }
+    println!("stream isolation: only seq {victim} moved");
+
+    println!("\nALL PASS — chunk-0 varlen batched prefill matches the per-stream path");
+    Ok(())
+}
+
+/// Digest of one sequence's K and V pages, in block-table order.
+fn seq_kv_digest(k: &[bf16], v: &[bf16], table: &[u32], block_elems: usize) -> u64 {
+    let mut bytes = Vec::with_capacity(table.len() * block_elems * 4);
+    for &blk in table {
+        let lo = blk as usize * block_elems;
+        for x in &k[lo..lo + block_elems] {
+            bytes.extend_from_slice(&x.to_bits().to_le_bytes());
+        }
+        for x in &v[lo..lo + block_elems] {
+            bytes.extend_from_slice(&x.to_bits().to_le_bytes());
+        }
+    }
+    digest(&bytes)
+}

--- a/crates/spark-model/src/layers/ops.rs
+++ b/crates/spark-model/src/layers/ops.rs
@@ -13,6 +13,9 @@
 
 #[path = "ops/activations.rs"]
 mod activations;
+#[cfg(test)]
+#[path = "ops/chunk_zero_ssot_tests.rs"]
+mod chunk_zero_ssot_tests;
 #[path = "ops/derived_weights.rs"]
 mod derived_weights;
 #[path = "ops/dispatch_config.rs"]

--- a/crates/spark-model/src/layers/ops/chunk_zero_ssot_tests.rs
+++ b/crates/spark-model/src/layers/ops/chunk_zero_ssot_tests.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! SSOT pin for the CHUNK-ZERO batched-prefill admission predicate.
+//!
+//! The predicate lives in exactly one function,
+//! [`super::prefill_batched_chunk_zero_allowed`]. Every other site that needs
+//! "may a wave of fresh prompts co-admit into one forward?" calls it.
+//!
+//! Why a source-scanning test rather than a behavioural one: the predicate
+//! reads process-global `OnceLock`s seeded from the environment, so a
+//! behavioural test can only observe whatever the first reader in the test
+//! binary happened to resolve. What actually broke (#927 cell E) was not the
+//! predicate's value — it was one of four readers computing its OWN disjunction
+//! and getting a different answer: admission said yes to a `--prefill-varlen-batch`
+//! chunk-0 wave, `Qwen3AttentionLayer::prefill_inner` said no, and the refusal
+//! landed mid-forward with KV blocks already allocated, failing all sixteen
+//! requests in the wave. The defect was a duplicated expression, so the test
+//! is on the expressions.
+
+/// Files that decide chunk-zero admission, and the call each must make.
+const READERS: &[(&str, &str)] = &[
+    (
+        "eligible.rs (admission)",
+        include_str!("../../model/trait_impl/prefill_b/batch_kernel/eligible.rs"),
+    ),
+    (
+        "batch_kernel.rs (paged upload)",
+        include_str!("../../model/trait_impl/prefill_b/batch_kernel.rs"),
+    ),
+    (
+        "prefill_inner.rs (attention layer body)",
+        include_str!("../qwen3_attention/trait_impl/prefill_inner.rs"),
+    ),
+    (
+        "paged_attn_batched.rs (batched attention entry)",
+        include_str!("../qwen3_attention/prefill/paged_attn_batched.rs"),
+    ),
+];
+
+/// The shape that must never come back: a reader OR-ing the two levers itself.
+fn rederives_the_predicate(src: &str) -> bool {
+    // Strip comment lines so this file's own narration (and the fix's SSOT
+    // comments, which name the old expression) does not trip the scan.
+    src.lines()
+        .map(str::trim_start)
+        .filter(|l| !l.starts_with("//"))
+        .any(|l| {
+            l.contains("prefill_batched_first_chunk_enabled")
+                || (l.contains("prefill_varlen_enabled") && l.contains("chunk"))
+        })
+}
+
+#[test]
+fn every_chunk_zero_reader_calls_the_one_predicate() {
+    for (name, src) in READERS {
+        assert!(
+            src.contains("prefill_batched_chunk_zero_allowed"),
+            "{name} decides chunk-zero admission but does not call \
+             ops::prefill_batched_chunk_zero_allowed()",
+        );
+    }
+}
+
+#[test]
+fn no_chunk_zero_reader_rederives_the_disjunction() {
+    for (name, src) in READERS {
+        assert!(
+            !rederives_the_predicate(src),
+            "{name} re-derives the chunk-zero predicate instead of calling \
+             ops::prefill_batched_chunk_zero_allowed() — that divergence is \
+             exactly the #927 cell-E failure",
+        );
+    }
+}
+
+#[test]
+fn the_predicate_is_defined_once() {
+    let helpers = include_str!("dispatch_helpers.rs");
+    assert_eq!(
+        helpers
+            .matches("pub fn prefill_batched_chunk_zero_allowed")
+            .count(),
+        1,
+        "the chunk-zero predicate must have exactly one definition",
+    );
+}

--- a/crates/spark-model/src/layers/ops/dispatch_helpers.rs
+++ b/crates/spark-model/src/layers/ops/dispatch_helpers.rs
@@ -68,6 +68,26 @@ pub fn prefill_varlen_enabled() -> bool {
         .get_or_init(|| bool_value_enabled(std::env::var("ATLAS_PREFILL_VARLEN").ok().as_deref()))
 }
 
+/// SSOT: may a batch of CHUNK-ZERO (fresh-prompt) streams co-admit into one
+/// batched prefill forward?
+///
+/// Four readers have to agree on this one predicate, and for a while they did
+/// not: the admission check (`check_kernel_batched_eligible`) and the batched
+/// paged-attention entry (`prefill_attention_paged_attn_batched`) both read
+/// `codispatch || varlen`, while the attention layer body
+/// (`Qwen3AttentionLayer::prefill_inner`) read `codispatch` alone. With
+/// `--prefill-varlen-batch` on, admission therefore ACCEPTED a wave of fresh
+/// prompts that the layer then refused mid-forward — after Phase A had already
+/// allocated KV blocks and staged hidden — and the whole wave's requests were
+/// failed. That is the H100 round-11 cell-E failure (#927): sixteen HTTP 200s
+/// with zero tokens at C=16.
+///
+/// One function, four call sites. Adding a fifth reader means calling this,
+/// never re-deriving it.
+pub fn prefill_batched_chunk_zero_allowed() -> bool {
+    prefill_batched_first_chunk_enabled() || prefill_varlen_enabled()
+}
+
 fn bool_value_enabled(value: Option<&str>) -> bool {
     matches!(value, Some("1")) || value.is_some_and(|value| value.eq_ignore_ascii_case("true"))
 }

--- a/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn_batched.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/prefill/paged_attn_batched.rs
@@ -87,8 +87,7 @@ impl Qwen3AttentionLayer {
         // Must mirror `check_kernel_batched_eligible`'s `allow_chunk_zero`
         // exactly — a batch admitted there and rejected here bails after the
         // streams have already been mutated.
-        let allow_first_chunk = crate::layers::ops::prefill_batched_first_chunk_enabled()
-            || crate::layers::ops::prefill_varlen_enabled();
+        let allow_first_chunk = crate::layers::ops::prefill_batched_chunk_zero_allowed();
         if seq_len_start == 0 && !allow_first_chunk {
             anyhow::bail!(
                 "prefill_attention_paged_attn_batched: seq_len_start=0 not supported \

--- a/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
+++ b/crates/spark-model/src/layers/qwen3_attention/trait_impl/prefill_inner.rs
@@ -128,8 +128,15 @@ impl Qwen3AttentionLayer {
         // tried and FAILED for large prefill chunks — numerically off + ~7x
         // slower (the kernel's batch dim is not compatible with the co-dispatch
         // stacking at large seq_len). So batched chunk-0 still uses paged.
+        // SSOT with `check_kernel_batched_eligible`'s `allow_chunk_zero` and
+        // with `prefill_attention_paged_attn_batched`'s own guard — all three
+        // read `ops::prefill_batched_chunk_zero_allowed()`. This line used to
+        // read `prefill_batched_first_chunk_enabled()` alone, so
+        // `--prefill-varlen-batch` admitted a fresh-prompt wave here and then
+        // bailed mid-forward with Phase A already committed (#927 cell E:
+        // sixteen HTTP 200s, zero tokens, at C=16).
         let allow_batched_first_chunk =
-            batched_meta.is_some() && crate::layers::ops::prefill_batched_first_chunk_enabled();
+            batched_meta.is_some() && crate::layers::ops::prefill_batched_chunk_zero_allowed();
         if batched_meta.is_some() && seq_len_start == 0 && !allow_batched_first_chunk {
             anyhow::bail!(
                 "prefill_inner: batched mode requires seq_len_start > 0 (paged path); \
@@ -671,6 +678,11 @@ impl Qwen3AttentionLayer {
             qsa.prefill_ingest(st, normed, num_tokens, seq_len_start, ctx.gpu, stream)?;
         }
 
+        // NOT relaxed alongside `prefill_inner`'s chunk-zero guard: the mHC
+        // path is DeepSeek-V4 (MLA, `kv_lora_rank > 0`), which
+        // `check_kernel_batched_eligible` rejects wholesale via `config_is_mla`
+        // before any stream is touched. So this is unreachable from the batched
+        // dispatcher and stays a hard failure rather than a fallback invitation.
         if batched_meta.is_some() && seq_len_start == 0 {
             anyhow::bail!(
                 "prefill_inner_hc: batched mode requires seq_len_start > 0; \

--- a/crates/spark-model/src/model/ssm_pool.rs
+++ b/crates/spark-model/src/model/ssm_pool.rs
@@ -441,12 +441,34 @@ impl SsmStatePool {
         })
     }
 
+    /// Return `idx` to the free list.
+    ///
+    /// IDEMPOTENT BY CONSTRUCTION (#1002). This used to be a `debug_assert`,
+    /// which is a release-build no-op — and release is exactly where it bites: on H100
+    /// round 13 cell V two sequences ended up owning one slot (the scheduler
+    /// compacted an active survivor onto a slot a `prefilling` stream still
+    /// held), and each of them released it. The duplicate entry made
+    /// `claim_slot` hand that index to two FRESH sequences, so a burst-scoped
+    /// collision became permanent state corruption: a 16-way probe minutes
+    /// later — with the varlen lever not even engaging — still decoded with
+    /// `slots=[0, 0, 0, 1, 1, 2, 2, 3, ...]` and lost 6/16 responses to the
+    /// content-loop watchdog.
+    ///
+    /// A double release is always a bug upstream; refusing the second push
+    /// bounds its blast radius to the sequences already involved instead of
+    /// poisoning the pool for the life of the process. The refusal is a
+    /// runtime check rather than an assertion precisely so it holds in the
+    /// build that shipped the failure, and it is loud: one ERROR line names
+    /// the slot.
     pub(super) fn release_slot(&self, idx: usize) {
         let mut free = self.free_slots.lock();
-        debug_assert!(
-            !free.contains(&idx),
-            "release_slot: slot {idx} already free (double-release hands it to two seqs)"
-        );
+        if free.contains(&idx) {
+            tracing::error!(
+                "release_slot: SSM pool slot {idx} was already free — refusing the duplicate \
+                 push (a double release hands one slot to two sequences; see #1002)"
+            );
+            return;
+        }
         free.push(idx);
     }
 
@@ -1189,6 +1211,47 @@ mod slot_guard_tests {
 
     fn free_count(pool: &SsmStatePool) -> usize {
         pool.free_slots.lock().len()
+    }
+
+    /// #1002. A duplicated free-list entry hands ONE slot to TWO sequences —
+    /// the shape round-13 cell V left behind after an active survivor was
+    /// compacted onto a `prefilling` stream's slot and both owners later
+    /// released it. First half pins the damage a duplicate does; second half
+    /// pins that `release_slot` refuses to create one.
+    #[test]
+    fn a_duplicated_free_entry_issues_one_slot_to_two_sequences() {
+        let pool = bare_pool(2);
+        // Bypass `release_slot` to construct the corrupted state directly.
+        pool.free_slots.lock().push(1);
+        let claimed: Vec<usize> = (0..3).map(|_| pool.claim_slot().unwrap()).collect();
+        assert_eq!(claimed.len(), 3);
+        let distinct: std::collections::HashSet<usize> = claimed.iter().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            2,
+            "a duplicated entry issues one index twice: {claimed:?}"
+        );
+    }
+
+    #[test]
+    fn double_release_is_refused_not_pushed() {
+        let pool = bare_pool(2);
+        let idx = pool.claim_slot().unwrap();
+        pool.release_slot(idx);
+        assert_eq!(free_count(&pool), 2);
+        // The bug: a second owner of the same slot releases it too.
+        pool.release_slot(idx);
+        assert_eq!(
+            free_count(&pool),
+            2,
+            "the duplicate push must be refused — otherwise `claim_slot` hands \
+             slot {idx} to two future sequences for the life of the process"
+        );
+        // And the pool still issues each claimable index exactly once.
+        let a = pool.claim_slot().unwrap();
+        let b = pool.claim_slot().unwrap();
+        assert_ne!(a, b);
+        assert!(pool.claim_slot().is_err(), "pool must now be exhausted");
     }
 
     #[test]

--- a/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
+++ b/crates/spark-model/src/model/trait_impl/decode_graph_key.rs
@@ -141,6 +141,29 @@ impl TransformerModel {
                 }
             }
         }
+        // INVARIANT, always on (#1002): every LIVE row must own a DISTINCT
+        // pool slot. Two rows on one slot share their GDN `h_state` /
+        // `conv_state`, which is cross-stream state bleed — degenerate,
+        // repetition-looping output that the content-loop watchdog then cuts
+        // (round 13 cell V: 24 fires, 6/16 responses stopped at 49 tokens).
+        // The slot vector is right here and `n <= 32`, so the check is a few
+        // dozen comparisons per step against a multi-millisecond forward; the
+        // round-13 diagnosis took a serve-log archaeology pass that this line
+        // would have replaced. Warn only — the graph key itself is still
+        // correct (it describes exactly the pointers that will be baked), and
+        // refusing to decode is worse than decoding on corrupted state.
+        if key.iter().enumerate().any(|(i, s)| key[..i].contains(s)) {
+            static WARNED: std::sync::Once = std::sync::Once::new();
+            let shared = key.clone();
+            WARNED.call_once(move || {
+                tracing::error!(
+                    "SSM pool slot SHARED by two live decode rows: slots={shared:?}. \
+                     Their recurrent state is aliased — expect repetition/watchdog cuts on \
+                     those streams. See #1002 (scheduler slot compaction vs the prefilling \
+                     queue); this fires once per process."
+                );
+            });
+        }
         let dummy = self.ssm_pool.dummy_slot() as u32;
         for _ in n..padded_n {
             key.push(dummy);

--- a/crates/spark-model/src/model/trait_impl/mod.rs
+++ b/crates/spark-model/src/model/trait_impl/mod.rs
@@ -188,6 +188,28 @@ impl Model for TransformerModel {
         Ok(out)
     }
 
+    /// Report the tail-checkpoint cut `prefill_chunk_dispatch` would apply to
+    /// this prompt's final chunk, so the scheduler can pre-split and keep the
+    /// batched and per-stream geometries identical (#927). The predicate and
+    /// the arithmetic are the dispatcher's own — see
+    /// `prefill_b::tail_split_cut`.
+    fn prefill_tail_cut(&self, tokens: &[u32]) -> Option<usize> {
+        if prefill_b::tail_split_disabled()
+            || self.config.num_ssm_layers() == 0
+            || !self.ssm_snapshots.is_enabled()
+            || !self.prefix_cache.is_active()
+            || self.tokens_have_vision_pad(tokens)
+        {
+            return None;
+        }
+        let bs = self.kv_cache.lock().block_size();
+        let total = tokens.len();
+        let cut = prefill_b::tail_split_cut(total, bs);
+        // `prefill_chunk_dispatch` splits only when `cut > chunk_start && cut <
+        // total`, and the scheduler only asks about a chunk starting at 0.
+        (cut > 0 && cut < total).then_some(cut)
+    }
+
     /// Q12 Phase 4b override. The concrete dispatcher routes ineligible
     /// batches to its sequential path before state mutation. Errors from an
     /// admitted kernel batch must propagate: retrying sequentially can

--- a/crates/spark-model/src/model/trait_impl/prefill_b.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b.rs
@@ -27,6 +27,8 @@ use crate::traits::{Model, SequenceState};
 mod batch;
 mod batch_kernel;
 #[cfg(test)]
+mod batch_kernel_chunk_zero_tests;
+#[cfg(test)]
 mod batch_kernel_tests;
 mod batched_layer;
 mod embed_chunk;
@@ -110,7 +112,10 @@ impl TransformerModel {
         {
             let bs = self.kv_cache.lock().block_size();
             // One block below the last block boundary strictly under `total`.
-            let cut = ((total.saturating_sub(1) / bs) * bs).saturating_sub(bs);
+            // SSOT: `tail_split_cut` — `Model::prefill_tail_cut` hands the same
+            // number to the scheduler so the batched path can pre-split and
+            // keep this shape (#927).
+            let cut = tail_split_cut(total, bs);
             // UNCONDITIONAL. This used to additionally require
             // `ep_active || peek_matched_tokens(..) > 0`, i.e. it split only on a
             // WARM request (radix already populated) — which made the prompt take a
@@ -136,7 +141,7 @@ impl TransformerModel {
             // That is the OTHER way to satisfy the invariant — always one pass — and
             // it keeps the single-pass numerics, at the cost of the warm-turn tail
             // checkpoint this split exists to create.
-            let split_disabled = std::env::var("ATLAS_NO_TAIL_SPLIT").as_deref() == Ok("1");
+            let split_disabled = tail_split_disabled();
             if !split_disabled && cut > chunk_start && cut < total {
                 self.prefill_chunk_dispatch(
                     tokens,
@@ -386,5 +391,60 @@ impl TransformerModel {
             )?;
             Ok(DevicePtr::NULL)
         }
+    }
+}
+
+/// The tail-checkpoint cut for a prompt of `total` tokens at KV block size
+/// `bs`: one block below the last block boundary strictly under `total`.
+///
+/// Free function so `prefill_chunk_dispatch` (which performs the split) and
+/// `TransformerModel::prefill_tail_cut` (which reports it to the scheduler)
+/// cannot drift apart — two call sites computing this expression separately is
+/// exactly the class of divergence that produced #927 cell E one module over.
+pub(in crate::model) fn tail_split_cut(total: usize, bs: usize) -> usize {
+    if bs == 0 {
+        return 0;
+    }
+    ((total.saturating_sub(1) / bs) * bs).saturating_sub(bs)
+}
+
+/// `ATLAS_NO_TAIL_SPLIT=1` — disable the tail-checkpoint split entirely
+/// (same-binary A/B; keeps the single-pass numerics and loses the warm-turn
+/// tail checkpoint).
+pub(in crate::model) fn tail_split_disabled() -> bool {
+    std::env::var("ATLAS_NO_TAIL_SPLIT").as_deref() == Ok("1")
+}
+
+#[cfg(test)]
+mod tail_split_cut_tests {
+    use super::tail_split_cut;
+
+    #[test]
+    fn the_cut_is_one_block_below_the_last_boundary_under_the_prompt() {
+        // The #927 shape: a 1193-token prompt at block size 16 splits
+        // 1168 + 25. ((1193-1)/16)*16 = 1184, minus one block = 1168.
+        assert_eq!(tail_split_cut(1193, 16), 1168);
+        assert_eq!(1193 - tail_split_cut(1193, 16), 25);
+    }
+
+    #[test]
+    fn a_prompt_on_a_boundary_still_cuts_a_block_below_it() {
+        // 1024 is itself a boundary; the last boundary STRICTLY under it is
+        // 1008, so the cut is 992 and the tail is 32 — never zero-length.
+        assert_eq!(tail_split_cut(1024, 16), 992);
+    }
+
+    #[test]
+    fn short_prompts_saturate_to_zero_and_disable_the_split() {
+        // `prefill_chunk_dispatch` only splits when `cut > chunk_start`, so a
+        // zero cut means "one pass" for a chunk starting at 0.
+        assert_eq!(tail_split_cut(16, 16), 0);
+        assert_eq!(tail_split_cut(0, 16), 0);
+        assert_eq!(tail_split_cut(1, 16), 0);
+    }
+
+    #[test]
+    fn a_zero_block_size_is_not_a_division() {
+        assert_eq!(tail_split_cut(1193, 0), 0);
     }
 }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch.rs
@@ -140,14 +140,22 @@ impl TransformerModel {
         // Buffer-arena fit check (per-stream sequential layout still respects
         // arena cap on each call). Bail loud if any stream's chunk exceeds
         // the arena — CUDA 700 territory.
+        //
+        // DECLINE, not failure: this runs before a single stream has been
+        // touched, so the caller re-runs the wave per-stream and only the
+        // oversized stream fails (against its own guard, with its own error).
+        // As a plain bail it took the whole wave's requests down for one
+        // stream's chunk — the same all-or-nothing shape as #927 cell E.
         let arena_cap = self.buffers.max_batch_tokens();
         for (i, s) in streams.iter().enumerate() {
             if s.chunk_len > arena_cap {
-                anyhow::bail!(
-                    "Batched prefill stream {i} chunk_len={} exceeds arena \
-                     capacity {arena_cap}. Reduce --max-prefill-tokens.",
-                    s.chunk_len
-                );
+                return Err(anyhow::Error::new(
+                    crate::traits::BatchedPrefillDeclined::new(format!(
+                        "stream {i} chunk_len={} exceeds arena capacity {arena_cap} \
+                         (reduce --max-prefill-tokens)",
+                        s.chunk_len
+                    )),
+                ));
             }
         }
 

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel.rs
@@ -41,7 +41,6 @@ mod eligible;
 // Re-exports so `batch_kernel::check_kernel_batched_eligible` (used by
 // `batch_kernel_tests.rs`) and the env-flag predicates resolve unchanged
 // after the eligibility cluster moved into the `eligible` submodule.
-use eligible::first_chunk_batched_enabled;
 pub(in crate::model) use eligible::{
     batched_reserve_hybrid_ssm_ok, cache_batch_matches_compatible, check_kernel_batched_eligible,
     config_is_mla, varlen_prefill_enabled,
@@ -218,8 +217,8 @@ impl TransformerModel {
         // stream's `block_table_dev` stays NULL, and the batched paged
         // attention kernel dereferences `block_table_ptrs[b]` unless the
         // opt-in FlashInfer ragged arm happens to be enabled.
-        let force_paged_first_chunk = streams[0].chunk_start == 0
-            && (crate::layers::ops::prefill_batched_first_chunk_enabled() || varlen);
+        let force_paged_first_chunk =
+            streams[0].chunk_start == 0 && crate::layers::ops::prefill_batched_chunk_zero_allowed();
 
         // Tracks MRoPE / paged-flag agreement across streams.
         let mut use_mrope: Option<bool> = None;

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel/eligible.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel/eligible.rs
@@ -3,8 +3,9 @@
 //! Eligibility gating for the Q12 Path B kernel-batched prefill.
 //!
 //! Extracted from `batch_kernel.rs` to keep each file under the 500-LoC
-//! file-size cap. Holds the env-flag predicates (`first_chunk_batched_enabled`,
-//! `varlen_prefill_enabled`), the pure-data eligibility check
+//! file-size cap. Holds the env-flag predicate (`varlen_prefill_enabled`; the
+//! chunk-zero predicate itself is `ops::prefill_batched_chunk_zero_allowed`,
+//! the SSOT this module's admission check reads), the pure-data eligibility check
 //! (`check_kernel_batched_eligible`, unit-tested in `batch_kernel_tests.rs`),
 //! and the `TransformerModel::kernel_batched_eligible` wrapper the dispatcher
 //! calls upfront.
@@ -25,20 +26,6 @@ use spark_runtime::prefix_cache::PrefixMatch;
 /// living as an inline expression no test can see.
 pub(in crate::model) fn config_is_mla(config: &ModelConfig) -> bool {
     config.kv_lora_rank > 0
-}
-
-/// Whether chunk-0 streams may use the batched (paged) prefill path. Enabled by
-/// `ATLAS_Q12_BATCHED_FIRST_CHUNK=1` or `ATLAS_PREFILL_CODISPATCH=1` (the latter
-/// is the single end-to-end flag for cross-request co-dispatch of fresh prompts,
-/// whose every stream starts at chunk_start==0).
-pub(super) fn first_chunk_batched_enabled() -> bool {
-    ["ATLAS_Q12_BATCHED_FIRST_CHUNK", "ATLAS_PREFILL_CODISPATCH"]
-        .iter()
-        .any(|k| {
-            std::env::var(k)
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false)
-        })
 }
 
 impl TransformerModel {
@@ -94,7 +81,9 @@ impl TransformerModel {
             self.config.num_experts_per_tok,
             self.config.mrope_interleaved,
             // VARLEN v1 batches chunk-0 (fresh K/V) through FlashInfer ragged.
-            crate::layers::ops::prefill_batched_first_chunk_enabled() || varlen,
+            // SSOT with the two layer-side guards — see
+            // `ops::prefill_batched_chunk_zero_allowed`.
+            crate::layers::ops::prefill_batched_chunk_zero_allowed(),
             varlen,
         )
     }

--- a/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel_chunk_zero_tests.rs
+++ b/crates/spark-model/src/model/trait_impl/prefill_b/batch_kernel_chunk_zero_tests.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Chunk-ZERO batched-prefill admission tests (#927).
+//!
+//! Sibling of `batch_kernel_tests.rs`, which was at the 500-LoC cap. Same
+//! predicate under test (`check_kernel_batched_eligible`); these cases are the
+//! ones the H100 round-11 receipt named — a co-arriving burst of FRESH prompts,
+//! which is the wave that fixes the serialised prefill and the wave the layer
+//! used to refuse after admission had accepted it.
+
+use super::batch_kernel::check_kernel_batched_eligible;
+
+/// (chunk_len, eff_len, chunk_start, is_last_chunk) — `eff == chunk_len`, the
+/// conservative charge used when no prefix hit is proven.
+fn s(chunk_len: usize, chunk_start: usize, is_last: bool) -> (usize, usize, usize, bool) {
+    (chunk_len, chunk_len, chunk_start, is_last)
+}
+
+/// Qwen3.8-27B: 8 experts per token, no MRoPE.
+const TOP_K: usize = 8;
+const MROPE: bool = false;
+
+#[test]
+fn admits_the_h100_c16_chunk_zero_wave() {
+    // The #927 receipt shape, at the admission boundary: six fresh 1193-token
+    // prompts (chunk_start 0, is_last) against the 8192-token prefill budget.
+    // Admission has always said YES to this under VARLEN; what failed was the
+    // attention layer saying NO a moment later, after Phase A had allocated KV
+    // for all six. The pair is now one predicate
+    // (`ops::prefill_batched_chunk_zero_allowed`), pinned by
+    // `layers::ops::chunk_zero_ssot_tests`; this test pins the admission half.
+    let streams: Vec<_> = (0..6).map(|_| s(1193, 0, true)).collect();
+    let arena: usize = 8_196;
+    let scratch =
+        spark_runtime::buffers::q12_batched_scratch_bytes_varlen(6, 6 * 1193, 1193, TOP_K, MROPE);
+    assert!(check_kernel_batched_eligible(
+        streams.clone(),
+        6,
+        arena,
+        false,
+        128,
+        scratch,
+        TOP_K,
+        MROPE,
+        true, // allow_chunk_zero — the resolved chunk-zero predicate
+        true, // varlen
+    ));
+    // And the tail wave the pre-split produces: six 25-token tails sharing
+    // chunk_start == 1168. One forward, not six.
+    let tails: Vec<_> = (0..6).map(|_| s(25, 1168, true)).collect();
+    assert!(check_kernel_batched_eligible(
+        tails, 6, arena, false, 128, scratch, TOP_K, MROPE, true, true,
+    ));
+    // Control: with the chunk-zero predicate OFF the same wave is refused —
+    // and refused HERE, before any stream is touched, which is the whole point
+    // of the admission check owning the decision.
+    assert!(!check_kernel_batched_eligible(
+        streams, 6, arena, false, 128, scratch, TOP_K, MROPE, false, true,
+    ));
+}
+
+#[test]
+fn varlen_admits_ragged_chunk_zero_lengths() {
+    // The equal-`chunk_len` requirement is exactly what VARLEN lifts; a burst
+    // of real prompts is never uniform. `chunk_start` and `is_last` must still
+    // match — those change the model-side dispatch, not just the geometry.
+    let arena: usize = 8_196;
+    let scratch =
+        spark_runtime::buffers::q12_batched_scratch_bytes_varlen(4, 4_000, 1_400, TOP_K, MROPE);
+    let ragged = [
+        s(1193, 0, true),
+        s(900, 0, true),
+        s(1400, 0, true),
+        s(507, 0, true),
+    ];
+    assert!(check_kernel_batched_eligible(
+        ragged, 4, arena, false, 128, scratch, TOP_K, MROPE, true, true,
+    ));
+    assert!(
+        !check_kernel_batched_eligible(
+            ragged, 4, arena, false, 128, scratch, TOP_K, MROPE, true, false,
+        ),
+        "without VARLEN the ragged lengths must still be refused",
+    );
+    // A mixed chunk_start is refused under VARLEN too — a head and a tail
+    // cannot share one forward, which is why the scheduler's wave planner
+    // groups on (chunk_start, is_last).
+    let mixed = [s(1168, 0, false), s(25, 1168, true)];
+    assert!(!check_kernel_batched_eligible(
+        mixed, 2, arena, false, 128, scratch, TOP_K, MROPE, true, true,
+    ));
+}

--- a/crates/spark-model/src/model/trait_impl/sequence.rs
+++ b/crates/spark-model/src/model/trait_impl/sequence.rs
@@ -488,6 +488,16 @@ impl TransformerModel {
         // sequences → shared GDN state → cross-stream content bleed. A no-op
         // for the ownership-TRANSFER caller (lifecycle swap-out), where the
         // target is owned by the retiring victim and not on the free list.
+        //
+        // The false return is therefore NOT an error here and cannot be
+        // promoted to one: this call cannot tell "owned by the victim I am
+        // about to disown" (legal) from "owned by a live stream that keeps
+        // it" (corruption). Choosing a legal target is the CALLER's rule, and
+        // it has exactly one home — `scheduler::mod_helpers::slot_targets`,
+        // which routes around slots held by the `prefilling` queue, plus the
+        // `a.seq.slot_idx == victim_idx` transfer precondition in
+        // `scheduler::lifecycle::swap_out_sequence`. Both exist because
+        // round-13 cell V violated them (#1002).
         self.ssm_pool.claim_specific(new_slot);
         if let Some(g) = seq.ssm_slot.as_mut() {
             // Guard owned `old_slot`; drop that ownership before releasing.

--- a/crates/spark-model/src/traits.rs
+++ b/crates/spark-model/src/traits.rs
@@ -20,6 +20,56 @@ pub struct MixedForwardResult {
     pub prefill_logits: DevicePtr,
 }
 
+/// A batched-prefill refusal raised BEFORE any stream's state was mutated.
+///
+/// The distinction is not cosmetic. Once a batched forward has entered Phase A
+/// it has allocated KV blocks, taken prefix reservations and staged hidden for
+/// every member, so re-running those streams one at a time would double-allocate
+/// — the caller must fail them (with a response, never a silent drop). A refusal
+/// raised before that point leaves the streams exactly as the scheduler handed
+/// them over, so the caller can and MUST re-run the whole wave per-stream and
+/// complete every request.
+///
+/// Attach with `anyhow::Error::new(BatchedPrefillDeclined::new(reason))` (or
+/// `.context(..)` on top of it) and detect with `downcast_ref`. The scheduler's
+/// wave-failure path (`run_batched_prefill_step`) is the reader.
+#[derive(Debug, Clone)]
+pub struct BatchedPrefillDeclined {
+    reason: String,
+}
+
+impl BatchedPrefillDeclined {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// Does this error chain carry a decline marker? True ⇒ no stream state was
+    /// mutated and the wave may safely be re-run per-stream.
+    pub fn is_decline(err: &anyhow::Error) -> bool {
+        err.chain()
+            .any(|c| c.downcast_ref::<BatchedPrefillDeclined>().is_some())
+    }
+}
+
+impl std::fmt::Display for BatchedPrefillDeclined {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "batched prefill declined before any stream was mutated: {} \
+             (caller must re-run this wave per-stream)",
+            self.reason
+        )
+    }
+}
+
+impl std::error::Error for BatchedPrefillDeclined {}
+
 /// Per-stream input slice for batched prefill.
 ///
 /// One of these per concurrent prefilling stream — `prefill_batch_chunk` and

--- a/crates/spark-model/src/traits/model.rs
+++ b/crates/spark-model/src/traits/model.rs
@@ -205,6 +205,33 @@ pub trait Model: Send + Sync {
         })
     }
 
+    /// Where this model would split the FINAL prefill chunk of `tokens` to
+    /// land an SSM tail checkpoint, if it would split it at all.
+    ///
+    /// `TransformerModel::prefill_chunk_dispatch` splits the last chunk once,
+    /// one KV block below the last block boundary under the prompt length, so
+    /// the snapshot it saves there is `<=` whatever a later turn's
+    /// block-floored prefix match lands on. The split is UNCONDITIONAL on
+    /// hybrid-SSM models with the prefix cache active, because making the
+    /// forward's shape depend on radix contents made cold and warm answers
+    /// differ at temperature 0 (BF16 accumulation is not associative).
+    ///
+    /// The scheduler needs the same cut to keep that invariant when it batches
+    /// fresh prompts: a wave member handed `is_last_chunk = true` over the
+    /// whole prompt would take a one-pass shape inside the batched path (which
+    /// does not split), while the per-stream path takes the two-pass shape.
+    /// Asking the model where it would cut lets the scheduler pre-split, so
+    /// batched and per-stream see identical per-sequence geometry — and the
+    /// short tails of a co-arriving burst share a `chunk_start` and batch into
+    /// ONE forward instead of N standalone 25-token passes (#927: 11.7% of
+    /// prefill GPU time for 2.1% of the tokens).
+    ///
+    /// Returns `None` when the model would not split (no SSM layers, no prefix
+    /// cache, prompt too short, vision pads, `ATLAS_NO_TAIL_SPLIT=1`).
+    fn prefill_tail_cut(&self, _tokens: &[u32]) -> Option<usize> {
+        None
+    }
+
     /// Process N concurrent prefill chunks in one forward pass (same weight
     /// load amortised across N streams). The default implementation falls
     /// back to a per-stream loop calling `prefill_chunk` — implementors that

--- a/crates/spark-server/src/anthropic/tests/ir_carry.rs
+++ b/crates/spark-server/src/anthropic/tests/ir_carry.rs
@@ -349,6 +349,7 @@ fn choice() -> crate::ir::Choice {
         tool_calls: Vec::new(),
         refusal: None,
         finish_reason: crate::ir::FinishReason::Stop,
+        stop_reason: None,
         matched_stop: None,
         logprobs: None,
     }

--- a/crates/spark-server/src/anthropic/tests/translator_stream.rs
+++ b/crates/spark-server/src/anthropic/tests/translator_stream.rs
@@ -47,6 +47,7 @@ fn text_stream_framing() {
             reason: FinishReason::Stop,
             usage: usage(3, 1),
             token_ids: Vec::new(),
+            stop_reason: None,
         },
     ]);
     assert_eq!(
@@ -91,6 +92,7 @@ fn thinking_then_text_framing() {
             reason: FinishReason::Stop,
             usage: usage(0, 0),
             token_ids: Vec::new(),
+            stop_reason: None,
         },
     ]);
     assert_eq!(
@@ -131,6 +133,7 @@ fn tool_call_stream_framing() {
             reason: FinishReason::ToolCalls,
             usage: usage(0, 0),
             token_ids: Vec::new(),
+            stop_reason: None,
         },
     ]);
     assert_eq!(
@@ -182,6 +185,7 @@ fn multi_tool_calls_close_and_reopen_blocks() {
             reason: FinishReason::ToolCalls,
             usage: usage(0, 2),
             token_ids: Vec::new(),
+            stop_reason: None,
         },
     ]);
     assert_eq!(

--- a/crates/spark-server/src/api/chat_blocking_choice.rs
+++ b/crates/spark-server/src/api/chat_blocking_choice.rs
@@ -32,7 +32,6 @@ pub(super) fn build_choice_message(
     cwd_hint: Option<&str>,
     choice_idx: usize,
 ) -> ir::Choice {
-    let _ = response; // currently only used for finish_reason.clone() below
     // Neutral locals — the wire annotations (URL citations) are derived
     // at encode time by the surfaces that emit them.
     let mut reasoning_content = reasoning_content_i;
@@ -179,6 +178,20 @@ pub(super) fn build_choice_message(
         tool_calls,
         refusal: msg_refusal,
         finish_reason: ir::FinishReason::from(finish_reason_i.as_str()),
+        // ── `stop_reason` extension field (#927 / #1000 / #1002) ─────
+        // The guard NAME, beside the wire `finish_reason` that flattens
+        // every non-timeout guard to "length"
+        // (`scheduler::lifecycle::guard_stop_wire_reason` carries the
+        // measured rationale for that, and it does not change here).
+        // Skipped entirely when `None`, so a natural stop serialises
+        // byte-identically to before.
+        //
+        // Round 13 cell V was measured on THIS surface: the 16-way probe
+        // ran `stream=false` and 6/16 responses came back at 49 tokens,
+        // cut by the content-loop watchdog and every one labelled
+        // `finish_reason: "length"` on a request that asked for 256. A
+        // blocking client had nothing else to read.
+        stop_reason: response.guard_stop,
         matched_stop: None, // caller fills
         logprobs: None,     // caller fills
     }

--- a/crates/spark-server/src/api/chat_stream/handle_done.rs
+++ b/crates/spark-server/src/api/chat_stream/handle_done.rs
@@ -217,6 +217,34 @@ pub(super) fn handle_done(
         reason: crate::ir::FinishReason::from(fr),
         usage,
         token_ids: state.take_ids_if(ctx.req_return_token_ids),
+        // ── `stop_reason` extension field (#927 / #1000 / #1002) ─────
+        // The follow-up `guard_stop_wire_reason` named: the wire
+        // `finish_reason` above stays exactly what it was, and WHICH
+        // guard fired rides a separate, optional key.
+        //
+        // Round-13 cell V (`--prefill-varlen-batch`) is the receipt: 6
+        // of 16 responses were truncated at 49 tokens by the
+        // content-loop / fuzzy / SimHash degeneration watchdogs, and
+        // all 6 reported `finish_reason: "length"`. That value is not
+        // wrong and must not move — relabelling guard cuts to `"stop"`
+        // measurably cost 2/10 then 6/10 episodes of the agentic gate,
+        // and a fifth enum value hard-fails strictly typed clients. But
+        // "length" alone is also not enough: a client deciding whether
+        // to raise `max_tokens` and retry, or to reroll because the
+        // model degenerated, cannot read that decision off it.
+        //
+        // `state.guard_stop` is already the merged view of BOTH guard
+        // families — the scheduler's `ActiveSeq::guard_stop` arrives on
+        // `StreamEvent::Done` and is folded in with `.or()` at
+        // `chat_stream::mod`, and the stream-side watchdogs in
+        // `handle_token` write the same field. So this is the one place
+        // that knows the guard's name at the terminal delta, and it is
+        // the same value the `--dump` body reports below; the two
+        // cannot drift.
+        //
+        // `None` whenever no guard fired, which serde skips — an
+        // ordinary stop/length response is byte-identical to today.
+        stop_reason: state.guard_stop,
     });
 
     // Metrics. (REQUESTS_ACTIVE is released by the ActiveRequestGuard in

--- a/crates/spark-server/src/api/chat_stream/mod.rs
+++ b/crates/spark-server/src/api/chat_stream/mod.rs
@@ -26,6 +26,8 @@ mod handle_done;
 mod handle_error;
 mod handle_token;
 mod state;
+#[cfg(test)]
+mod stop_reason_tests;
 mod strip;
 mod token_ids;
 mod tool_handlers;

--- a/crates/spark-server/src/api/chat_stream/stop_reason_tests.rs
+++ b/crates/spark-server/src/api/chat_stream/stop_reason_tests.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! THE invariant behind the `stop_reason` extension field:
+//!
+//! **The terminal delta must carry the guard name, and carrying it must
+//! not tempt anyone into moving `finish_reason`.**
+//!
+//! #927 / #1000 / #1002. Round-13 cell V (`--prefill-varlen-batch`)
+//! produced 6 of 16 responses truncated at 49 tokens by the content-loop
+//! / fuzzy / SimHash degeneration watchdogs, and every one of them
+//! reported `finish_reason: "length"` on the OpenAI-compatible wire. The
+//! client could not tell a quality cut from a budget stop — it is the
+//! same bytes either way, and the two want opposite recoveries (raise
+//! `max_tokens` and continue, vs. reroll the turn).
+//!
+//! The fix `guard_stop_wire_reason` named was an extension FIELD, not a
+//! new `finish_reason` value, and both halves of that sentence are
+//! load-bearing:
+//!   * the field must actually be populated — `state.guard_stop` is
+//!     already computed at the terminal-delta site (it is the same value
+//!     the `--dump` body reports), so the only way this breaks is a
+//!     refactor quietly dropping it on the way out;
+//!   * `finish_reason` must NOT move. Relabelling guard cuts to `"stop"`
+//!     measurably cost 2/10 then 6/10 episodes of the agentic gate, and
+//!     minting a fifth enum value hard-fails strictly typed clients
+//!     (Rust `async-openai` fails deserialization outright; pydantic-ai
+//!     raised on OpenRouter's non-standard `"error"`).
+//!
+//! Behavioural coverage of the serialized shape lives with the encoder
+//! (`openai::encode_stream::tests` for the chunk, `openai::tests::
+//! chat_wire` for the blocking body). What those cannot see is whether
+//! the PRODUCER still hands the encoder a real value, because reaching
+//! `handle_done` behaviourally needs a whole `StreamCtx` and a live
+//! scheduler channel. That property is structural, so this test is too —
+//! same reasoning, and same in-tree precedent (`cancel_guard_tests`), as
+//! the invariant one directory over.
+
+/// The Done arm, read as source. Kept as a `const` so a rename of the
+/// file is a compile error here rather than a silently vacuous test.
+const HANDLE_DONE: &str = include_str!("handle_done.rs");
+
+/// Slice the source from `needle` for `window` bytes, clamped to a char
+/// boundary. Used to keep each assertion scoped to one statement group
+/// instead of matching anywhere in a 460-line file.
+fn window_after(src: &str, needle: &str, window: usize) -> String {
+    let start = src.find(needle).unwrap_or_else(|| {
+        panic!("anchor vanished from handle_done.rs: {needle:?} — update this test with the code")
+    });
+    let mut end = (start + window).min(src.len());
+    while !src.is_char_boundary(end) {
+        end -= 1;
+    }
+    src[start..end].to_string()
+}
+
+/// The source of one free function, from its signature to the closing
+/// brace in column 0. Exact rather than windowed, so an assertion over
+/// "everything in this function" cannot quietly start reading the next
+/// item's doc comment when the file grows.
+fn fn_body(src: &str, signature: &str) -> String {
+    let start = src.find(signature).unwrap_or_else(|| {
+        panic!(
+            "anchor vanished from handle_done.rs: {signature:?} — update this test with the code"
+        )
+    });
+    let rest = &src[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("no column-0 closing brace after {signature:?}"));
+    rest[..end].to_string()
+}
+
+/// POSITIVE. The terminal `StreamDelta::Finish` names the guard, and it
+/// names it by reading `state.guard_stop` — the MERGED view of both
+/// guard families. The scheduler's `ActiveSeq::guard_stop` arrives on
+/// `StreamEvent::Done` and is folded in with `.or()` in
+/// `chat_stream::mod`; the stream-side watchdogs in `handle_token` write
+/// the same field. Recomputing the name from anything else here would
+/// silently cover only one family — which is exactly the shape of the
+/// bug that made two shipped fixes inert (see the `.or()` note at the
+/// merge site).
+#[test]
+fn terminal_delta_carries_the_merged_guard_name() {
+    let finish = window_after(HANDLE_DONE, "deltas.push(StreamDelta::Finish {", 2_048);
+    assert!(
+        finish.contains("stop_reason: state.guard_stop,"),
+        "the terminal delta must carry `stop_reason: state.guard_stop` — without it the \
+         guard name never reaches the wire and a degeneration cut is indistinguishable \
+         from a budget stop (#927 / #1000 / #1002, round-13 cell V: 6/16 responses cut \
+         at 49 tokens, all reporting bare `finish_reason: \"length\"`).\n\nFinish block:\n{finish}"
+    );
+}
+
+/// SSOT. The delta and the `--dump` body must report the SAME guard, by
+/// reading the same expression. They are ~60 lines apart and describe
+/// one event; if they can drift, a dump captured while chasing a
+/// degeneration will disagree with the wire the client actually saw, and
+/// the receipt stops being evidence.
+#[test]
+fn dump_body_and_wire_field_read_the_same_source() {
+    assert!(
+        HANDLE_DONE.contains("\"guard_stop\": state.guard_stop,"),
+        "the --dump body must keep reading `state.guard_stop`"
+    );
+    assert!(
+        HANDLE_DONE.contains("stop_reason: state.guard_stop,"),
+        "the wire field must read the same expression the dump does"
+    );
+}
+
+/// NEGATIVE, and the point of the whole design. Adding a place to say
+/// WHICH guard fired is exactly when someone reaches for a nicer
+/// `finish_reason` — "we can report `stop` now, the detail is in
+/// `stop_reason`". That trade was already measured and lost: the
+/// agentic gate fell to 2/10, then 6/10. The guard rung must still
+/// resolve to `"length"`.
+#[test]
+fn guard_rung_still_resolves_to_length() {
+    let rung = window_after(
+        HANDLE_DONE,
+        "} else if stream_guard_stop.is_some() {",
+        1_024,
+    );
+    let body = rung
+        .split_once("} else {")
+        .map(|(before, _)| before.to_string())
+        .unwrap_or(rung);
+    assert!(
+        body.contains("\"length\""),
+        "the stream-guard rung must still resolve to \"length\" — a degeneration cut is a \
+         truncation, and every client keys truncation recovery on it (openai-python raises \
+         LengthFinishReasonError, Instructor raises IncompleteOutputException, aider's \
+         continuation fires). `stop_reason` is a companion to that value, never a licence \
+         to change it.\n\nRung:\n{body}"
+    );
+    assert!(
+        !body.contains("\"stop\""),
+        "guard cuts must not report \"stop\": measured at 2/10 then 6/10 agentic-gate \
+         episodes.\n\nRung:\n{body}"
+    );
+}
+
+/// NEGATIVE. No fifth `finish_reason` value was minted alongside the new
+/// field. `"timeout"` is the one deliberate, shipped exception
+/// (`ir::FINISH_REASON_TIMEOUT`) and is referenced by its constant, not
+/// spelled as a literal, so any NEW non-standard string shows up here as
+/// a bare quoted word in the resolver.
+///
+/// ★ Scoped to the function BODY, not a byte window. The first version
+/// took 1200 bytes from the signature and ran off the end of the `fn`
+/// into `wire_finish_reason_tests`, where the phrase "length is a lie"
+/// appears in a doc comment — a failure with nothing wrong in the code
+/// it was guarding. A structural test that over-reads its own subject
+/// is worse than no test: it trains people to ignore it.
+#[test]
+fn no_new_nonstandard_finish_reason_value() {
+    let resolver = fn_body(HANDLE_DONE, "fn resolve_wire_finish_reason");
+    const ALLOWED: &[&str] = &["\"length\"", "\"tool_calls\"", "\"stop\""];
+    let mut rest = resolver.as_str();
+    while let Some(open) = rest.find('"') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('"') else { break };
+        let lit = &rest[open..open + close + 2];
+        assert!(
+            ALLOWED.contains(&lit),
+            "unexpected finish_reason literal {lit} in resolve_wire_finish_reason — typed \
+             clients hard-fail on unknown enum VALUES, which is why the guard detail rides \
+             the `stop_reason` FIELD instead (#1002). Carry \"timeout\" via \
+             `ir::FINISH_REASON_TIMEOUT`, as the deadline rung already does."
+        );
+        rest = &rest[open + close + 2..];
+    }
+}

--- a/crates/spark-server/src/api/inference_types.rs
+++ b/crates/spark-server/src/api/inference_types.rs
@@ -333,6 +333,21 @@ pub struct InferenceResponse {
     /// i+1. Empty unless requested. The handler prepends the null entry
     /// for the first prompt token (no preceding context).
     pub prompt_logprobs: Vec<TokenLogprobs>,
+    /// The server-side guard that ended this response, if any
+    /// (`ActiveSeq::guard_stop` — e.g. `"fuzzy_repetition"`). The blocking
+    /// twin of `StreamEvent::Done.guard_stop`, and the source of the
+    /// `stop_reason` extension field on the wire.
+    ///
+    /// `finish_reason` flattens every non-timeout guard to `"length"` on
+    /// purpose (`scheduler::lifecycle::guard_stop_wire_reason` carries the
+    /// measured rationale), which left a NON-STREAMING client unable to tell
+    /// a degeneration cut from a budget stop at all. Round 13 cell V is the
+    /// receipt and it was measured on exactly this surface: the 16-way probe
+    /// ran `stream=false` and 6/16 responses came back cut at 49 tokens by
+    /// the content-loop watchdog, every one of them labelled
+    /// `finish_reason: "length"` on a request that asked for 256
+    /// (#927 / #1000 / #1002).
+    pub guard_stop: Option<&'static str>,
 }
 
 /// Events sent during streaming generation.

--- a/crates/spark-server/src/ir/response.rs
+++ b/crates/spark-server/src/ir/response.rs
@@ -38,6 +38,29 @@ pub struct Choice {
     /// Refusal message (safety classifier), when set.
     pub refusal: Option<String>,
     pub finish_reason: FinishReason,
+    /// The server-side degeneration guard that cut this choice, when
+    /// one did (`"content_loop_watchdog"`, `"fuzzy_repetition"`, …);
+    /// `None` for every ordinary stop. Companion to — never a
+    /// replacement for — `finish_reason`: a guard cut keeps reporting
+    /// `"length"` on the OpenAI wire (see [`FINISH_REASON_TIMEOUT`]'s
+    /// note on why no further non-standard enum VALUE may be minted),
+    /// and this carries the detail as an extension FIELD instead.
+    ///
+    /// #927 / #1000 / #1002, round-13 cell V
+    /// (`--prefill-varlen-batch`): 6 of 16 responses were cut at 49
+    /// tokens by the content-loop watchdog while reporting
+    /// `finish_reason: "length"`; the client could not distinguish a
+    /// quality cut from a budget stop.
+    ///
+    /// Both surfaces produce it. Streaming carries
+    /// `ActiveSeq::guard_stop` on the Done frame
+    /// (`StreamDelta::Finish::stop_reason`); blocking carries the same
+    /// value on `api::InferenceResponse::guard_stop`, set by
+    /// `scheduler::lifecycle::finish_sequence` and read by
+    /// `api::chat_blocking_choice`. The blocking surface is the one the
+    /// round-13 probe actually ran (`stream=false`), so it is not
+    /// optional.
+    pub stop_reason: Option<&'static str>,
     /// The client stop sequence that terminated generation, when one
     /// did. Feeds Anthropic's `stop_sequence` field.
     pub matched_stop: Option<String>,
@@ -100,8 +123,13 @@ pub struct Usage {
 /// raised on OpenRouter's non-standard "error"). "timeout" is kept as a
 /// deliberate, shipped exception because silent truncation is worse; do
 /// NOT add further non-standard values — server-side guard cuts map to
-/// "stop" and carry their detail in the `guard_stop` side-channel (see
-/// `scheduler::lifecycle::guard_stop_wire_reason`).
+/// "length" and carry their detail in the `stop_reason` extension FIELD
+/// (see `scheduler::lifecycle::guard_stop_wire_reason` for the mapping
+/// and [`Choice::stop_reason`] for the field). Unknown FIELDS are
+/// ignored by every SDK; unknown enum VALUES are what hard-fail typed
+/// clients — which is why the detail rides a new key rather than a
+/// fifth `finish_reason` string. vLLM makes the same split with its own
+/// `stop_reason` extension.
 pub const FINISH_REASON_TIMEOUT: &str = "timeout";
 
 /// Why generation stopped. `Other` preserves unknown engine reasons

--- a/crates/spark-server/src/ir/stream.rs
+++ b/crates/spark-server/src/ir/stream.rs
@@ -39,6 +39,24 @@ pub enum StreamDelta {
         reason: super::response::FinishReason,
         usage: super::response::Usage,
         token_ids: Vec<u32>,
+        /// The server-side degeneration guard that cut this response,
+        /// when one did (`"content_loop_watchdog"`,
+        /// `"fuzzy_repetition"`, `"simhash_semantic_loop"`,
+        /// `"token_loop_watchdog"`, …); `None` for every ordinary
+        /// stop. Deliberately SEPARATE from `reason`: the wire
+        /// `finish_reason` for a guard cut stays `"length"` (see
+        /// `scheduler::lifecycle::guard_stop_wire_reason` and
+        /// `api::chat_stream::handle_done::resolve_wire_finish_reason`
+        /// for the measured reason that value must not move), so this
+        /// is the only channel that says WHICH guard fired.
+        ///
+        /// #927 / #1000 / #1002, round-13 cell V
+        /// (`--prefill-varlen-batch`): 6 of 16 responses were cut at 49
+        /// tokens by the content-loop / fuzzy / SimHash watchdogs and
+        /// every one of them reported `finish_reason: "length"` on the
+        /// wire. A client could not tell a quality cut from a budget
+        /// stop — which is exactly the retry decision it needs to make.
+        stop_reason: Option<&'static str>,
     },
     /// Stream-level error payload, sent verbatim as SSE data.
     Error { message: String },

--- a/crates/spark-server/src/main_modules/serve_flags.rs
+++ b/crates/spark-server/src/main_modules/serve_flags.rs
@@ -116,7 +116,7 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
     tracing::info!(
         "kernel flags: ssm_h_dtype={} gdn_fused_norm={} ssm_batched_recurrent={} \
          exact_verify={} ssm_tail_midchunk={} mtp_gate={} ssm_rollback_mode={:?} \
-         prefill_varlen_batch={}",
+         prefill_varlen_batch={} prefill_chunk_zero_batch={}",
         if gdn.h_f16 { "f16" } else { "f32" },
         gdn.fused_norm,
         gdn.batched_recurrent,
@@ -132,6 +132,13 @@ pub(crate) fn publish_kernel_flags(args: &cli::ServeArgs) {
         spark_model::ssm_reserve::ssm_rollback_mode(),
         // RESOLVED, not the raw argument — may come from the environment.
         spark_model::layers::ops::prefill_varlen_enabled(),
+        // The chunk-zero admission decision itself, printed beside the lever
+        // that sets it. Four call sites read this predicate; when they
+        // disagreed, `--prefill-varlen-batch` admitted a wave of fresh prompts
+        // and then refused it mid-forward, failing all sixteen requests at
+        // C=16 with an HTTP 200 and no body (#927 cell E). A boot line that
+        // names the resolved decision is what makes that arguable from a log.
+        spark_model::layers::ops::prefill_batched_chunk_zero_allowed(),
     );
 }
 

--- a/crates/spark-server/src/openai/chat_response.rs
+++ b/crates/spark-server/src/openai/chat_response.rs
@@ -28,6 +28,20 @@ pub struct ChatChoice {
     pub message: ChatMessage,
     pub finish_reason: String,
     pub logprobs: Option<ChoiceLogprobs>,
+    /// WHICH server-side degeneration guard cut this response, when one
+    /// did (`"content_loop_watchdog"`, `"fuzzy_repetition"`, …).
+    /// Skipped when absent, so an ordinary stop/length body is
+    /// byte-identical to what shipped before this field existed.
+    ///
+    /// Blocking twin of [`ChunkChoice::stop_reason`]; the full
+    /// rationale lives there. Short version (#927 / #1000 / #1002):
+    /// round-13 cell V cut 6 of 16 responses at 49 tokens via the
+    /// content-loop watchdog and reported `finish_reason: "length"` for
+    /// all of them. The wire `finish_reason` is a measured contract and
+    /// does not move; the detail rides an extension FIELD, which every
+    /// SDK ignores when it does not know it (cf. vLLM's `stop_reason`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<&'static str>,
 }
 
 /// Token usage and performance timing.
@@ -183,6 +197,7 @@ impl ChatCompletionResponse {
                 },
                 finish_reason: finish_reason.to_string(),
                 logprobs: None,
+                stop_reason: None,
             }],
             usage,
             service_tier: None,
@@ -215,6 +230,7 @@ impl ChatCompletionResponse {
                 },
                 finish_reason: "tool_calls".to_string(),
                 logprobs: None,
+                stop_reason: None,
             }],
             usage,
             service_tier: None,

--- a/crates/spark-server/src/openai/encode.rs
+++ b/crates/spark-server/src/openai/encode.rs
@@ -77,6 +77,11 @@ pub(crate) fn encode_chat_response(
                 },
                 finish_reason: c.finish_reason.as_wire().to_string(),
                 logprobs: c.logprobs.map(encode_logprobs),
+                // Carried through verbatim: the IR decides whether a
+                // guard cut this choice, the wire only reports it.
+                // `None` (the ordinary case) is skipped by serde, so
+                // this body is byte-identical to the pre-#1002 shape.
+                stop_reason: c.stop_reason,
             }
         })
         .collect();

--- a/crates/spark-server/src/openai/encode_stream.rs
+++ b/crates/spark-server/src/openai/encode_stream.rs
@@ -83,6 +83,7 @@ fn delta_to_payloads(d: &StreamDelta, model: &str, id: &str, include_usage: bool
             reason,
             usage,
             token_ids,
+            stop_reason,
         } => {
             let wire_usage = wire_usage(usage);
             if include_usage {
@@ -91,17 +92,24 @@ fn delta_to_payloads(d: &StreamDelta, model: &str, id: &str, include_usage: bool
                 // final `finish_reason` chunk (usage omitted). Residual
                 // token ids ride the final chunk, keeping
                 // Σ token_ids == completion_tokens.
+                //
+                // `stop_reason` rides the FINISH chunk, not the
+                // usage-only one: it is a property of how the response
+                // ended, and the usage chunk carries `choices: []` —
+                // there is no choice object on it to hang it from.
                 vec![
                     chunk_json(ChatCompletionChunk::usage_only_chunk(model, id, wire_usage)),
                     chunk_json(
                         ChatCompletionChunk::final_chunk_no_usage(model, id, reason.as_wire())
-                            .with_token_ids(token_ids.clone()),
+                            .with_token_ids(token_ids.clone())
+                            .with_stop_reason(*stop_reason),
                     ),
                 ]
             } else {
                 vec![chunk_json(
                     ChatCompletionChunk::done_chunk(model, id, reason.as_wire(), wire_usage)
-                        .with_token_ids(token_ids.clone()),
+                        .with_token_ids(token_ids.clone())
+                        .with_stop_reason(*stop_reason),
                 )]
             }
         }
@@ -292,6 +300,7 @@ mod tests {
             reason: FinishReason::Stop,
             usage,
             token_ids: vec![7],
+            stop_reason: None,
         };
 
         // include_usage=true: usage-only chunk (`choices:[]`) FIRST,
@@ -355,6 +364,106 @@ mod tests {
         assert!(p[0].contains("\"usage\":{"), "payload: {}", p[0]);
         assert!(p[0].contains("\"total_tokens\":15"), "payload: {}", p[0]);
         assert!(p[0].contains("\"token_ids\":[7]"), "payload: {}", p[0]);
+    }
+
+    /// A degeneration guard cut: `finish_reason` stays `"length"` and
+    /// the guard's NAME rides the new `stop_reason` key beside it.
+    ///
+    /// #927 / #1000 / #1002. Round-13 cell V (`--prefill-varlen-batch`)
+    /// produced 6 of 16 responses truncated at 49 tokens by the
+    /// content-loop / fuzzy / SimHash watchdogs, every one of them
+    /// reporting `finish_reason: "length"` — indistinguishable on the
+    /// wire from a response that simply hit `max_tokens`. This asserts
+    /// the pairing, not a replacement: the `"length"` value is a
+    /// measured contract (relabelling guard cuts to `"stop"` cost 2/10
+    /// then 6/10 episodes of the agentic gate) and must still be there.
+    #[test]
+    fn guard_cut_stamps_stop_reason_beside_length() {
+        let d = StreamDelta::Finish {
+            reason: FinishReason::Length,
+            usage: crate::ir::Usage::default(),
+            token_ids: Vec::new(),
+            stop_reason: Some("content_loop_watchdog"),
+        };
+
+        // include_usage=false: the single done chunk carries both.
+        let p = delta_to_payloads(&d, "m", "id-1", false);
+        assert_eq!(p.len(), 1);
+        let choice = &norm(&p[0])["choices"][0];
+        assert_eq!(choice["finish_reason"], "length", "payload: {}", p[0]);
+        assert_eq!(
+            choice["stop_reason"], "content_loop_watchdog",
+            "payload: {}",
+            p[0]
+        );
+
+        // include_usage=true: the guard name rides the FINISH chunk,
+        // never the usage-only chunk — that one has `choices: []` and
+        // so has no choice object to hang it from.
+        let p = delta_to_payloads(&d, "m", "id-1", true);
+        assert_eq!(p.len(), 2);
+        assert!(
+            !p[0].contains("stop_reason"),
+            "usage-only chunk must not carry it: {}",
+            p[0]
+        );
+        let choice = &norm(&p[1])["choices"][0];
+        assert_eq!(choice["finish_reason"], "length", "payload: {}", p[1]);
+        assert_eq!(
+            choice["stop_reason"], "content_loop_watchdog",
+            "payload: {}",
+            p[1]
+        );
+
+        // Every guard name the two families can produce rides through
+        // verbatim — the encoder does not whitelist, classify, or
+        // rewrite it.
+        for guard in [
+            "fuzzy_repetition",
+            "simhash_semantic_loop",
+            "token_loop_watchdog",
+            "content_loop_watchdog",
+        ] {
+            let d = StreamDelta::Finish {
+                reason: FinishReason::Length,
+                usage: crate::ir::Usage::default(),
+                token_ids: Vec::new(),
+                stop_reason: Some(guard),
+            };
+            let p = delta_to_payloads(&d, "m", "id-1", false);
+            assert_eq!(norm(&p[0])["choices"][0]["stop_reason"], guard);
+        }
+    }
+
+    /// NEGATIVE, and the hard requirement of the change: an ordinary
+    /// stop must be BYTE-IDENTICAL to what shipped before the field
+    /// existed. `skip_serializing_if` means the key is absent, not
+    /// `null` — asserted on the parsed value, because a substring check
+    /// would also pass for `"stop_reason":null`.
+    #[test]
+    fn natural_stop_omits_stop_reason_key() {
+        let d = StreamDelta::Finish {
+            reason: FinishReason::Stop,
+            usage: crate::ir::Usage::default(),
+            token_ids: Vec::new(),
+            stop_reason: None,
+        };
+        for include_usage in [false, true] {
+            for payload in delta_to_payloads(&d, "m", "id-1", include_usage) {
+                let v = norm(&payload);
+                assert!(
+                    !payload.contains("stop_reason"),
+                    "wire moved for a normal stop: {payload}"
+                );
+                for choice in v["choices"].as_array().expect("choices array") {
+                    assert!(
+                        choice.get("stop_reason").is_none(),
+                        "key must be ABSENT, not null: {payload}"
+                    );
+                    assert_eq!(choice["finish_reason"], "stop");
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/spark-server/src/openai/stream_chunk.rs
+++ b/crates/spark-server/src/openai/stream_chunk.rs
@@ -36,6 +36,29 @@ pub struct ChunkChoice {
     /// format is byte-identical for clients that did not opt in.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub token_ids: Vec<u32>,
+    /// WHICH server-side degeneration guard cut this response, when one
+    /// did — `"content_loop_watchdog"`, `"fuzzy_repetition"`,
+    /// `"simhash_semantic_loop"`, `"token_loop_watchdog"`, … Set only on
+    /// the terminal chunk (the one carrying `finish_reason`), and only
+    /// when a guard actually fired; skipped otherwise, so a normal
+    /// stop/length chunk is byte-identical to what shipped before.
+    ///
+    /// WHY A FIELD AND NOT A FINISH REASON (#927 / #1000 / #1002).
+    /// Round-13 cell V (`--prefill-varlen-batch`) produced 6 of 16
+    /// responses truncated at 49 tokens by the content-loop / fuzzy /
+    /// SimHash watchdogs, and every one of them reported
+    /// `finish_reason: "length"` on the wire — a client could not tell
+    /// a quality cut from a budget stop. The wire `finish_reason` still
+    /// must not move: relabelling guard cuts to `"stop"` measurably
+    /// cost 2/10 then 6/10 episodes of the agentic gate
+    /// (`scheduler::lifecycle::guard_stop_wire_reason`), and minting a
+    /// fifth enum value hard-fails strictly typed clients (Rust
+    /// `async-openai` fails deserialization outright; pydantic-ai
+    /// raised on OpenRouter's non-standard `"error"`). Unknown FIELDS,
+    /// by contrast, are ignored by every SDK — the same seam vLLM uses
+    /// for its own `stop_reason`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<&'static str>,
 }
 
 #[derive(Debug, Serialize)]
@@ -86,6 +109,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -112,6 +136,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -137,6 +162,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -177,6 +203,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -213,6 +240,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -238,6 +266,7 @@ impl ChatCompletionChunk {
                 finish_reason: Some(finish_reason.to_string()),
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: Some(usage),
         }
@@ -284,6 +313,7 @@ impl ChatCompletionChunk {
                 finish_reason: None,
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -311,6 +341,7 @@ impl ChatCompletionChunk {
                 finish_reason: Some(finish_reason.to_string()),
                 logprobs: None,
                 token_ids: Vec::new(),
+                stop_reason: None,
             }],
             usage: None,
         }
@@ -326,6 +357,26 @@ impl ChatCompletionChunk {
             && let Some(choice) = self.choices.first_mut()
         {
             choice.token_ids = ids;
+        }
+        self
+    }
+
+    /// Stamp the guard name onto this chunk's first choice. Same
+    /// no-op-when-absent shape as [`Self::with_token_ids`]: `None`
+    /// leaves the chunk byte-identical to what a client received
+    /// before the field existed, so no snapshot of an ordinary
+    /// stop/length response moves.
+    ///
+    /// Only the terminal chunk is stamped (`encode_stream` calls this
+    /// on the `Finish` arm alone) — a guard cut is one event, not a
+    /// property of every delta that preceded it. See
+    /// [`ChunkChoice::stop_reason`] for the #927 / #1000 / #1002
+    /// receipt behind the field.
+    pub(crate) fn with_stop_reason(mut self, guard: Option<&'static str>) -> Self {
+        if guard.is_some()
+            && let Some(choice) = self.choices.first_mut()
+        {
+            choice.stop_reason = guard;
         }
         self
     }

--- a/crates/spark-server/src/openai/tests/chat_wire.rs
+++ b/crates/spark-server/src/openai/tests/chat_wire.rs
@@ -148,3 +148,70 @@ fn tool_call_response_carries_reasoning_content() {
         "reasoning_content missing: {json}"
     );
 }
+
+// ── `stop_reason` extension field (#927 / #1000 / #1002) ────────────
+
+/// Blocking twin of the streaming assertions in
+/// `encode_stream::tests`: the non-streaming `chat.completion` choice
+/// reports `finish_reason: "length"` AND names the guard that cut it.
+///
+/// Round-13 cell V (`--prefill-varlen-batch`) is the receipt — 6 of 16
+/// responses truncated at 49 tokens by the content-loop watchdog, all
+/// of them reporting bare `"length"`. `finish_reason` is deliberately
+/// unchanged here: the detail is an extension FIELD (unknown fields are
+/// ignored by every SDK; unknown enum VALUES hard-fail typed clients),
+/// which is the seam vLLM uses for its own `stop_reason`.
+#[test]
+fn blocking_choice_carries_stop_reason_beside_length() {
+    let choice = ChatChoice {
+        index: 0,
+        message: ChatMessage {
+            role: "assistant".to_string(),
+            reasoning_content: None,
+            annotations: None,
+            refusal: None,
+            content: Some("the the the".to_string()),
+            tool_calls: None,
+        },
+        finish_reason: "length".to_string(),
+        logprobs: None,
+        stop_reason: Some("content_loop_watchdog"),
+    };
+    let json = serde_json::to_value(&choice).expect("serializable");
+    assert_eq!(json["finish_reason"], "length");
+    assert_eq!(json["stop_reason"], "content_loop_watchdog");
+}
+
+/// NEGATIVE: a natural EOS stop must not gain a key. `to_value` rather
+/// than a substring check, so `"stop_reason":null` cannot sneak past —
+/// absent and null are different bytes to a client that branches on
+/// `"stop_reason" in choice`.
+#[test]
+fn blocking_choice_omits_stop_reason_on_natural_stop() {
+    let choice = ChatChoice {
+        index: 0,
+        message: ChatMessage {
+            role: "assistant".to_string(),
+            reasoning_content: None,
+            annotations: None,
+            refusal: None,
+            content: Some("done.".to_string()),
+            tool_calls: None,
+        },
+        finish_reason: "stop".to_string(),
+        logprobs: None,
+        stop_reason: None,
+    };
+    let json = serde_json::to_value(&choice).expect("serializable");
+    assert_eq!(json["finish_reason"], "stop");
+    assert!(
+        json.get("stop_reason").is_none(),
+        "key must be ABSENT, not null: {json}"
+    );
+    assert!(
+        !serde_json::to_string(&choice)
+            .unwrap()
+            .contains("stop_reason"),
+        "wire moved for a normal stop"
+    );
+}

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -53,8 +53,16 @@ use super::*;
 /// documented risk (see `ir::FINISH_REASON_TIMEOUT`). The guard's NAME
 /// reaches diagnostics via `StreamEvent::Done.guard_stop` and the --dump
 /// body; the right home for it on the wire is an extension FIELD (unknown
-/// fields are ignored by every SDK, cf. vLLM's `stop_reason`), which is
-/// follow-up work, not a reason to keep lying in the enum.
+/// fields are ignored by every SDK, cf. vLLM's `stop_reason`), not the enum.
+///
+/// ★ That extension field now SHIPS (#1002): `stop_reason` rides the
+/// terminal streaming chunk and the blocking choice beside this
+/// `finish_reason`, skipped entirely when no guard fired, so a normal
+/// response serialises byte-identically to before. The mapping above is
+/// unchanged — round 13 cell V is why it needed a companion at all: 6/16
+/// probe responses cut at 49 tokens by the content-loop watchdog, every one
+/// reporting `"length"` on a request that asked for 256, with nothing on the
+/// wire to say a guard had fired.
 fn guard_stop_wire_reason(guard: &'static str) -> &'static str {
     match guard {
         // Defensive: the deadline guard is intercepted before the
@@ -191,6 +199,11 @@ pub fn finish_sequence(model: &dyn Model, a: &mut ActiveSeq, max_seq_len: usize)
                         reasoning_tokens: a.thinking_tokens,
                         cached_prompt_tokens: a.cached_prompt_tokens,
                         accepted_prediction_tokens: a.mtp_acct.accepted_total() as usize,
+                        // The guard NAME, beside the flattened wire reason —
+                        // the blocking twin of the streaming Done frame's
+                        // `guard_stop`. Reaches the client as the
+                        // `stop_reason` extension field (#1002).
+                        guard_stop: a.guard_stop,
                         prompt_logprobs: std::mem::take(&mut a.seq.prompt_logprobs)
                             .into_iter()
                             .map(|p| crate::api::TokenLogprobs {

--- a/crates/spark-server/src/scheduler/lifecycle.rs
+++ b/crates/spark-server/src/scheduler/lifecycle.rs
@@ -294,7 +294,23 @@ pub fn swap_out_sequence(
     let mut a = active.swap_remove(victim_idx);
 
     // Compact the swapped-in sequence (same logic as retire path).
-    if victim_idx < active.len() && active[victim_idx].seq.slot_idx != victim_idx {
+    //
+    // `a.seq.slot_idx == victim_idx` is the ownership-TRANSFER precondition,
+    // and it is load-bearing (#1002). `compact_sequence` calls
+    // `ssm_pool.claim_specific(target)` and IGNORES a false return, so
+    // migrating onto a slot the victim does not own silently double-owns it —
+    // and with `--prefill-varlen-batch` the active vec is routinely
+    // non-contiguous because the streams parked in `prefilling` hold the low
+    // slots. Round 13 cell V is the receipt: a survivor migrated onto a
+    // prefilling stream's slot, the two shared one GDN h_state, and the
+    // later double release poisoned the pool free list for the rest of the
+    // serve. When the premise does not hold, skip the compaction (and the
+    // detach that pairs with it): non-contiguous slots cost the batched-GDN
+    // fast path, shared recurrent state costs correctness.
+    if victim_idx < active.len()
+        && active[victim_idx].seq.slot_idx != victim_idx
+        && a.seq.slot_idx == victim_idx
+    {
         // NOT `?`. `a` is already OUT of `active` — this function holds the
         // only handle to it — so an early return here is the one owner
         // dropping the request, and the drop is silent twice over: the sink

--- a/crates/spark-server/src/scheduler/lifecycle_tests.rs
+++ b/crates/spark-server/src/scheduler/lifecycle_tests.rs
@@ -307,6 +307,33 @@ fn call_site_passes_the_real_last_token_and_eos() {
     assert_eq!(finish_and_recv(a, rx).finish_reason, "tool_calls");
 }
 
+/// The BLOCKING producer for the `stop_reason` extension field (#1002).
+///
+/// `finish_reason` flattens every non-timeout guard to `"length"` and that
+/// does not change (`guard_stop_wire_reason` carries the measured reason).
+/// The guard NAME therefore has to travel beside it, and the blocking sink is
+/// where round 13 measured the failure: the 16-way cell-V probe ran
+/// `stream=false` and came back with 6/16 responses cut at 49 tokens by the
+/// content-loop watchdog, every one labelled `"length"` on a request that
+/// asked for 256, with nothing else on the wire to read.
+#[test]
+fn the_blocking_response_carries_the_guard_name_beside_length() {
+    let (a, rx) = test_seq(vec![5, 6, 42], 3, Some("fuzzy_repetition"), 10);
+    let r = finish_and_recv(a, rx);
+    assert_eq!(r.finish_reason, "length", "the wire value must not move");
+    assert_eq!(
+        r.guard_stop,
+        Some("fuzzy_repetition"),
+        "the guard name must reach the blocking response, or the non-streaming \
+         surface cannot tell a quality cut from a budget stop"
+    );
+    // An ordinary stop carries nothing — the field is skipped on the wire.
+    let (a, rx) = test_seq(vec![5, 6, 151645], 3, None, 10);
+    let r = finish_and_recv(a, rx);
+    assert_eq!(r.finish_reason, "stop");
+    assert_eq!(r.guard_stop, None);
+}
+
 #[test]
 fn call_site_passes_the_real_guard() {
     // Timeout is the one guard with a distinct wire reason — proves

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -56,6 +56,8 @@ mod prefill_a_step;
 mod prefill_a_step_params;
 mod prefill_b_step;
 #[cfg(test)]
+mod prefill_fallback_tests;
+#[cfg(test)]
 mod prefill_fifo_tests;
 mod repetition;
 mod rollback;
@@ -74,6 +76,8 @@ mod swap_out_tests;
 mod teardown;
 #[cfg(test)]
 mod test_support;
+#[cfg(test)]
+mod test_support_prefill;
 #[cfg(test)]
 mod think_skip_tests;
 mod types;

--- a/crates/spark-server/src/scheduler/mod.rs
+++ b/crates/spark-server/src/scheduler/mod.rs
@@ -1024,7 +1024,16 @@ pub fn run(
         // on this same iteration. Placed here rather than in a decode step
         // because the MTP/speculative path does not run `process_decode_logits`.
         enforce_request_deadlines(&mut active);
-        retire_finished_sequences(&*model, &mut active, sched.limits.max_seq_len);
+        // Slots owned by streams still in `prefilling` are NOT the active
+        // set's to reuse — Phase 2 compaction must route around them (#1002,
+        // `mod_helpers::slot_targets`).
+        let reserved_slots = prefilling_reserved_slots(&prefilling);
+        retire_finished_sequences(
+            &*model,
+            &mut active,
+            &reserved_slots,
+            sched.limits.max_seq_len,
+        );
         sched.timing.record(mtp_timing::Phase::LoopRetire, t_loop);
 
         // ── Swap-in: resume swapped sequences when blocks free up ──

--- a/crates/spark-server/src/scheduler/mod_helpers.rs
+++ b/crates/spark-server/src/scheduler/mod_helpers.rs
@@ -302,9 +302,18 @@ pub(super) fn enforce_request_deadlines(active: &mut [ActiveSeq]) {
 /// non-contiguous w.r.t. `slot_idx` — pre-allocated slots stay valid
 /// in place across the swap_remove, and the per-slot CUDA graph cache
 /// stays warm because the seq never moved.
+///
+/// `reserved_slots` carries the pool slots owned by sequences that are NOT in
+/// `active` — the streams parked in the scheduler's `prefilling` queue, which
+/// claim their slot at admission and hold it across every chunk. They are
+/// invisible to the survivor set, so Phase 2 has to be TOLD about them or it
+/// migrates a survivor onto a live stream's recurrent state (#1002; the
+/// module-level rationale and the round-13 receipt live in
+/// `mod_helpers::slot_targets`).
 pub(super) fn retire_finished_sequences(
     model: &dyn Model,
     active: &mut Vec<ActiveSeq>,
+    reserved_slots: &[usize],
     max_seq_len: usize,
 ) {
     if model.ep_protocol_v2() {
@@ -346,8 +355,27 @@ pub(super) fn retire_finished_sequences(
     }
 
     // Phase 2: compact survivors back into contiguous slots [0..n).
-    compact_survivors_into_range(model, &mut survivors);
+    compact_survivors_into_range(model, &mut survivors, reserved_slots);
     *active = survivors;
+}
+
+/// Pool slots owned by the streams still in the scheduler's `prefilling`
+/// queue. These are live owners that the active set knows nothing about, so
+/// slot compaction must treat them as untouchable — see
+/// `mod_helpers::slot_targets` for the failure they caused (#1002).
+pub(super) fn prefilling_reserved_slots(prefilling: &[PrefillInProgress]) -> Vec<usize> {
+    // The RAII guard is the authority on ownership (`slot_idx` can be the
+    // `usize::MAX` reuse sentinel, or stale after a migration). Fall back to
+    // `slot_idx` only for a sequence with no guard at all — the host-only /
+    // mock construction — and drop the sentinel.
+    prefilling
+        .iter()
+        .filter_map(|p| match p.seq.ssm_slot_idx() {
+            Some(idx) => Some(idx),
+            None if p.seq.slot_idx != usize::MAX => Some(p.seq.slot_idx),
+            None => None,
+        })
+        .collect()
 }
 
 /// Compact live sequences into contiguous SSM slots `[0..n)` (n = the slice
@@ -365,28 +393,38 @@ pub(super) fn retire_finished_sequences(
 /// slot) must already be released to the pool before this runs, so it is
 /// available as a target. Never call this under `ep_protocol_v2()` — v2
 /// keeps slots pinned in place (see `retire_finished_sequences`).
-pub(super) fn compact_survivors_into_range(model: &dyn Model, survivors: &mut [ActiveSeq]) {
-    let n = survivors.len();
-    let occupied: std::collections::HashSet<usize> =
-        survivors.iter().map(|a| a.seq.slot_idx).collect();
-    let mut free_targets: Vec<usize> = (0..n).filter(|s| !occupied.contains(s)).collect();
-    for a in survivors.iter_mut() {
-        if a.seq.slot_idx >= n {
-            match free_targets.pop() {
-                Some(target) => {
-                    if let Err(e) = model.compact_sequence(&mut a.seq, target) {
-                        tracing::error!("compact_sequence: {e:#}");
-                    }
-                }
-                None => tracing::error!(
-                    "compact_survivors_into_range: no free target for out-of-range \
-                     slot {} (n={n})",
-                    a.seq.slot_idx
-                ),
-            }
+///
+/// `reserved` lists slots owned by sequences OUTSIDE `survivors` (the
+/// `prefilling` queue). A slot on that list is never chosen as a target, and a
+/// survivor with no legal target keeps its own slot rather than colliding —
+/// the #1002 fix; `slot_targets` carries the round-13 receipt.
+pub(super) fn compact_survivors_into_range(
+    model: &dyn Model,
+    survivors: &mut [ActiveSeq],
+    reserved: &[usize],
+) {
+    let occupied: Vec<usize> = survivors.iter().map(|a| a.seq.slot_idx).collect();
+    let plan = slot_targets::plan_slot_compaction(&occupied, reserved);
+    let planned = plan.len();
+    for (i, target) in plan {
+        if let Err(e) = model.compact_sequence(&mut survivors[i].seq, target) {
+            tracing::error!("compact_sequence: {e:#}");
         }
+    }
+    // Not an error — a stalled migration is the SAFE outcome (see
+    // `slot_targets`) — but it costs the batched-GDN fast path, so say so once
+    // per tick at debug when it bites.
+    let out_of_range = occupied.iter().filter(|&&s| s >= occupied.len()).count();
+    let stalled = out_of_range.saturating_sub(planned);
+    if stalled > 0 {
+        tracing::debug!(
+            "compact_survivors_into_range: {stalled} survivor(s) kept an out-of-range slot \
+             (n={}, reserved={reserved:?}) — slots stay non-contiguous this tick",
+            occupied.len(),
+        );
     }
 }
 
 mod send;
+mod slot_targets;
 pub use send::*;

--- a/crates/spark-server/src/scheduler/mod_helpers/slot_targets.rs
+++ b/crates/spark-server/src/scheduler/mod_helpers/slot_targets.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pure target selection for SSM pool-slot compaction. Split from
+//! `mod_helpers.rs` (500-LoC cap) so the rule is unit-testable without a
+//! `Model`, a GPU or an `ActiveSeq`.
+//!
+//! ## Why this is a separate, tested rule (#1002, H100 round 13)
+//!
+//! `compact_survivors_into_range` packs the DECODING sequences into
+//! contiguous pool slots `[0..n)` so the batched GDN recurrence keeps its
+//! "slots are consecutive in slice order" precondition. It used to derive
+//! the free targets from the survivors alone:
+//!
+//! ```text
+//! free_targets = (0..n) \ { a.seq.slot_idx : a in survivors }
+//! ```
+//!
+//! That set is only correct while the decoding sequences are the ONLY
+//! owners of pool slots. They are not. A sequence claims its slot at
+//! admission (`alloc_sequence_state`), so every stream sitting in the
+//! scheduler's `prefilling` queue — mid chunked prefill, not yet decoding —
+//! owns one too, and those slots are invisible to the formula above.
+//!
+//! Round 13 cell V made that live. `--prefill-varlen-batch` makes
+//! `phase_start_prefills` DEFER chunk 0 into `prefilling` so co-arriving
+//! prompts can batch (`want_varlen_defer`), which is the first configuration
+//! that parks fourteen slot-owning streams there while two decode. The
+//! per-tick compaction then read `n = 2`, saw the survivor at slot 7 as
+//! out-of-range, and migrated it onto slot 1 — owned by a prefilling stream.
+//! The serve log caught the migration in the act, 30 ms apart:
+//!
+//! ```text
+//! Captured CUDA graph for batch size 2 (n=2, slots=Some([0, 7]))
+//! Captured CUDA graph for batch size 2 (n=2, slots=Some([0, 1]))
+//! ```
+//!
+//! Two live sequences then shared one GDN `h_state`/`conv_state`, which is
+//! cross-stream state bleed: cell V logged 24 content-loop-watchdog fires, 2
+//! fuzzy-repetition stops and 5 SimHash stops against ZERO on cells A, D, T1
+//! and T2, and 6/16 probe responses were cut at 49 tokens. Worse, the
+//! collision outlives the burst — both owners later release the same index,
+//! double-pushing it onto the pool free list, so `claim_slot` hands it to two
+//! fresh sequences for the rest of the serve. That is why the 16-way probe
+//! four minutes later still decoded with `slots=[0, 0, 0, 1, 1, 2, 2, 3, ...]`
+//! even though varlen never engaged for it.
+//!
+//! The rule therefore takes the slots held by NON-survivors as an explicit
+//! input, and a survivor with no legal target simply stays where it is:
+//! non-contiguous slots cost the batched-recurrence fast path (the model logs
+//! `SSM batched recurrent DECLINED`), which is a measured ~28% on one block —
+//! a price worth paying against shared recurrent state.
+
+/// Plan `(survivor index, target slot)` migrations that pack survivors into
+/// contiguous pool slots `[0..n)`.
+///
+/// * `occupied[i]` — survivor `i`'s current pool slot, in survivor order.
+/// * `reserved` — pool slots owned by sequences that are NOT survivors
+///   (streams in the scheduler's `prefilling` queue). NEVER a target.
+///
+/// Only survivors whose slot is `>= n` move, and only onto a slot in
+/// `[0..n)` that no survivor occupies and no non-survivor reserves. When no
+/// such slot exists the survivor is omitted from the plan and keeps its own.
+/// Every planned target is distinct, and no target is ever a slot that is
+/// still owned by anything.
+pub(crate) fn plan_slot_compaction(occupied: &[usize], reserved: &[usize]) -> Vec<(usize, usize)> {
+    let n = occupied.len();
+    // Ascending, then popped from the back — byte-identical target choice to
+    // the pre-#1002 `(0..n).filter(..).collect::<Vec<_>>().pop()` for the case
+    // that formula already got right (nothing reserved).
+    let mut free_targets: Vec<usize> = (0..n)
+        .filter(|s| !occupied.contains(s) && !reserved.contains(s))
+        .collect();
+    let mut plan = Vec::new();
+    for (i, &slot) in occupied.iter().enumerate() {
+        if slot < n {
+            continue;
+        }
+        match free_targets.pop() {
+            Some(target) => plan.push((i, target)),
+            // Not an error: with slot-owning streams parked in `prefilling`
+            // there genuinely may be no free slot below `n`. Staying put is
+            // the correct outcome — see the module doc.
+            None => break,
+        }
+    }
+    plan
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_slot_compaction;
+
+    #[test]
+    fn packs_out_of_range_survivors_when_nothing_is_reserved() {
+        // The pre-existing behaviour this must not change: two survivors at
+        // slots 0 and 7, nothing else owns a slot, so 7 migrates to 1.
+        assert_eq!(plan_slot_compaction(&[0, 7], &[]), vec![(1, 1)]);
+    }
+
+    #[test]
+    fn in_range_survivors_do_not_move() {
+        assert_eq!(plan_slot_compaction(&[0, 1, 2], &[]), Vec::new());
+    }
+
+    #[test]
+    fn a_reserved_slot_is_never_a_target() {
+        // THE round-13 cell-V shape (#1002). Two streams finished prefill and
+        // decode at slots 0 and 7; the other fourteen are still in
+        // `prefilling` under `--prefill-varlen-batch` and own slots 1..=6 and
+        // 8..=15. `n == 2`, so the only in-range candidate is slot 1 — and a
+        // prefilling stream owns it. The survivor must stay at slot 7.
+        //
+        // Before this rule the plan was `[(1, 1)]`, and the two sequences at
+        // slot 1 shared one GDN h_state: 24 content-loop-watchdog fires, 6/16
+        // responses cut at 49 tokens, then a double-release that poisoned the
+        // pool free list for the rest of the serve.
+        let reserved: Vec<usize> = (1..=6).chain(8..=15).collect();
+        assert_eq!(plan_slot_compaction(&[0, 7], &reserved), Vec::new());
+    }
+
+    #[test]
+    fn packs_into_whatever_is_genuinely_free() {
+        // Three survivors at 5, 1, 9; slot 0 reserved by a prefilling stream,
+        // slot 2 free. Only ONE target exists, so exactly one survivor moves
+        // and the other keeps its slot rather than colliding.
+        let plan = plan_slot_compaction(&[5, 1, 9], &[0]);
+        assert_eq!(plan, vec![(0, 2)]);
+    }
+
+    #[test]
+    fn targets_are_distinct_and_never_occupied_or_reserved() {
+        let occupied = [11usize, 3, 12, 1, 13];
+        let reserved = [0usize, 7];
+        let plan = plan_slot_compaction(&occupied, &reserved);
+        let n = occupied.len();
+        let mut seen = Vec::new();
+        for &(i, target) in &plan {
+            assert!(occupied[i] >= n, "an in-range survivor was moved");
+            assert!(target < n, "target {target} outside [0..{n})");
+            assert!(!reserved.contains(&target), "target {target} is reserved");
+            assert!(
+                !occupied.contains(&target),
+                "target {target} is held by another survivor"
+            );
+            assert!(!seen.contains(&target), "target {target} planned twice");
+            seen.push(target);
+        }
+    }
+
+    #[test]
+    fn empty_survivor_set_plans_nothing() {
+        assert_eq!(plan_slot_compaction(&[], &[]), Vec::new());
+        assert_eq!(plan_slot_compaction(&[], &[0, 1, 2]), Vec::new());
+    }
+}

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -20,7 +20,11 @@
 //!  - `run_batched_mixed`   — Q12 Phase 5 batched mixed (decode+prefill) step.
 //!  - `prefill_waves`       — pure wave planner for `run_batched_prefill`
 //!                            (VARLEN budget capping + geometry grouping).
+//!  - `prefill_fallback`    — per-stream re-run of a DECLINED wave, plus the
+//!                            advance/sample bookkeeping both paths share.
 
+#[path = "phase_continue_prefills/prefill_fallback.rs"]
+mod prefill_fallback;
 #[path = "phase_continue_prefills/prefill_waves.rs"]
 mod prefill_waves;
 #[path = "phase_continue_prefills/run_batched_mixed.rs"]

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -45,9 +45,9 @@ use super::{FirstTokenPolicy, sample_first_token};
 use crate::scheduling_policy::{ActiveSeqTiming, SchedulingPolicy};
 
 // Re-export for `phase_start_prefills`: the deferral decision and the wave
-// planner have to agree about the budget, so the predicate lives with the
-// planner (#1002).
-pub(super) use prefill_waves::varlen_defer_pays;
+// planner have to agree about the budget, so the rule lives with the planner
+// (#1002).
+pub(super) use prefill_waves::varlen_admission;
 
 use run_batched_mixed::run_batched_mixed_step;
 use run_batched_prefill::run_batched_prefill_step;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills.rs
@@ -44,6 +44,11 @@ use super::types::{ActiveSeq, PrefillInProgress};
 use super::{FirstTokenPolicy, sample_first_token};
 use crate::scheduling_policy::{ActiveSeqTiming, SchedulingPolicy};
 
+// Re-export for `phase_start_prefills`: the deferral decision and the wave
+// planner have to agree about the budget, so the predicate lives with the
+// planner (#1002).
+pub(super) use prefill_waves::varlen_defer_pays;
+
 use run_batched_mixed::run_batched_mixed_step;
 use run_batched_prefill::run_batched_prefill_step;
 use run_standard::run_standard_chunk_loop;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_fallback.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_fallback.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Per-stream fallback for a DECLINED batched-prefill wave, and the
+//! advance-and-sample bookkeeping both dispatch paths share.
+//!
+//! A batched forward can refuse a wave for reasons that have nothing to do
+//! with the requests in it (an arena that cannot hold the stacked chunk, a
+//! geometry the kernel path does not cover). When the refusal is raised BEFORE
+//! any stream was mutated — `spark_model::traits::BatchedPrefillDeclined` — the
+//! streams are exactly as the scheduler handed them over and the correct
+//! response is to prefill them one at a time, not to drop them.
+//!
+//! The scheduler used to drop them: `run_batched_prefill_step` pushed
+//! `(i, None)` for every member and `promote_completed_prefills` freed the
+//! sequence without touching its sink. On a streaming request the SSE body was
+//! already committed with a 200, so the client saw a stream that ended with no
+//! content, no `finish_reason` and no usage frame — `err=0`, nothing to retry
+//! on. Measured on H100 round 11 (#927) cell E: `ATLAS_PREFILL_VARLEN=1` at
+//! C=16 returned sixteen empty 200s on 3/3 reps, and intermittently dropped 3
+//! of 16 on an otherwise-clean run. Silent truncation is the worst failure
+//! shape available: it is indistinguishable from a correct empty answer.
+//!
+//! Two rules come out of that, and both are enforced here and in
+//! `phase_promote_prefills`:
+//!   1. a decline re-runs the whole wave per-stream, and
+//!   2. a stream that still fails gets an error frame — never a closed channel.
+
+use spark_model::traits::{Model, PrefillSlice};
+use spark_runtime::gpu::DevicePtr;
+
+use super::super::types::PrefillInProgress;
+use super::super::{FirstTokenPolicy, sample_first_token};
+
+/// Re-run one declined wave's members through the single-stream dispatch.
+///
+/// Each member is handed to `prefill_batch_chunk` on its own: at `n == 1` the
+/// model's dispatcher delegates straight to the single-stream path, which is
+/// the same code the non-batched scheduler runs. A member that fails on its own
+/// fails alone — the rest of the wave still completes.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_wave_per_stream(
+    model: &dyn Model,
+    sched: &crate::scheduler::sched_ctx::SchedCtx,
+    prefilling: &mut [PrefillInProgress],
+    completed_indices: &mut Vec<(usize, Option<u32>)>,
+    wave: &[usize],
+    chunk_lens: &[usize],
+    is_last_flags: &[bool],
+    n: usize,
+    prefill_stream: u64,
+    prefill_event: u64,
+    think_end_token: Option<u32>,
+    tool_call_start_token: Option<u32>,
+) {
+    for &i in wave {
+        let logits = {
+            let p = &mut prefilling[i];
+            let mut one = [PrefillSlice {
+                prompt_tokens: &p.prompt_tokens,
+                seq: &mut p.seq,
+                chunk_start: p.chunk_offset,
+                chunk_len: chunk_lens[i],
+                is_last_chunk: is_last_flags[i],
+            }];
+            match model.prefill_batch_chunk(&mut one, prefill_stream) {
+                Ok(v) => v.first().copied().unwrap_or(DevicePtr::NULL),
+                Err(e) => {
+                    tracing::error!(
+                        "Per-stream prefill fallback[{i}/{n}] failed after a declined wave: {e:#}",
+                    );
+                    completed_indices.push((i, None));
+                    continue;
+                }
+            }
+        };
+        let _ = model.record_event(prefill_event, prefill_stream);
+        let _ = model.stream_wait_event(model.default_stream(), prefill_event);
+        advance_and_sample(
+            model,
+            sched,
+            &mut prefilling[i],
+            i,
+            n,
+            chunk_lens[i],
+            is_last_flags[i],
+            logits,
+            completed_indices,
+            think_end_token,
+            tool_call_start_token,
+        );
+    }
+}
+
+/// Advance one stream's `chunk_offset` and, when the chunk it just ran was its
+/// last, sample the first token into `completed_indices`.
+///
+/// SSOT for both dispatch paths (the batched wave and the per-stream fallback)
+/// so a stream cannot be advanced on one path and not the other.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn advance_and_sample(
+    model: &dyn Model,
+    sched: &crate::scheduler::sched_ctx::SchedCtx,
+    p: &mut PrefillInProgress,
+    i: usize,
+    n: usize,
+    chunk_len: usize,
+    is_last: bool,
+    logits: DevicePtr,
+    completed_indices: &mut Vec<(usize, Option<u32>)>,
+    think_end_token: Option<u32>,
+    tool_call_start_token: Option<u32>,
+) {
+    p.chunk_offset += chunk_len;
+    if !is_last {
+        return;
+    }
+    if logits == DevicePtr::NULL {
+        tracing::error!(
+            "Batched prefill: stream {i} marked is_last but model returned NULL logits"
+        );
+        completed_indices.push((i, None));
+        return;
+    }
+    // #131: grammar-constrain the FIRST token (and advance the matcher);
+    // no-op without a grammar.
+    // P1-4 (2026-07-09): thread the resolved `min_p` — previously a
+    // hardcoded 0.0 inside the sampler. Kill-switch: ATLAS_NO_MTP_MINP=1.
+    match sample_first_token(
+        model,
+        logits,
+        p.temperature,
+        p.top_k,
+        p.top_p,
+        p.min_p,
+        &p.eos_tokens,
+        p.grammar_state.as_mut(),
+        FirstTokenPolicy::for_birth(p.enable_thinking, think_end_token, tool_call_start_token),
+        &sched.levers.sampling(),
+    ) {
+        Ok(first) => {
+            tracing::info!(
+                "Batched prefill[{i}/{n}] first token: {first} (chunk_len={chunk_len}, \
+                 total_tokens={})",
+                p.prompt_tokens.len(),
+            );
+            completed_indices.push((i, Some(first)));
+        }
+        Err(e) => {
+            tracing::error!("Batched prefill[{i}] sampling: {e:#}");
+            completed_indices.push((i, None));
+        }
+    }
+}

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
@@ -170,6 +170,117 @@ where
     smallest.saturating_add(second) <= wave_token_cap
 }
 
+/// The waves this tick actually DISPATCHES — all of them with the flag off,
+/// only the FIRST under VARLEN.
+///
+/// # Why one wave per tick (#1002, H100 round 15 §3.7)
+///
+/// Waves used to run back-to-back inside one tick. Promotion is a PHASE — a
+/// stream's first token reaches its client in `promote_completed_prefills`,
+/// after `continue_in_progress_prefills` returns — and decode runs later still,
+/// in the tick's own decode step. So a stream that finished in wave 1 waited
+/// for waves 2 and 3 before anyone heard from it, and every TTFT in the burst
+/// landed on the slowest one. Measured on the SHORT shape, where the deferral
+/// predicate correctly says batching pays: sixteen 1193-token prompts,
+/// `16 streams -> 3 wave(s)`, **TTFT p50 1 359.4 -> 4 141.2 ms (p50 = p99) and
+/// aggregate 513.86 -> 427.53 tok/s (-16.8%)** against the same-binary control,
+/// even though TPOT IMPROVED 25.90 -> 21.28 ms. The batching works; the
+/// scheduling of it did not.
+///
+/// Capping at one wave per tick is the fix the tick structure supports: wave 1
+/// runs, its finished streams are promoted at the end of THIS tick, decode
+/// interleaves from the next one, and the streams that did not fit re-plan next
+/// tick — where they batch among themselves, because the planner is re-run from
+/// the live geometry every tick. The alternative (promote inside the wave loop)
+/// buys nothing: `promote_completed_prefills` removes from `prefilling`, which
+/// invalidates the wave indices, and decode still would not run until the
+/// prefill phase returned.
+///
+/// FAIRNESS is unchanged in kind, not degraded: wave 1 always contains stream
+/// 0, because the planner is first-fit in FIFO order, so the head of the queue
+/// advances one chunk every tick — exactly the guarantee the single-stream
+/// `prefilling.first_mut()` path gives — and it now carries everyone who fits
+/// with it. Flag OFF is one wave holding every stream, so this returns it
+/// whole and the dispatch is byte-identical to the pre-wave scheduler.
+pub(super) fn waves_this_tick(planned: Vec<Vec<usize>>, varlen: bool) -> Vec<Vec<usize>> {
+    if !varlen {
+        return planned;
+    }
+    planned.into_iter().take(1).collect()
+}
+
+/// Why this tick's admission did — or did not — defer chunk-0 so it could
+/// batch. `defer` is the verdict; `reason` is the ONE input that decided it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::scheduler) struct VarlenAdmission {
+    pub defer: bool,
+    pub reason: &'static str,
+}
+
+/// The deferral verdict, as a pure function of the tick's own inputs.
+///
+/// # Why this is a function, and why it logs its reason every burst
+///
+/// H100 round 15 anomaly 8: varlen engaged in two of four otherwise identical
+/// short-shape bursts (427 tok/s) and not the other two (514 tok/s, i.e. the
+/// no-lever numbers), which is a 17.52% rep spread that is not measurement
+/// noise. The planner itself is deterministic — [`plan_prefill_waves`] is a
+/// pure function of the geometries — so the variation is upstream, in WHICH
+/// tick a burst's requests are admitted on: `active` must be empty and two
+/// chunk-0s must be co-admitted, and a burst whose first request has already
+/// been promoted to decode by the time the rest arrive fails the first test.
+/// That is a property of arrival timing against the scheduler's tick period,
+/// not something the planner can make deterministic; it is INHERENT. So the
+/// reason is logged per burst instead, and a run's engagement becomes readable
+/// from its serve log rather than inferred from its throughput.
+///
+/// `chunk_zero_heads` is the same upper-bounded head list `varlen_defer_pays`
+/// grades (`phase_start_prefills::varlen_chunk_zero_heads`).
+pub(in crate::scheduler) fn varlen_admission(
+    varlen_on: bool,
+    chunked: bool,
+    is_ep: bool,
+    active: usize,
+    new_reqs: usize,
+    prefilling_in_flight: usize,
+    chunk_zero_heads: &[usize],
+    wave_token_cap: usize,
+) -> VarlenAdmission {
+    let no = |reason| VarlenAdmission {
+        defer: false,
+        reason,
+    };
+    if !varlen_on {
+        return no("lever off (--prefill-varlen-batch)");
+    }
+    if !chunked {
+        return no("chunked prefill disabled");
+    }
+    if is_ep {
+        return no("expert-parallel: no batched prefill path");
+    }
+    if active > 0 {
+        // THE round-15 engagement variable. Deferring here would park
+        // slot-owning streams while decode runs, which is the configuration
+        // #1002's slot-aliasing fix was written for.
+        return no("decode already active this tick (arrival timing)");
+    }
+    if new_reqs < 2 && prefilling_in_flight == 0 {
+        return no("nothing to batch with (one arrival, nothing in flight)");
+    }
+    if !varlen_defer_pays(chunk_zero_heads.iter().copied(), wave_token_cap) {
+        return no("no two chunk-0s fit one wave");
+    }
+    VarlenAdmission {
+        defer: true,
+        reason: "two smallest chunk-0s share a wave",
+    }
+}
+
 #[cfg(test)]
 #[path = "prefill_waves_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "prefill_waves_tick_tests.rs"]
+mod tick_tests;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
@@ -76,156 +76,100 @@ pub(super) fn plan_prefill_waves(
     waves.into_iter().map(|(_, _, members)| members).collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{WaveGeom, plan_prefill_waves};
-
-    fn g(chunk_start: usize, chunk_len: usize, is_last: bool) -> WaveGeom {
-        WaveGeom {
-            chunk_start,
-            chunk_len,
-            is_last,
-        }
+/// Per-stream chunk geometry for ONE dispatch tick: how many tokens the
+/// stream advances and whether that chunk is its last.
+///
+/// SSOT for `run_batched_prefill_step`'s per-stream loop, factored out so the
+/// geometry a stream gets in a batched wave can be compared — in a test, with
+/// no model and no GPU — against the sequence the same stream gets on the
+/// per-stream path. #1002 asked that question of the round-13 shapes and the
+/// answer has to stay pinned: BF16 accumulation is not associative, so a
+/// stream that takes a different chunk shape depending on who it batched with
+/// is a different answer to the same request at temperature 0.
+///
+/// * `effective_max` — `max_prefill_tokens`, or `remaining` for MLA models
+///   (no paged-MLA prefill kernel ⇒ multi-chunk prefill is forced off).
+/// * `tail_cut` — `Model::prefill_tail_cut`, the offset where
+///   `prefill_chunk_dispatch` would split this prompt's FINAL chunk to land an
+///   SSM tail checkpoint. Under VARLEN the scheduler pre-splits there so the
+///   tails of a co-arriving burst share a `chunk_start` and batch.
+///
+/// NOTE the budget NEVER truncates a chunk-0 below the cut: `chunk_len` starts
+/// at `min(remaining, effective_max)` and the wave cap is applied by the
+/// PLANNER, which opens a new wave rather than shrinking a member (a stream
+/// whose own chunk exceeds the cap gets a singleton wave). Pinned by
+/// `chunk_zero_is_never_truncated_by_the_wave_budget`.
+pub(super) fn plan_stream_chunk(
+    chunk_offset: usize,
+    total: usize,
+    effective_max: usize,
+    tail_cut: Option<usize>,
+    varlen: bool,
+) -> (usize, bool) {
+    let remaining = total - chunk_offset;
+    let mut chunk_len = remaining.min(effective_max);
+    let mut is_last = chunk_offset + chunk_len >= total;
+    // TAIL PRE-SPLIT (VARLEN only) — the condition mirrors
+    // `prefill_chunk_dispatch`'s own (`cut > chunk_start && cut < total`, on a
+    // last chunk) exactly, plus the requirement that the cut lie inside THIS
+    // chunk.
+    if varlen
+        && is_last
+        && let Some(cut) = tail_cut
+        && cut > chunk_offset
+        && cut < total
+        && cut <= chunk_offset + chunk_len
+    {
+        chunk_len = cut - chunk_offset;
+        is_last = false;
     }
-
-    #[test]
-    fn flag_off_is_one_wave_with_every_stream_in_order() {
-        // Byte-identical dispatch behaviour: the pre-wave scheduler made ONE
-        // prefill_batch_chunk call with all streams, whatever their geometry
-        // or total token count.
-        let geoms = [g(0, 200, true), g(2048, 512, false), g(0, 4096, true)];
-        assert_eq!(plan_prefill_waves(&geoms, false, 2048), vec![vec![0, 1, 2]]);
+    // Align intermediate chunks to the GDN WY4 boundary (4 tokens). The tail
+    // cut is a multiple of the KV block size, itself a multiple of 4 on every
+    // shipped config, so this is a no-op there.
+    if !is_last && chunk_len >= 4 {
+        chunk_len = (chunk_len / 4) * 4;
     }
-
-    #[test]
-    fn empty_streams_no_waves() {
-        assert!(plan_prefill_waves(&[], true, 2048).is_empty());
-        assert!(plan_prefill_waves(&[], false, 2048).is_empty());
-    }
-
-    #[test]
-    fn ragged_chunk0_wave_packs_up_to_the_budget() {
-        // Ten ~200-token fresh prompts against the 2048-token budget: the
-        // first ten fit (Σ = 2000), the eleventh opens wave 2 — the measured
-        // C=32 case (285 ms/prompt serial) becomes ⌈32/10⌉ dispatches.
-        let geoms: Vec<WaveGeom> = (0..11).map(|_| g(0, 200, true)).collect();
-        let waves = plan_prefill_waves(&geoms, true, 2048);
-        assert_eq!(waves.len(), 2);
-        assert_eq!(waves[0], (0..10).collect::<Vec<_>>());
-        assert_eq!(waves[1], vec![10]);
-    }
-
-    #[test]
-    fn the_h100_c16_burst_packs_six_prompts_per_prefill_step() {
-        // The #927 receipt, exactly: sixteen 1193-token prompts arriving
-        // together against `--max-prefill-tokens 8192`. Measured behaviour
-        // before this work was 32 prefill chunks for 32 requests — one prompt
-        // per step, 220.8 ms each, budget never binding (2048 and 24576 both
-        // changed nothing, ±0.4%). Six fit: 6 x 1193 = 7158 <= 8192, and a
-        // seventh would be 8351.
-        //
-        // The tail pre-split in `run_batched_prefill_step` makes each prompt's
-        // HEAD 1168 tokens (one KV block below the last boundary under 1193),
-        // so seven heads is 8176 — still inside the budget. Both geometries
-        // are pinned here because the planner sees whichever one the caller
-        // built, and "how many prompts per step" is the whole claim.
-        let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
-        let waves = plan_prefill_waves(&whole, true, 8192);
-        assert_eq!(waves.len(), 3, "16 prompts / 6 per wave = 3 waves");
-        assert_eq!(waves[0].len(), 6);
-        assert_eq!(waves[1].len(), 6);
-        assert_eq!(waves[2].len(), 4);
-
-        let heads: Vec<WaveGeom> = (0..16).map(|_| g(0, 1168, false)).collect();
-        let waves = plan_prefill_waves(&heads, true, 8192);
-        assert_eq!(waves[0].len(), 7, "1168-token heads pack 7 per step");
-
-        // And the 25-token tails all share `chunk_start == 1168`, so the
-        // planner puts every one of them in a SINGLE forward — against 32
-        // standalone 25-token passes measured at 29.26 ms each (1170 µs/token,
-        // 11.7% of prefill GPU time for 2.1% of the tokens).
-        let tails: Vec<WaveGeom> = (0..16).map(|_| g(1168, 25, true)).collect();
-        let waves = plan_prefill_waves(&tails, true, 8192);
-        assert_eq!(waves, vec![(0..16).collect::<Vec<_>>()]);
-    }
-
-    #[test]
-    fn flag_off_still_admits_every_prompt_in_one_call() {
-        // Control for the test above: with VARLEN off the planner must not
-        // start splitting anything — the model-side dispatcher is what refuses
-        // the batch, and it needs to see the same one-call shape it always did.
-        let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
-        assert_eq!(
-            plan_prefill_waves(&whole, false, 8192),
-            vec![(0..16).collect::<Vec<_>>()],
-        );
-    }
-
-    #[test]
-    fn budget_cap_is_exact_not_off_by_one() {
-        // 1024 + 1024 == cap exactly ⇒ same wave; +1 more opens a new one.
-        let geoms = [g(0, 1024, true), g(0, 1024, true), g(0, 1, true)];
-        let waves = plan_prefill_waves(&geoms, true, 2048);
-        assert_eq!(waves, vec![vec![0, 1], vec![2]]);
-    }
-
-    #[test]
-    fn mixed_geometry_splits_into_compatible_waves() {
-        // The model-side contract: chunk_start and is_last must match across
-        // a batch (check_kernel_batched_eligible). A wave mixing them would
-        // be rejected wholesale and every stream would fall back to serial —
-        // the planner must never emit one.
-        let geoms = [
-            g(0, 200, true),     // fresh single-chunk
-            g(0, 2048, false),   // fresh long prompt, chunk 0 of many
-            g(0, 300, true),     // fresh single-chunk → wave of stream 0
-            g(2048, 512, false), // mid-prefill continuation
-            g(0, 250, true),     // fresh single-chunk → wave of stream 0
-        ];
-        let waves = plan_prefill_waves(&geoms, true, 2048);
-        assert_eq!(waves, vec![vec![0, 2, 4], vec![1], vec![3]]);
-        // Cross-check the invariant directly: uniform (chunk_start, is_last)
-        // per wave, Σ ≤ cap for every multi-member wave.
-        for wave in &waves {
-            let head = geoms[wave[0]];
-            let total: usize = wave.iter().map(|&i| geoms[i].chunk_len).sum();
-            assert!(wave.len() == 1 || total <= 2048);
-            for &i in wave {
-                assert_eq!(geoms[i].chunk_start, head.chunk_start);
-                assert_eq!(geoms[i].is_last, head.is_last);
-            }
-        }
-    }
-
-    #[test]
-    fn oversized_stream_gets_a_singleton_wave() {
-        // chunk_len > cap must still dispatch (single-stream path); it must
-        // not absorb siblings past the cap.
-        let geoms = [g(0, 4096, true), g(0, 100, true)];
-        let waves = plan_prefill_waves(&geoms, true, 2048);
-        assert_eq!(waves, vec![vec![0], vec![1]]);
-    }
-
-    #[test]
-    fn every_stream_is_assigned_exactly_once() {
-        let geoms: Vec<WaveGeom> = (0..37)
-            .map(|i| g((i % 3) * 1024, 100 + i * 7, i % 2 == 0))
-            .collect();
-        let waves = plan_prefill_waves(&geoms, true, 1024);
-        let mut seen = vec![0usize; geoms.len()];
-        for wave in &waves {
-            assert!(!wave.is_empty());
-            for &i in wave {
-                seen[i] += 1;
-            }
-        }
-        assert!(
-            seen.iter().all(|&c| c == 1),
-            "each stream in exactly one wave"
-        );
-        // FIFO order preserved within each wave.
-        for wave in &waves {
-            assert!(wave.windows(2).all(|w| w[0] < w[1]));
-        }
-    }
+    (chunk_len, is_last)
 }
+
+/// Does deferring these chunk-0s into `prefilling` so they can BATCH actually
+/// buy anything? True only when the two smallest heads fit one wave together.
+///
+/// #1002 / round 13, long shape. Sixteen 4593-token prompts pre-split to
+/// `4576 + 17`, and `2 x 4576 = 9152 > 8192`, so the planner emitted
+/// `16 streams -> 14 wave(s), M per wave [51, 4576 x13]`. Fourteen waves for
+/// sixteen streams is not batching — but the deferral was paid anyway, and it
+/// is not free: waves run back-to-back inside ONE tick, so no stream is
+/// promoted until every wave has run, and every TTFT collapses onto the p99.
+/// Measured: long-shape C=16 TTFT 7 524.7 -> 13 756.1 ms (+82.8%) and
+/// aggregate 308.86 -> 214.25 tok/s (-30.6%) against the same-binary control,
+/// for zero batching. When this returns false the request keeps the inline
+/// chunk-0 of `phase_start_prefills` and the staggered TTFT that comes with it.
+///
+/// Two heads, not `n`: the planner is first-fit, so a single pair sharing a
+/// wave is the smallest win that justifies the deferral, and the two smallest
+/// heads are the pair most likely to fit.
+pub(in crate::scheduler) fn varlen_defer_pays<I>(heads: I, wave_token_cap: usize) -> bool
+where
+    I: IntoIterator<Item = usize>,
+{
+    let mut smallest = usize::MAX;
+    let mut second = usize::MAX;
+    for h in heads {
+        if h < smallest {
+            second = smallest;
+            smallest = h;
+        } else if h < second {
+            second = h;
+        }
+    }
+    if second == usize::MAX {
+        // Fewer than two candidates — nothing to batch with.
+        return false;
+    }
+    smallest.saturating_add(second) <= wave_token_cap
+}
+
+#[cfg(test)]
+#[path = "prefill_waves_tests.rs"]
+mod tests;

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves.rs
@@ -116,6 +116,52 @@ mod tests {
     }
 
     #[test]
+    fn the_h100_c16_burst_packs_six_prompts_per_prefill_step() {
+        // The #927 receipt, exactly: sixteen 1193-token prompts arriving
+        // together against `--max-prefill-tokens 8192`. Measured behaviour
+        // before this work was 32 prefill chunks for 32 requests — one prompt
+        // per step, 220.8 ms each, budget never binding (2048 and 24576 both
+        // changed nothing, ±0.4%). Six fit: 6 x 1193 = 7158 <= 8192, and a
+        // seventh would be 8351.
+        //
+        // The tail pre-split in `run_batched_prefill_step` makes each prompt's
+        // HEAD 1168 tokens (one KV block below the last boundary under 1193),
+        // so seven heads is 8176 — still inside the budget. Both geometries
+        // are pinned here because the planner sees whichever one the caller
+        // built, and "how many prompts per step" is the whole claim.
+        let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
+        let waves = plan_prefill_waves(&whole, true, 8192);
+        assert_eq!(waves.len(), 3, "16 prompts / 6 per wave = 3 waves");
+        assert_eq!(waves[0].len(), 6);
+        assert_eq!(waves[1].len(), 6);
+        assert_eq!(waves[2].len(), 4);
+
+        let heads: Vec<WaveGeom> = (0..16).map(|_| g(0, 1168, false)).collect();
+        let waves = plan_prefill_waves(&heads, true, 8192);
+        assert_eq!(waves[0].len(), 7, "1168-token heads pack 7 per step");
+
+        // And the 25-token tails all share `chunk_start == 1168`, so the
+        // planner puts every one of them in a SINGLE forward — against 32
+        // standalone 25-token passes measured at 29.26 ms each (1170 µs/token,
+        // 11.7% of prefill GPU time for 2.1% of the tokens).
+        let tails: Vec<WaveGeom> = (0..16).map(|_| g(1168, 25, true)).collect();
+        let waves = plan_prefill_waves(&tails, true, 8192);
+        assert_eq!(waves, vec![(0..16).collect::<Vec<_>>()]);
+    }
+
+    #[test]
+    fn flag_off_still_admits_every_prompt_in_one_call() {
+        // Control for the test above: with VARLEN off the planner must not
+        // start splitting anything — the model-side dispatcher is what refuses
+        // the batch, and it needs to see the same one-call shape it always did.
+        let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
+        assert_eq!(
+            plan_prefill_waves(&whole, false, 8192),
+            vec![(0..16).collect::<Vec<_>>()],
+        );
+    }
+
+    #[test]
     fn budget_cap_is_exact_not_off_by_one() {
         // 1024 + 1024 == cap exactly ⇒ same wave; +1 more opens a new one.
         let geoms = [g(0, 1024, true), g(0, 1024, true), g(0, 1, true)];

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves_tests.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves_tests.rs
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Tests for the VARLEN prefill wave planner and the per-stream chunk
+//! geometry. Split from `prefill_waves.rs` for the 500-LoC cap; the #1002
+//! round-13 replays roughly tripled the module.
+
+use super::{WaveGeom, plan_prefill_waves, plan_stream_chunk, varlen_defer_pays};
+
+fn g(chunk_start: usize, chunk_len: usize, is_last: bool) -> WaveGeom {
+    WaveGeom {
+        chunk_start,
+        chunk_len,
+        is_last,
+    }
+}
+
+#[test]
+fn flag_off_is_one_wave_with_every_stream_in_order() {
+    // Byte-identical dispatch behaviour: the pre-wave scheduler made ONE
+    // prefill_batch_chunk call with all streams, whatever their geometry
+    // or total token count.
+    let geoms = [g(0, 200, true), g(2048, 512, false), g(0, 4096, true)];
+    assert_eq!(plan_prefill_waves(&geoms, false, 2048), vec![vec![0, 1, 2]]);
+}
+
+#[test]
+fn empty_streams_no_waves() {
+    assert!(plan_prefill_waves(&[], true, 2048).is_empty());
+    assert!(plan_prefill_waves(&[], false, 2048).is_empty());
+}
+
+#[test]
+fn ragged_chunk0_wave_packs_up_to_the_budget() {
+    // Ten ~200-token fresh prompts against the 2048-token budget: the
+    // first ten fit (Σ = 2000), the eleventh opens wave 2 — the measured
+    // C=32 case (285 ms/prompt serial) becomes ⌈32/10⌉ dispatches.
+    let geoms: Vec<WaveGeom> = (0..11).map(|_| g(0, 200, true)).collect();
+    let waves = plan_prefill_waves(&geoms, true, 2048);
+    assert_eq!(waves.len(), 2);
+    assert_eq!(waves[0], (0..10).collect::<Vec<_>>());
+    assert_eq!(waves[1], vec![10]);
+}
+
+#[test]
+fn the_h100_c16_burst_packs_six_prompts_per_prefill_step() {
+    // The #927 receipt, exactly: sixteen 1193-token prompts arriving
+    // together against `--max-prefill-tokens 8192`. Measured behaviour
+    // before this work was 32 prefill chunks for 32 requests — one prompt
+    // per step, 220.8 ms each, budget never binding (2048 and 24576 both
+    // changed nothing, ±0.4%). Six fit: 6 x 1193 = 7158 <= 8192, and a
+    // seventh would be 8351.
+    //
+    // The tail pre-split in `run_batched_prefill_step` makes each prompt's
+    // HEAD 1168 tokens (one KV block below the last boundary under 1193),
+    // so seven heads is 8176 — still inside the budget. Both geometries
+    // are pinned here because the planner sees whichever one the caller
+    // built, and "how many prompts per step" is the whole claim.
+    let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
+    let waves = plan_prefill_waves(&whole, true, 8192);
+    assert_eq!(waves.len(), 3, "16 prompts / 6 per wave = 3 waves");
+    assert_eq!(waves[0].len(), 6);
+    assert_eq!(waves[1].len(), 6);
+    assert_eq!(waves[2].len(), 4);
+
+    let heads: Vec<WaveGeom> = (0..16).map(|_| g(0, 1168, false)).collect();
+    let waves = plan_prefill_waves(&heads, true, 8192);
+    assert_eq!(waves[0].len(), 7, "1168-token heads pack 7 per step");
+
+    // And the 25-token tails all share `chunk_start == 1168`, so the
+    // planner puts every one of them in a SINGLE forward — against 32
+    // standalone 25-token passes measured at 29.26 ms each (1170 µs/token,
+    // 11.7% of prefill GPU time for 2.1% of the tokens).
+    let tails: Vec<WaveGeom> = (0..16).map(|_| g(1168, 25, true)).collect();
+    let waves = plan_prefill_waves(&tails, true, 8192);
+    assert_eq!(waves, vec![(0..16).collect::<Vec<_>>()]);
+}
+
+#[test]
+fn flag_off_still_admits_every_prompt_in_one_call() {
+    // Control for the test above: with VARLEN off the planner must not
+    // start splitting anything — the model-side dispatcher is what refuses
+    // the batch, and it needs to see the same one-call shape it always did.
+    let whole: Vec<WaveGeom> = (0..16).map(|_| g(0, 1193, true)).collect();
+    assert_eq!(
+        plan_prefill_waves(&whole, false, 8192),
+        vec![(0..16).collect::<Vec<_>>()],
+    );
+}
+
+#[test]
+fn budget_cap_is_exact_not_off_by_one() {
+    // 1024 + 1024 == cap exactly ⇒ same wave; +1 more opens a new one.
+    let geoms = [g(0, 1024, true), g(0, 1024, true), g(0, 1, true)];
+    let waves = plan_prefill_waves(&geoms, true, 2048);
+    assert_eq!(waves, vec![vec![0, 1], vec![2]]);
+}
+
+#[test]
+fn mixed_geometry_splits_into_compatible_waves() {
+    // The model-side contract: chunk_start and is_last must match across
+    // a batch (check_kernel_batched_eligible). A wave mixing them would
+    // be rejected wholesale and every stream would fall back to serial —
+    // the planner must never emit one.
+    let geoms = [
+        g(0, 200, true),     // fresh single-chunk
+        g(0, 2048, false),   // fresh long prompt, chunk 0 of many
+        g(0, 300, true),     // fresh single-chunk → wave of stream 0
+        g(2048, 512, false), // mid-prefill continuation
+        g(0, 250, true),     // fresh single-chunk → wave of stream 0
+    ];
+    let waves = plan_prefill_waves(&geoms, true, 2048);
+    assert_eq!(waves, vec![vec![0, 2, 4], vec![1], vec![3]]);
+    // Cross-check the invariant directly: uniform (chunk_start, is_last)
+    // per wave, Σ ≤ cap for every multi-member wave.
+    for wave in &waves {
+        let head = geoms[wave[0]];
+        let total: usize = wave.iter().map(|&i| geoms[i].chunk_len).sum();
+        assert!(wave.len() == 1 || total <= 2048);
+        for &i in wave {
+            assert_eq!(geoms[i].chunk_start, head.chunk_start);
+            assert_eq!(geoms[i].is_last, head.is_last);
+        }
+    }
+}
+
+#[test]
+fn oversized_stream_gets_a_singleton_wave() {
+    // chunk_len > cap must still dispatch (single-stream path); it must
+    // not absorb siblings past the cap.
+    let geoms = [g(0, 4096, true), g(0, 100, true)];
+    let waves = plan_prefill_waves(&geoms, true, 2048);
+    assert_eq!(waves, vec![vec![0], vec![1]]);
+}
+
+#[test]
+fn every_stream_is_assigned_exactly_once() {
+    let geoms: Vec<WaveGeom> = (0..37)
+        .map(|i| g((i % 3) * 1024, 100 + i * 7, i % 2 == 0))
+        .collect();
+    let waves = plan_prefill_waves(&geoms, true, 1024);
+    let mut seen = vec![0usize; geoms.len()];
+    for wave in &waves {
+        assert!(!wave.is_empty());
+        for &i in wave {
+            seen[i] += 1;
+        }
+    }
+    assert!(
+        seen.iter().all(|&c| c == 1),
+        "each stream in exactly one wave"
+    );
+    // FIFO order preserved within each wave.
+    for wave in &waves {
+        assert!(wave.windows(2).all(|w| w[0] < w[1]));
+    }
+}
+
+// ── #1002: the round-13 receipt, replayed over the planner ────────────
+
+/// `prefill_chunk_dispatch`'s tail cut for a prompt of `total` tokens at
+/// KV block size `bs` — one block below the last boundary under `total`.
+/// Mirrors `Model::prefill_tail_cut` so these tests can drive the real
+/// geometry function with no model. 1193 @ bs=16 -> 1168; 4593 -> 4576.
+fn tail_cut(total: usize, bs: usize) -> Option<usize> {
+    let cut = ((total - 1) / bs) * bs - bs;
+    (cut > 0 && cut < total).then_some(cut)
+}
+
+/// Replay one stream's WHOLE chunk sequence through the geometry SSOT.
+fn chunk_sequence(total: usize, bs: usize, budget: usize, varlen: bool) -> Vec<usize> {
+    let mut offset = 0;
+    let mut seq = Vec::new();
+    while offset < total {
+        let (len, is_last) = plan_stream_chunk(offset, total, budget, tail_cut(total, bs), varlen);
+        assert!(len > 0, "a stream must always advance");
+        seq.push(len);
+        offset += len;
+        if is_last {
+            break;
+        }
+    }
+    assert_eq!(offset, total, "the chunk sequence must cover the prompt");
+    seq
+}
+
+#[test]
+fn round13_short_shape_waves_are_7_7_2_heads_then_16_tails() {
+    // THE round-13 cell-V shape: sixteen 1193-token prompts, block size
+    // 16, `--max-prefill-tokens 8192`. The serve log's planner line for
+    // the burst was `16 streams -> 3 wave(s), M per wave [50, 8176, 8176]`
+    // — which is 2 already-split TAILS (2 x 25) plus 14 heads, because two
+    // streams had arrived one tick earlier. Planned from a clean slate the
+    // sixteen heads must pack 7 / 7 / 2 and the sixteen tails must share
+    // ONE wave.
+    let heads: Vec<WaveGeom> = (0..16)
+        .map(|_| WaveGeom {
+            chunk_start: 0,
+            chunk_len: 1168,
+            is_last: false,
+        })
+        .collect();
+    let waves = plan_prefill_waves(&heads, true, 8192);
+    assert_eq!(
+        waves.iter().map(|w| w.len()).collect::<Vec<_>>(),
+        vec![7, 7, 2],
+        "7 x 1168 = 8176 <= 8192; an eighth would be 9344"
+    );
+    for w in &waves {
+        let m: usize = w.iter().map(|&i| heads[i].chunk_len).sum();
+        assert!(m <= 8192, "wave M {m} over the cap");
+    }
+    assert_eq!(
+        waves
+            .iter()
+            .map(|w| w.iter().map(|&i| heads[i].chunk_len).sum::<usize>())
+            .collect::<Vec<_>>(),
+        vec![8176, 8176, 2336],
+        "the nsys histogram: 8176 x2 and 2336 x1"
+    );
+
+    let tails: Vec<WaveGeom> = (0..16)
+        .map(|_| WaveGeom {
+            chunk_start: 1168,
+            chunk_len: 25,
+            is_last: true,
+        })
+        .collect();
+    assert_eq!(
+        plan_prefill_waves(&tails, true, 8192),
+        vec![(0..16).collect::<Vec<_>>()],
+    );
+}
+
+#[test]
+fn chunk_zero_is_never_truncated_by_the_wave_budget() {
+    // The hypothesis round 13 raised against the `50`-token wave: did the
+    // leftover 16 tokens of an 8192 budget hand two streams a 25-token
+    // CHUNK ZERO? It cannot. The budget the per-stream geometry sees is
+    // `max_prefill_tokens`, and the WAVE cap is applied by the planner,
+    // which opens a new wave rather than shrinking a member. (The `50` was
+    // 2 x 25 TAILS from an earlier tick's streams — `[50, 8176, 8176]` is
+    // 2 tails + 14 heads, and 2 x 25 + 14 x 1168 = 16402 exactly.)
+    for n in 1..=16 {
+        let geoms: Vec<WaveGeom> = (0..n)
+            .map(|_| WaveGeom {
+                chunk_start: 0,
+                chunk_len: 1168,
+                is_last: false,
+            })
+            .collect();
+        for wave in plan_prefill_waves(&geoms, true, 8192) {
+            for i in wave {
+                assert_eq!(
+                    geoms[i].chunk_len, 1168,
+                    "the planner must never shrink a member's chunk_len"
+                );
+            }
+        }
+    }
+    // And the geometry function itself: chunk 0 is the whole head, always.
+    let (len, is_last) = plan_stream_chunk(0, 1193, 8192, tail_cut(1193, 16), true);
+    assert_eq!((len, is_last), (1168, false));
+}
+
+#[test]
+fn batched_geometry_equals_per_stream_geometry_on_the_round13_shapes() {
+    // BF16 accumulation is not associative, so a stream must take the same
+    // chunk sequence whoever it batches with. The VARLEN pre-split exists
+    // to reproduce, in the scheduler, the split `prefill_chunk_dispatch`
+    // performs inside a single per-stream call.
+    assert_eq!(chunk_sequence(1193, 16, 8192, true), vec![1168, 25]);
+    assert_eq!(chunk_sequence(4593, 16, 8192, true), vec![4576, 17]);
+    // Flag OFF the scheduler hands the whole prompt over in one call and
+    // the model splits it internally — same spans, one dispatch.
+    assert_eq!(chunk_sequence(1193, 16, 8192, false), vec![1193]);
+    assert_eq!(chunk_sequence(4593, 16, 8192, false), vec![4593]);
+    // Every stream of the burst gets the identical sequence regardless of
+    // wave membership: the geometry depends only on the prompt.
+    let all: Vec<Vec<usize>> = (0..16)
+        .map(|_| chunk_sequence(1193, 16, 8192, true))
+        .collect();
+    assert!(all.windows(2).all(|w| w[0] == w[1]));
+}
+
+#[test]
+fn round13_long_shape_does_not_defer_because_no_two_heads_fit() {
+    // 4593 pre-splits to 4576 + 17 and `2 x 4576 = 9152 > 8192`, so the
+    // planner degenerates to one stream per wave — the measured
+    // `16 streams -> 14 wave(s), M per wave [51, 4576 x13]`, which cost
+    // +82.8% TTFT and -30.6% aggregate for zero batching. The admission
+    // predicate must refuse the deferral outright.
+    assert!(
+        !varlen_defer_pays((0..16).map(|_| 4593), 8192),
+        "no two 4593-token chunk-0s fit an 8192 wave"
+    );
+    assert!(
+        !varlen_defer_pays((0..16).map(|_| 4576), 8192),
+        "nor do two heads after the tail pre-split"
+    );
+    // The short shape still defers.
+    assert!(varlen_defer_pays((0..16).map(|_| 1193), 8192));
+    // And if it HAD deferred, this is the shape it would have got.
+    let longs: Vec<WaveGeom> = (0..16)
+        .map(|_| WaveGeom {
+            chunk_start: 0,
+            chunk_len: 4576,
+            is_last: false,
+        })
+        .collect();
+    assert_eq!(
+        plan_prefill_waves(&longs, true, 8192).len(),
+        16,
+        "one stream per wave — not batching"
+    );
+}
+
+#[test]
+fn defer_pays_needs_two_candidates_and_respects_the_cap() {
+    assert!(!varlen_defer_pays(std::iter::empty(), 8192));
+    assert!(!varlen_defer_pays(std::iter::once(100), 8192), "alone");
+    // Exactly the cap fits; one more token does not.
+    assert!(varlen_defer_pays([4096, 4096].into_iter(), 8192));
+    assert!(!varlen_defer_pays([4096, 4097].into_iter(), 8192));
+    // The two SMALLEST are the pair that decides it.
+    assert!(varlen_defer_pays([8000, 100, 90].into_iter(), 8192));
+}
+
+#[test]
+fn replays_the_round13_cell_v_arrival_pattern_tick_by_tick() {
+    // The arrival pattern recovered from the cell-V serve log
+    // (`atlas-h100-best-V/serve.log`, 2026-09-11T18:54:30-31Z). Two
+    // requests landed a tick ahead of the other fourteen, which is why the
+    // logged wave line reads `[50, 8176, 8176]` and not `[8176, 8176,
+    // 2336]`: the `50` is TWO 25-token TAILS, not a truncated chunk 0.
+    //
+    //   18:54:30.634  Varlen prefill waves: 2 streams  -> 1 wave(s)  [2336]
+    //   18:54:31.262  Varlen prefill waves: 16 streams -> 3 wave(s)  [50, 8176, 8176]
+    //   (next tick, via the mixed path)                             [350]
+    //
+    // and the nsys prefill histogram for the burst is exactly
+    // `8176 x2, 2336 x1, 350 x1, 50 x1` = 19 088 = 16 x 1193.
+    const HEAD: usize = 1168;
+    const TAIL: usize = 25;
+    let head = WaveGeom {
+        chunk_start: 0,
+        chunk_len: HEAD,
+        is_last: false,
+    };
+    let tail = WaveGeom {
+        chunk_start: HEAD,
+        chunk_len: TAIL,
+        is_last: true,
+    };
+    let m = |geoms: &[WaveGeom], waves: &[Vec<usize>]| -> Vec<usize> {
+        waves
+            .iter()
+            .map(|w| w.iter().map(|&i| geoms[i].chunk_len).sum())
+            .collect()
+    };
+
+    // Tick 1 — the two early arrivals, both fresh.
+    let t1 = vec![head; 2];
+    let w1 = plan_prefill_waves(&t1, true, 8192);
+    assert_eq!(m(&t1, &w1), vec![2336]);
+
+    // Tick 2 — those two are now at the tail; fourteen fresh join them.
+    let mut t2 = vec![tail; 2];
+    t2.extend(std::iter::repeat_n(head, 14));
+    let w2 = plan_prefill_waves(&t2, true, 8192);
+    assert_eq!(m(&t2, &w2), vec![50, 8176, 8176], "the logged wave line");
+    assert_eq!(w2[0], vec![0, 1], "the 50 is the two TAILS");
+
+    // Tick 3 — the fourteen reach their tails and batch into one forward.
+    let t3 = vec![tail; 14];
+    let w3 = plan_prefill_waves(&t3, true, 8192);
+    assert_eq!(m(&t3, &w3), vec![350]);
+
+    // Every prompt token accounted for, once: the nsys histogram.
+    let total: usize = m(&t1, &w1).iter().sum::<usize>()
+        + m(&t2, &w2).iter().sum::<usize>()
+        + m(&t3, &w3).iter().sum::<usize>();
+    assert_eq!(total, 16 * 1193);
+
+    // And no wave ever mixes geometries or exceeds the cap.
+    for (geoms, waves) in [(&t1, &w1), (&t2, &w2), (&t3, &w3)] {
+        for w in waves {
+            let head_geom = geoms[w[0]];
+            assert!(w.iter().map(|&i| geoms[i].chunk_len).sum::<usize>() <= 8192);
+            for &i in w {
+                assert_eq!(geoms[i].chunk_start, head_geom.chunk_start);
+                assert_eq!(geoms[i].is_last, head_geom.is_last);
+            }
+        }
+    }
+}

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves_tick_tests.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/prefill_waves_tick_tests.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! One wave per tick, and why a burst engages the lever at all.
+//!
+//! H100 round 15 §3.7 measured the VARLEN lever as a THROUGHPUT loss on the
+//! short shape even with #1002's slot-aliasing fix in: whenever it engaged,
+//! `16 streams -> 3 wave(s)` ran back-to-back inside one tick, no stream was
+//! promoted until all three had run, and TTFT p50 collapsed onto p99
+//! (1 359.4 -> 4 141.2 ms) while aggregate fell 513.86 -> 427.53 tok/s
+//! (-16.8%). TPOT moved the other way (25.90 -> 21.28 ms), which is what says
+//! the batching itself works and the SCHEDULING of it did not.
+//!
+//! Split from `prefill_waves_tests.rs` for the 500-LoC cap.
+
+use super::{WaveGeom, plan_prefill_waves, varlen_admission, waves_this_tick};
+
+/// The round-13/15 short shape: 1193 tokens pre-split to a 1168-token head and
+/// a 25-token tail at KV block size 16.
+const HEAD: usize = 1168;
+const TAIL: usize = 25;
+const CAP: usize = 8192;
+
+fn head() -> WaveGeom {
+    WaveGeom {
+        chunk_start: 0,
+        chunk_len: HEAD,
+        is_last: false,
+    }
+}
+
+fn tail() -> WaveGeom {
+    WaveGeom {
+        chunk_start: HEAD,
+        chunk_len: TAIL,
+        is_last: true,
+    }
+}
+
+/// THE fix, on THE shape. Sixteen fresh 1193-token streams against an
+/// 8192-token budget plan 7 / 7 / 2 — and only the first seven prefill on tick
+/// 1. The other nine keep their `chunk_offset` and re-plan next tick, so wave 2
+/// is never issued before wave 1's streams have been through
+/// `promote_completed_prefills` and the tick's decode step.
+#[test]
+fn only_the_first_wave_prefills_on_tick_one() {
+    let geoms = vec![head(); 16];
+    let planned = plan_prefill_waves(&geoms, true, CAP);
+    assert_eq!(
+        planned.iter().map(Vec::len).collect::<Vec<_>>(),
+        vec![7, 7, 2],
+        "7 x 1168 = 8176 <= 8192; an eighth would be 9344"
+    );
+
+    let dispatched = waves_this_tick(planned.clone(), true);
+    assert_eq!(dispatched, vec![(0..7).collect::<Vec<_>>()]);
+    let ran: usize = dispatched.iter().map(Vec::len).sum();
+    assert_eq!(ran, 7, "only 7 of 16 streams advance on tick 1");
+    assert_eq!(
+        geoms.len() - ran,
+        9,
+        "the other nine are deferred to the next tick, not dropped"
+    );
+}
+
+/// Tick by tick, the whole burst — the property the round-15 collapse violated:
+/// a stream reaches its LAST chunk (and therefore its first token, and
+/// therefore promotion) before a later wave's forward is ever issued.
+///
+/// Tick 1: streams 0..6 take their heads. Tick 2: the planner is re-run from
+/// the live geometry, so those seven are now at `chunk_start = 1168` and stand
+/// FIRST in FIFO order — their tails are wave 1 and they complete. Only then
+/// does the next set of heads go. Under the old all-waves-per-tick rule all
+/// sixteen heads and then all sixteen tails ran inside two ticks with nobody
+/// promoted in between, which is the p50 = p99 signature.
+#[test]
+fn the_first_waves_streams_reach_decode_before_the_second_waves_forward() {
+    // Tick 1 — sixteen fresh heads.
+    let t1 = vec![head(); 16];
+    let w1 = waves_this_tick(plan_prefill_waves(&t1, true, CAP), true);
+    assert_eq!(w1.len(), 1);
+    assert_eq!(w1[0], (0..7).collect::<Vec<_>>());
+    assert!(
+        !t1[w1[0][0]].is_last,
+        "the heads are not last chunks; nobody is promoted on tick 1"
+    );
+
+    // Tick 2 — the seven that ran are at their tails, nine are still fresh.
+    let mut t2 = vec![tail(); 7];
+    t2.extend(std::iter::repeat_n(head(), 9));
+    let w2 = waves_this_tick(plan_prefill_waves(&t2, true, CAP), true);
+    assert_eq!(w2, vec![(0..7).collect::<Vec<_>>()], "the seven TAILS");
+    for &i in &w2[0] {
+        assert!(
+            t2[i].is_last,
+            "stream {i} finishes its prompt on tick 2 and is promoted at the \
+             end of THIS tick — before any further head wave is issued"
+        );
+    }
+    let m: usize = w2[0].iter().map(|&i| t2[i].chunk_len).sum();
+    assert_eq!(
+        m,
+        7 * TAIL,
+        "one 175-token forward, not seven 25-token ones"
+    );
+}
+
+/// The deferred streams are not starved and they still BATCH: the wave the
+/// planner gives them next tick is the same first-fit pack, taken among
+/// themselves. Wave 1 always contains stream 0 because the planner is first-fit
+/// in FIFO order, so the head of the queue advances one chunk every tick —
+/// exactly the guarantee the single-stream `prefilling.first_mut()` path gives.
+#[test]
+fn deferred_streams_batch_among_themselves_next_tick() {
+    let nine = vec![head(); 9];
+    let w = waves_this_tick(plan_prefill_waves(&nine, true, CAP), true);
+    assert_eq!(w[0].len(), 7, "seven of the nine still pack one wave");
+    assert_eq!(w[0][0], 0, "the FIFO head is always in the dispatched wave");
+}
+
+/// Flag OFF is untouched: one wave holding every stream, dispatched whole. The
+/// pre-wave scheduler made ONE `prefill_batch_chunk` call with all streams and
+/// this lever is default OFF, so that path must be byte-identical.
+#[test]
+fn flag_off_still_dispatches_every_stream_in_one_tick() {
+    let geoms = vec![head(); 16];
+    let planned = plan_prefill_waves(&geoms, false, CAP);
+    assert_eq!(planned, vec![(0..16).collect::<Vec<_>>()]);
+    assert_eq!(waves_this_tick(planned.clone(), false), planned);
+    // And the degenerate cases.
+    assert!(waves_this_tick(Vec::new(), true).is_empty());
+    assert!(waves_this_tick(Vec::new(), false).is_empty());
+    let one = vec![vec![0usize]];
+    assert_eq!(waves_this_tick(one.clone(), true), one);
+}
+
+// ── the admission verdict, and WHY a burst engages (round 15 anomaly 8) ──
+
+/// The long shape still skips the deferral, for the reason it always did — the
+/// `deferral SKIPPED` serve line must keep firing on `4096x512` C=16, where
+/// round 15 measured V15 landing on A15's numbers exactly (398.34 vs 401.28
+/// tok/s, 4 115.2 vs 4 118.8 ms TTFT).
+#[test]
+fn the_long_shape_deferral_is_still_skipped_for_the_same_reason() {
+    let long = vec![4576usize; 16];
+    let a = varlen_admission(true, true, false, 0, 16, 0, &long, CAP);
+    assert!(!a.defer);
+    assert_eq!(a.reason, "no two chunk-0s fit one wave");
+
+    // …and the short shape still defers.
+    let short = vec![1193usize; 16];
+    let b = varlen_admission(true, true, false, 0, 16, 0, &short, CAP);
+    assert!(b.defer);
+    assert_eq!(b.reason, "two smallest chunk-0s share a wave");
+}
+
+/// WHY engagement varied burst to burst. Same sixteen short prompts, same
+/// budget, same binary — the only difference is whether a decode was already
+/// running when the tick admitted them, which is arrival timing against the
+/// scheduler's tick period and not something the planner can pin. The verdict
+/// now NAMES that input, so a serve log says which burst was which instead of
+/// leaving it to be inferred from a 17.52% rep spread.
+#[test]
+fn an_active_decode_is_what_flips_engagement_between_bursts() {
+    let short = vec![1193usize; 16];
+    let engaged = varlen_admission(true, true, false, 0, 16, 0, &short, CAP);
+    let not = varlen_admission(true, true, false, 1, 16, 0, &short, CAP);
+    assert!(engaged.defer && !not.defer);
+    assert_eq!(
+        not.reason,
+        "decode already active this tick (arrival timing)"
+    );
+    assert_ne!(
+        engaged.reason, not.reason,
+        "the log distinguishes the bursts"
+    );
+}
+
+/// Every other rung refuses with its own name, so the line is never ambiguous
+/// about which gate closed — the same posture `ssm_ba_gates_hopper_reject`
+/// takes, and for the same reason: a lever that asks to be enabled and silently
+/// is not measures as "no effect".
+#[test]
+fn every_admission_rung_names_itself() {
+    let short = vec![1193usize; 16];
+    let reasons = [
+        varlen_admission(false, true, false, 0, 16, 0, &short, CAP).reason,
+        varlen_admission(true, false, false, 0, 16, 0, &short, CAP).reason,
+        varlen_admission(true, true, true, 0, 16, 0, &short, CAP).reason,
+        varlen_admission(true, true, false, 3, 16, 0, &short, CAP).reason,
+        varlen_admission(true, true, false, 0, 1, 0, &[1193], CAP).reason,
+        varlen_admission(true, true, false, 0, 16, 0, &[4576; 16], CAP).reason,
+    ];
+    let mut unique = reasons.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), reasons.len(), "two rungs share a reason");
+    for r in reasons {
+        assert!(!r.is_empty());
+    }
+    // A lone arrival with a stream already in flight still defers: the late
+    // request joins the next wave, which is what `!prefilling.is_empty()`
+    // bought and must keep buying.
+    let late = varlen_admission(true, true, false, 0, 1, 1, &[1193, 1193], CAP);
+    assert!(late.defer);
+}

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -108,9 +108,14 @@ pub(super) fn run_batched_prefill_step(
             // planner groups all N tails into ONE forward. #927 measured the
             // standalone alternative at 29.3 ms for 25 tokens — 1 170 µs/token,
             // 11.7% of prefill GPU time for 2.1% of the tokens.
+            //
+            // The condition mirrors `prefill_chunk_dispatch`'s own
+            // (`cut > chunk_start && cut < total`, on a last chunk) exactly,
+            // plus the requirement that the cut lie inside THIS chunk — a
+            // prompt longer than the budget reaches its final chunk at a
+            // nonzero offset and splits there just the same.
             if varlen
                 && is_last
-                && p.chunk_offset == 0
                 && let Some(cut) = model.prefill_tail_cut(&p.prompt_tokens)
                 && cut > p.chunk_offset
                 && cut < p.prompt_tokens.len()

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -10,12 +10,11 @@
 //! FIFO `prefilling.first_mut()` starvation). Phase 2/3 replace the default
 //! impl with batched kernel dispatch for true L2-amortised throughput.
 
-use spark_model::traits::{Model, PrefillSlice};
-use spark_runtime::gpu::DevicePtr;
+use spark_model::traits::{BatchedPrefillDeclined, Model, PrefillSlice};
 use std::time::Instant;
 
 use super::super::types::PrefillInProgress;
-use super::super::{FirstTokenPolicy, sample_first_token};
+use super::prefill_fallback::{advance_and_sample, run_wave_per_stream};
 use super::prefill_waves::{WaveGeom, plan_prefill_waves};
 
 pub(super) fn run_batched_prefill_step(
@@ -90,8 +89,39 @@ pub(super) fn run_batched_prefill_step(
                 max_prefill_tokens
             };
             let mut chunk_len = remaining.min(effective_max);
-            let is_last = p.chunk_offset + chunk_len >= p.prompt_tokens.len();
-            // Align intermediate chunks to GDN WY4 boundary (4 tokens).
+            let mut is_last = p.chunk_offset + chunk_len >= p.prompt_tokens.len();
+            // TAIL PRE-SPLIT (VARLEN only). `prefill_chunk_dispatch` splits a
+            // model's FINAL prefill chunk once, one KV block below the last
+            // block boundary under the prompt, to land an SSM tail checkpoint
+            // a later turn's block-floored prefix match can actually use. The
+            // batched path does not split, so handing it the whole prompt as
+            // one `is_last` chunk would give a co-admitted stream a DIFFERENT
+            // forward shape than the per-stream path gives the same prompt —
+            // and BF16 accumulation is not associative, so at temperature 0
+            // that is a different answer for the same request (the reason the
+            // model-side split is unconditional in the first place).
+            //
+            // Asking the model where it would cut and cutting there keeps the
+            // geometry identical per sequence, AND it is what lets the tails
+            // batch: every member of a co-arriving burst of equal-length
+            // prompts gets the same `chunk_start` for its tail, so the wave
+            // planner groups all N tails into ONE forward. #927 measured the
+            // standalone alternative at 29.3 ms for 25 tokens — 1 170 µs/token,
+            // 11.7% of prefill GPU time for 2.1% of the tokens.
+            if varlen
+                && is_last
+                && p.chunk_offset == 0
+                && let Some(cut) = model.prefill_tail_cut(&p.prompt_tokens)
+                && cut > p.chunk_offset
+                && cut < p.prompt_tokens.len()
+                && cut <= p.chunk_offset + chunk_len
+            {
+                chunk_len = cut - p.chunk_offset;
+                is_last = false;
+            }
+            // Align intermediate chunks to GDN WY4 boundary (4 tokens). The
+            // tail cut is a multiple of the KV block size, which is itself a
+            // multiple of 4 on every shipped config, so this is a no-op there.
             if !is_last && chunk_len >= 4 {
                 chunk_len = (chunk_len / 4) * 4;
             }
@@ -162,14 +192,44 @@ pub(super) fn run_batched_prefill_step(
         let logits_per_stream = match model.prefill_batch_chunk(&mut slices, prefill_stream) {
             Ok(v) => v,
             Err(e) => {
+                let declined = BatchedPrefillDeclined::is_decline(&e);
                 tracing::error!(
-                    "Batched prefill error (wave of {} streams, {n} prefilling): {e:#}",
+                    "Batched prefill error (wave of {} streams, {n} prefilling, \
+                     declined={declined}): {e:#}",
                     wave.len()
                 );
-                // Fail ONLY this wave's streams (freed in
-                // `promote_completed_prefills`). Later waves are left
-                // untouched — they have not advanced this tick and retry
-                // next tick rather than dispatching after a failed forward.
+                drop(slices);
+                if declined {
+                    // DECLINE: the model refused before touching a single
+                    // stream, so every member of this wave still has to be
+                    // prefilled — one at a time, which is what the model would
+                    // have done anyway. Dropping them here is what produced
+                    // #927 cell E's sixteen empty HTTP 200s.
+                    run_wave_per_stream(
+                        model,
+                        sched,
+                        prefilling,
+                        completed_indices,
+                        &wave,
+                        &chunk_lens,
+                        &is_last_flags,
+                        n,
+                        prefill_stream,
+                        prefill_event,
+                        think_end_token,
+                        tool_call_start_token,
+                    );
+                    continue;
+                }
+                // HARD ERROR: an admitted batch can already own KV blocks and
+                // prefix reservations, so re-running it per-stream would
+                // double-allocate. Fail ONLY this wave's streams —
+                // `promote_completed_prefills` now sends each of them an error
+                // frame, so a failed wave is visible to its clients instead of
+                // closing sixteen streams with no content and no
+                // `finish_reason`. Later waves are left untouched: they have
+                // not advanced this tick and retry next tick rather than
+                // dispatching after a failed forward.
                 for &i in &wave {
                     completed_indices.push((i, None));
                 }
@@ -193,52 +253,19 @@ pub(super) fn run_batched_prefill_step(
         // completed — BEFORE the next wave dispatches, because every wave
         // reuses the same logits rows.
         for (k, &i) in wave.iter().enumerate() {
-            let p = &mut prefilling[i];
-            p.chunk_offset += chunk_lens[i];
-            if !is_last_flags[i] {
-                continue;
-            }
-            let logits = logits_per_stream[k];
-            if logits == DevicePtr::NULL {
-                tracing::error!(
-                    "Batched prefill: stream {i} marked is_last but model returned NULL logits",
-                );
-                completed_indices.push((i, None));
-                continue;
-            }
-            // #131: grammar-constrain the FIRST token (and advance the matcher);
-            // no-op without a grammar.
-            // P1-4 (2026-07-09): thread the resolved `min_p` — previously a
-            // hardcoded 0.0 inside the sampler. Kill-switch: ATLAS_NO_MTP_MINP=1.
-            match sample_first_token(
+            advance_and_sample(
                 model,
-                logits,
-                p.temperature,
-                p.top_k,
-                p.top_p,
-                p.min_p,
-                &p.eos_tokens,
-                p.grammar_state.as_mut(),
-                FirstTokenPolicy::for_birth(
-                    p.enable_thinking,
-                    think_end_token,
-                    tool_call_start_token,
-                ),
-                &sched.levers.sampling(),
-            ) {
-                Ok(first) => {
-                    tracing::info!(
-                        "Batched prefill[{i}/{n}] first token: {first} (chunk_len={}, total_tokens={})",
-                        chunk_lens[i],
-                        p.prompt_tokens.len(),
-                    );
-                    completed_indices.push((i, Some(first)));
-                }
-                Err(e) => {
-                    tracing::error!("Batched prefill[{i}] sampling: {e:#}");
-                    completed_indices.push((i, None));
-                }
-            }
+                sched,
+                &mut prefilling[i],
+                i,
+                n,
+                chunk_lens[i],
+                is_last_flags[i],
+                logits_per_stream[k],
+                completed_indices,
+                think_end_token,
+                tool_call_start_token,
+            );
         }
     }
 

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use super::super::types::PrefillInProgress;
 use super::prefill_fallback::{advance_and_sample, run_wave_per_stream};
-use super::prefill_waves::{WaveGeom, plan_prefill_waves, plan_stream_chunk};
+use super::prefill_waves::{WaveGeom, plan_prefill_waves, plan_stream_chunk, waves_this_tick};
 
 pub(super) fn run_batched_prefill_step(
     model: &dyn Model,
@@ -136,21 +136,34 @@ pub(super) fn run_batched_prefill_step(
             is_last: is_last_flags[i],
         })
         .collect();
-    let waves = plan_prefill_waves(&geoms, varlen, wave_cap);
+    let planned = plan_prefill_waves(&geoms, varlen, wave_cap);
+    let n_planned = planned.len();
+    // ONE WAVE PER TICK under VARLEN. Waves used to run back-to-back inside a
+    // tick, so no stream was promoted until every wave had run and every TTFT
+    // in the burst collapsed onto the slowest — H100 round 15 measured the
+    // short shape at TTFT p50 1 359.4 -> 4 141.2 ms (p50 = p99) and aggregate
+    // 513.86 -> 427.53 tok/s (-16.8%) whenever the lever engaged, with TPOT
+    // going the OTHER way (25.90 -> 21.28 ms). The rule and its reasoning live
+    // in `prefill_waves::waves_this_tick`; the deferred streams re-plan next
+    // tick and batch among themselves (#1002).
+    let waves = waves_this_tick(planned, varlen);
     let n_waves = waves.len();
     if varlen {
         // Engagement proof for serve-log diagnosis: one INFO line per tick
-        // with the planned wave shapes. M per wave = Σ chunk_len of its
-        // members — the row count every fused per-layer GEMM launches at
-        // (assuming the model-side dispatch admits; it logs its own verdict
-        // under target "atlas::q12").
+        // with the planned wave shapes and how much of it this tick runs.
+        // M per wave = Σ chunk_len of its members — the row count every fused
+        // per-layer GEMM launches at (assuming the model-side dispatch admits;
+        // it logs its own verdict under target "atlas::q12").
         let wave_m: Vec<usize> = waves
             .iter()
             .map(|w| w.iter().map(|&i| chunk_lens[i]).sum())
             .collect();
+        let dispatched: usize = waves.iter().map(Vec::len).sum();
         tracing::info!(
-            "Varlen prefill waves: {n} streams -> {n_waves} wave(s), M per wave {wave_m:?} \
-             (cap {wave_cap})"
+            "Varlen prefill waves: {n} streams -> {n_planned} wave(s) planned, \
+             {n_waves} dispatched this tick, M per wave {wave_m:?} (cap {wave_cap}), \
+             {} stream(s) deferred to the next tick",
+            n - dispatched,
         );
     }
 
@@ -259,6 +272,8 @@ pub(super) fn run_batched_prefill_step(
 
     let elapsed = t0_batch.elapsed().as_micros();
     if elapsed > 1000 {
-        tracing::debug!("Batched prefill step: {n} streams, {n_waves} waves, {elapsed}µs total");
+        tracing::debug!(
+            "Batched prefill step: {n} streams, {n_waves}/{n_planned} waves, {elapsed}µs total"
+        );
     }
 }

--- a/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
+++ b/crates/spark-server/src/scheduler/phase_continue_prefills/run_batched_prefill.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 
 use super::super::types::PrefillInProgress;
 use super::prefill_fallback::{advance_and_sample, run_wave_per_stream};
-use super::prefill_waves::{WaveGeom, plan_prefill_waves};
+use super::prefill_waves::{WaveGeom, plan_prefill_waves, plan_stream_chunk};
 
 pub(super) fn run_batched_prefill_step(
     model: &dyn Model,
@@ -79,58 +79,41 @@ pub(super) fn run_batched_prefill_step(
         let (chunk_len, is_last) = if let Some((cl, il)) = shared_geom {
             (cl, il)
         } else {
-            let remaining = p.prompt_tokens.len() - p.chunk_offset;
             // Same MLA correctness gate as `run_standard_chunk_loop` — MLA
             // models lack a paged-MLA prefill kernel so multi-chunk prefill
             // silently corrupts attention. Force single-chunk for MLA.
             let effective_max = if model.is_mla() {
-                remaining
+                p.prompt_tokens.len() - p.chunk_offset
             } else {
                 max_prefill_tokens
             };
-            let mut chunk_len = remaining.min(effective_max);
-            let mut is_last = p.chunk_offset + chunk_len >= p.prompt_tokens.len();
-            // TAIL PRE-SPLIT (VARLEN only). `prefill_chunk_dispatch` splits a
-            // model's FINAL prefill chunk once, one KV block below the last
-            // block boundary under the prompt, to land an SSM tail checkpoint
-            // a later turn's block-floored prefix match can actually use. The
-            // batched path does not split, so handing it the whole prompt as
-            // one `is_last` chunk would give a co-admitted stream a DIFFERENT
-            // forward shape than the per-stream path gives the same prompt —
-            // and BF16 accumulation is not associative, so at temperature 0
-            // that is a different answer for the same request (the reason the
-            // model-side split is unconditional in the first place).
+            // TAIL PRE-SPLIT (VARLEN only) + WY4 alignment live in
+            // `prefill_waves::plan_stream_chunk` — the SSOT, so a test can
+            // replay a stream's WHOLE chunk sequence and prove the batched
+            // path hands it the same geometry the per-stream path does
+            // (#1002; BF16 accumulation is not associative, so a shape that
+            // depends on who you batched with is a different answer to the
+            // same request at temperature 0).
             //
-            // Asking the model where it would cut and cutting there keeps the
-            // geometry identical per sequence, AND it is what lets the tails
-            // batch: every member of a co-arriving burst of equal-length
-            // prompts gets the same `chunk_start` for its tail, so the wave
-            // planner groups all N tails into ONE forward. #927 measured the
-            // standalone alternative at 29.3 ms for 25 tokens — 1 170 µs/token,
-            // 11.7% of prefill GPU time for 2.1% of the tokens.
-            //
-            // The condition mirrors `prefill_chunk_dispatch`'s own
-            // (`cut > chunk_start && cut < total`, on a last chunk) exactly,
-            // plus the requirement that the cut lie inside THIS chunk — a
-            // prompt longer than the budget reaches its final chunk at a
-            // nonzero offset and splits there just the same.
-            if varlen
-                && is_last
-                && let Some(cut) = model.prefill_tail_cut(&p.prompt_tokens)
-                && cut > p.chunk_offset
-                && cut < p.prompt_tokens.len()
-                && cut <= p.chunk_offset + chunk_len
-            {
-                chunk_len = cut - p.chunk_offset;
-                is_last = false;
-            }
-            // Align intermediate chunks to GDN WY4 boundary (4 tokens). The
-            // tail cut is a multiple of the KV block size, which is itself a
-            // multiple of 4 on every shipped config, so this is a no-op there.
-            if !is_last && chunk_len >= 4 {
-                chunk_len = (chunk_len / 4) * 4;
-            }
-            (chunk_len, is_last)
+            // Asking the model where it would cut and cutting there is also
+            // what lets the tails batch: every member of a co-arriving burst
+            // of equal-length prompts gets the same `chunk_start` for its
+            // tail, so the wave planner groups all N tails into ONE forward.
+            // #927 measured the standalone alternative at 29.3 ms for 25
+            // tokens — 1 170 us/token, 11.7% of prefill GPU time for 2.1% of
+            // the tokens.
+            let tail_cut = if varlen {
+                model.prefill_tail_cut(&p.prompt_tokens)
+            } else {
+                None
+            };
+            plan_stream_chunk(
+                p.chunk_offset,
+                p.prompt_tokens.len(),
+                effective_max,
+                tail_cut,
+                varlen,
+            )
         };
         chunk_lens.push(chunk_len);
         is_last_flags.push(is_last);

--- a/crates/spark-server/src/scheduler/phase_promote_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_promote_prefills.rs
@@ -42,7 +42,27 @@ pub(super) fn promote_completed_prefills(
         // chunk forward pass; see `prefill_fifo_tests`.
         let mut p = prefilling.remove(idx);
         let Some(first) = maybe_token else {
-            // Error path: free the sequence.
+            // Error path: TELL THE CLIENT, then free the sequence.
+            //
+            // This used to drop `p.sink` on the floor. For a streaming request
+            // that is not a failure the caller can see: the SSE body was
+            // already committed with a 200 when the handler subscribed, so the
+            // channel closing produced a stream that ends after the role
+            // delta — no content, no `finish_reason`, no usage frame, and
+            // `err=0` at the client. Measured on H100 round 11 (#927) cell E:
+            // one batched-prefill wave refused mid-forward returned SIXTEEN
+            // HTTP 200s carrying zero tokens, on 3/3 reps, with nothing but a
+            // server-side ERROR line to say so. A blocking request fared no
+            // better — the dropped `oneshot` surfaces as the misleading
+            // "Inference cancelled".
+            //
+            // `send_error_to_sink` is the same helper `prefill_request` uses
+            // for a failure between taking the sink and building an
+            // `ActiveSeq`; this is that same window, one phase later.
+            super::lifecycle::send_error_to_sink(
+                &mut p.sink,
+                "prefill failed for this sequence (see server log)",
+            );
             let mut seq = p.seq;
             if let Err(e) = model.free_sequence(&mut seq) {
                 tracing::error!("phase_promote_prefills: free_sequence (error path): {e:#}");

--- a/crates/spark-server/src/scheduler/phase_start_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_start_prefills.rs
@@ -98,24 +98,49 @@ pub(super) fn start_new_requests(
     // cannot disagree about the budget.
     let wave_token_cap = max_prefill_tokens.min(max_batch_tokens).max(1);
     let varlen_on = spark_model::layers::ops::prefill_varlen_enabled();
-    let varlen_eligible = chunked
-        && !model.is_ep()
-        && active.is_empty()
-        && (new_reqs.len() >= 2 || !prefilling.is_empty())
-        && varlen_on;
-    let varlen_pays = varlen_eligible
-        && super::phase_continue_prefills::varlen_defer_pays(
-            varlen_chunk_zero_heads(&new_reqs, prefilling, max_prefill_tokens),
-            wave_token_cap,
+    let heads = varlen_chunk_zero_heads(&new_reqs, prefilling, max_prefill_tokens);
+    // The verdict AND the one input that decided it, from the pure rule beside
+    // the wave planner so the two cannot disagree about the budget (#1002).
+    let admission = super::phase_continue_prefills::varlen_admission(
+        varlen_on,
+        chunked,
+        model.is_ep(),
+        active.len(),
+        new_reqs.len(),
+        prefilling.len(),
+        &heads,
+        wave_token_cap,
+    );
+    if varlen_on && chunked {
+        // ONE line per burst, always — H100 round 15 anomaly 8 found engagement
+        // varying two-of-four across identical bursts (427 vs 514 tok/s, a
+        // 17.52% rep spread) with nothing in the log to say which was which.
+        // The planner is deterministic; the ADMISSION is not — it reads how
+        // many requests landed in THIS tick and whether decode is already
+        // running, which is inherent to arrival timing. Reported, not pinned.
+        let mut two = heads.clone();
+        two.sort_unstable();
+        two.truncate(2);
+        tracing::info!(
+            "Varlen prefill admission: defer={} reason=\"{}\" new_reqs={} prefilling={} \
+             active={} smallest_chunk0={two:?} cap={wave_token_cap}",
+            admission.defer,
+            admission.reason,
+            new_reqs.len(),
+            prefilling.len(),
+            active.len(),
         );
-    if varlen_eligible && !varlen_pays {
+    }
+    if !admission.defer && admission.reason == "no two chunk-0s fit one wave" {
+        // The round-13 long shape, verbatim: `4593` pre-splits to `4576 + 17`
+        // and `2 x 4576 = 9152 > 8192`. Campaign logs grep this exact string.
         tracing::info!(
             "Varlen prefill: deferral SKIPPED for {} co-admitted request(s) — no two chunk-0s \
              fit one wave (cap {wave_token_cap}); running inline chunk-0 per request",
             new_reqs.len(),
         );
     }
-    let want_varlen_defer = varlen_pays;
+    let want_varlen_defer = admission.defer;
     // Always-mixed chunk-0 fuse: when decodes are active and ATLAS_HOLO_ALWAYS_MIXED
     // is on, DEFER a new request's chunk-0 (admit it to `prefilling` with
     // chunk_offset=0, skip the inline blocking prefill) so it runs this SAME tick

--- a/crates/spark-server/src/scheduler/phase_start_prefills.rs
+++ b/crates/spark-server/src/scheduler/phase_start_prefills.rs
@@ -10,6 +10,37 @@ use super::*;
 use crate::api::InferenceRequest;
 use crate::grammar::GrammarEngine;
 
+/// The chunk-0 lengths a VARLEN wave could pack THIS tick: the co-admitted
+/// requests plus any stream still parked at `chunk_offset == 0`.
+///
+/// Chunk-0 only. A wave's members must share `chunk_start` and `is_last`
+/// (`check_kernel_batched_eligible`), so a fresh prompt can only ever batch
+/// with another fresh prompt — counting a mid-prefill stream's 25-token tail
+/// here would claim company that the planner cannot actually seat.
+///
+/// Each length is an UPPER bound on the head the planner will see: the VARLEN
+/// tail pre-split makes the real head `prefill_tail_cut(..) <= prompt_len`.
+/// Bounding high makes `varlen_defer_pays` conservative in the safe direction
+/// — it can decline a deferral that would have marginally paid, never admit
+/// one that cannot batch at all. Both round-13 shapes are decided exactly:
+/// `2 x 1193 = 2386 <= 8192` defers, `2 x 4593 = 9186 > 8192` does not.
+fn varlen_chunk_zero_heads(
+    new_reqs: &[InferenceRequest],
+    prefilling: &[PrefillInProgress],
+    max_prefill_tokens: usize,
+) -> Vec<usize> {
+    new_reqs
+        .iter()
+        .map(|r| r.prompt_len().min(max_prefill_tokens))
+        .chain(
+            prefilling
+                .iter()
+                .filter(|p| p.chunk_offset == 0)
+                .map(|p| p.prompt_tokens.len().min(max_prefill_tokens)),
+        )
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn start_new_requests(
     model: &dyn Model,
@@ -54,11 +85,37 @@ pub(super) fn start_new_requests(
     // chunk-0 (and its `max_batch_tokens` solo budget) — deferral there
     // would only shrink its first chunk. Vision excluded per request, same
     // shared-buffer reason as codispatch; EP excluded like every batched path.
-    let want_varlen_defer = chunked
+    //
+    // AND only when the deferral can actually buy a batch. Waves run
+    // back-to-back inside one tick, so a deferred stream is not promoted
+    // until every wave of that tick has run — which collapses every TTFT
+    // onto the p99. When no two chunk-0s fit one wave that buys nothing at
+    // all: round 13's long shape pre-split 4593 to `4576 + 17`, `2 x 4576 =
+    // 9152 > 8192`, and the planner degenerated to `16 streams -> 14
+    // wave(s)` while C=16 TTFT went 7 524.7 -> 13 756.1 ms (+82.8%) and
+    // aggregate 308.86 -> 214.25 tok/s (-30.6%). `varlen_defer_pays` is the
+    // skip (#1002); the predicate lives beside the wave planner so the two
+    // cannot disagree about the budget.
+    let wave_token_cap = max_prefill_tokens.min(max_batch_tokens).max(1);
+    let varlen_on = spark_model::layers::ops::prefill_varlen_enabled();
+    let varlen_eligible = chunked
         && !model.is_ep()
         && active.is_empty()
         && (new_reqs.len() >= 2 || !prefilling.is_empty())
-        && spark_model::layers::ops::prefill_varlen_enabled();
+        && varlen_on;
+    let varlen_pays = varlen_eligible
+        && super::phase_continue_prefills::varlen_defer_pays(
+            varlen_chunk_zero_heads(&new_reqs, prefilling, max_prefill_tokens),
+            wave_token_cap,
+        );
+    if varlen_eligible && !varlen_pays {
+        tracing::info!(
+            "Varlen prefill: deferral SKIPPED for {} co-admitted request(s) — no two chunk-0s \
+             fit one wave (cap {wave_token_cap}); running inline chunk-0 per request",
+            new_reqs.len(),
+        );
+    }
+    let want_varlen_defer = varlen_pays;
     // Always-mixed chunk-0 fuse: when decodes are active and ATLAS_HOLO_ALWAYS_MIXED
     // is on, DEFER a new request's chunk-0 (admit it to `prefilling` with
     // chunk_offset=0, skip the inline blocking prefill) so it runs this SAME tick

--- a/crates/spark-server/src/scheduler/prefill_fallback_tests.rs
+++ b/crates/spark-server/src/scheduler/prefill_fallback_tests.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! A declined batched-prefill wave must not cost anyone their response.
+//!
+//! THE BUG (#927, H100 round 11 cell E). With `ATLAS_PREFILL_VARLEN=1` at
+//! C=16 the server logged
+//!
+//! ```text
+//! ERROR spark::scheduler::phase_continue_prefills::run_batched_prefill:
+//!   Batched prefill error (wave of 6 streams, 6 prefilling): prefill_inner:
+//!   batched mode requires seq_len_start > 0 (paged path); got seq_len_start=0.
+//!   Caller must fall back to per-stream for this chunk.
+//! ```
+//!
+//! and returned **sixteen HTTP 200 responses with zero tokens, no
+//! `finish_reason` and no usage frame**, on 3/3 ladder reps (`err=0` at the
+//! client). A recheck on the same process gave one clean rep and one that
+//! dropped 3 of 16 — intermittent silent truncation, the failure shape that is
+//! indistinguishable from a correct empty answer.
+//!
+//! Two independent defects produced it, and both are covered here:
+//!   1. `run_batched_prefill_step` failed every stream in the wave instead of
+//!      running the per-stream path the error message itself asked for, and
+//!   2. `promote_completed_prefills` freed a failed prefill's sequence while
+//!      DROPPING its `ResponseSink`, so the client's channel simply closed.
+//!
+//! These tests drive the real `continue_in_progress_prefills` → promote loop
+//! against a stub whose batched answer is scripted, and assert on the sinks.
+
+use super::phase_continue_prefills::continue_in_progress_prefills;
+use super::sched_ctx::SchedCtx;
+use super::test_support::{RespRx, test_prefill_ident};
+use super::test_support_prefill::{BatchedBehaviour, FIRST, PrefillStubModel};
+use super::types::{ActiveSeq, PrefillInProgress};
+use crate::scheduling_policy::FifoPolicy;
+use std::sync::atomic::Ordering;
+
+/// One prompt = one chunk = one tick of prefill work.
+const CHUNK: usize = 4;
+/// The receipt's burst width.
+const N: usize = 16;
+
+struct Harness {
+    active: Vec<ActiveSeq>,
+    prefilling: Vec<PrefillInProgress>,
+    rx: Vec<RespRx>,
+}
+
+fn harness(n: usize) -> Harness {
+    let mut prefilling = Vec::new();
+    let mut rx = Vec::new();
+    for id in 1..=n as u64 {
+        let (p, r) = test_prefill_ident(id, CHUNK);
+        prefilling.push(p);
+        rx.push(r);
+    }
+    Harness {
+        active: Vec::new(),
+        prefilling,
+        rx,
+    }
+}
+
+/// Run one scheduler tick. `active` starts empty, so the batched-prefill-only
+/// branch (`can_batch_prefill_only`) is the one under test.
+fn tick(model: &PrefillStubModel, h: &mut Harness) {
+    let policy = FifoPolicy;
+    let sched = SchedCtx::for_test();
+    continue_in_progress_prefills(
+        model,
+        &policy,
+        &mut h.active,
+        &mut h.prefilling,
+        CHUNK, // max_prefill_tokens
+        CHUNK, // max_batch_tokens
+        false, // always_mixed
+        0,     // prefill_stream
+        0,     // prefill_event
+        false, // use_mtp
+        false, // use_self_speculative
+        false, // use_ngram_speculative
+        None,
+        None,
+        None,
+        None,
+        None,
+        false, // adaptive_sampling
+        &sched,
+    );
+}
+
+#[test]
+fn a_declined_wave_is_re_run_per_stream_and_every_request_completes() {
+    let model = PrefillStubModel::with_batched(BatchedBehaviour::Decline);
+    let mut h = harness(N);
+
+    tick(&model, &mut h);
+
+    assert_eq!(
+        model.batched_calls.load(Ordering::Relaxed),
+        1,
+        "the wave must be attempted batched exactly once",
+    );
+    assert_eq!(
+        model.single_calls.load(Ordering::Relaxed),
+        N,
+        "a decline must re-run EVERY member of the wave on the single-stream \
+         path — this is the count that was 0 when the bug shipped",
+    );
+    assert!(
+        h.prefilling.is_empty(),
+        "every stream finished its only chunk",
+    );
+    assert_eq!(
+        h.active.len(),
+        N,
+        "all {N} requests must promote into decode; the receipt's failure was \
+         {N} requests promoted into nothing",
+    );
+    for a in &h.active {
+        assert_eq!(
+            a.last_token, FIRST,
+            "each promoted request has its first token"
+        );
+    }
+    // Nothing was completed, so nothing has answered its sink yet — the
+    // requests are alive, which is the point.
+    for r in &mut h.rx {
+        assert!(
+            matches!(
+                r.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            ),
+            "a promoted request's sink must still be open",
+        );
+    }
+}
+
+#[test]
+fn a_hard_batched_failure_still_answers_every_request() {
+    // An ADMITTED batch that fails mid-forward owns KV state, so re-running it
+    // per-stream would double-allocate. The requests must still be told.
+    let model = PrefillStubModel::with_batched(BatchedBehaviour::HardError);
+    let mut h = harness(N);
+
+    tick(&model, &mut h);
+
+    assert_eq!(
+        model.single_calls.load(Ordering::Relaxed),
+        0,
+        "a hard failure must NOT be retried per-stream",
+    );
+    assert!(h.prefilling.is_empty(), "the failed streams are retired");
+    assert!(h.active.is_empty(), "none of them promote");
+    for (i, r) in h.rx.iter_mut().enumerate() {
+        match r.try_recv() {
+            Ok(Err(_)) => {}
+            Ok(Ok(_)) => panic!("request {i} reported success after a failed prefill"),
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => panic!(
+                "request {i}'s sink was DROPPED — that is the silent HTTP-200 \
+                 with no body and no finish_reason (#927 cell E)",
+            ),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                panic!("request {i} was never answered")
+            }
+        }
+    }
+}
+
+#[test]
+fn the_control_the_batched_path_completes_everyone_when_it_works() {
+    // Discriminator: the two tests above must fail for the reason they name,
+    // not because the harness never gets off the ground.
+    let model = PrefillStubModel::with_batched(BatchedBehaviour::PerStream);
+    let mut h = harness(N);
+
+    tick(&model, &mut h);
+
+    assert_eq!(model.batched_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        model.single_calls.load(Ordering::Relaxed),
+        0,
+        "no fallback when the batch succeeds",
+    );
+    assert_eq!(h.active.len(), N);
+}

--- a/crates/spark-server/src/scheduler/prefill_fifo_tests.rs
+++ b/crates/spark-server/src/scheduler/prefill_fifo_tests.rs
@@ -28,169 +28,16 @@
 //! ordering assertions are on the production queue itself, not on a model
 //! of it.
 
-use anyhow::Result;
-use spark_model::traits::{Model, SequenceState};
-use spark_runtime::gpu::DevicePtr;
-
 use super::phase_continue_prefills::continue_in_progress_prefills;
 use super::phase_promote_prefills::promote_completed_prefills;
 use super::sched_ctx::SchedCtx;
 use super::test_support::{test_prefill_ident, test_seq};
+use super::test_support_prefill::{FIRST, PrefillStubModel};
 use super::types::{ActiveSeq, PrefillInProgress};
 use crate::scheduling_policy::FifoPolicy;
 
-/// The sampled first token. Not an EOS (the fixture's `eos_tokens` is
-/// empty), so promotion pushes onto `active` rather than finishing.
-const FIRST: u32 = 7;
-
 /// One prompt = one chunk = one tick of prefill work.
 const CHUNK: usize = 4;
-
-/// Minimal `Model`: every prefill chunk succeeds and the greedy sampler
-/// (temperature 0.0, no suppressed ids) answers from `argmax_on_device`.
-/// Everything else is unreachable on the single-stream prefill path.
-#[derive(Default)]
-struct PrefillStubModel;
-
-impl Model for PrefillStubModel {
-    fn prefill_chunk(
-        &self,
-        tokens: &[u32],
-        seq: &mut SequenceState,
-        chunk_start: usize,
-        chunk_len: usize,
-        _is_last: bool,
-        _stream: u64,
-    ) -> Result<DevicePtr> {
-        // Mirror the real contract: the chunk's tokens land in the sequence.
-        seq.tokens
-            .extend_from_slice(&tokens[chunk_start..chunk_start + chunk_len]);
-        seq.seq_len = seq.tokens.len();
-        Ok(DevicePtr::NULL)
-    }
-    fn argmax_on_device(&self, _logits_ptr: DevicePtr, _stream: u64) -> Result<u32> {
-        Ok(FIRST)
-    }
-    fn vocab_size(&self) -> usize {
-        32
-    }
-    fn free_sequence(&self, _seq: &mut SequenceState) -> Result<()> {
-        Ok(())
-    }
-    fn cache_sequence(&self, _seq: &SequenceState) {}
-    fn detach_slot_for_reuse(&self, _seq: &mut SequenceState) {}
-    fn has_proposer(&self) -> bool {
-        false
-    }
-    fn has_self_speculative(&self) -> bool {
-        false
-    }
-    fn logits_buffer_ptr(&self) -> DevicePtr {
-        DevicePtr::NULL
-    }
-    fn hidden_after_norm(&self) -> DevicePtr {
-        DevicePtr::NULL
-    }
-    fn bind_gpu_to_thread(&self) -> Result<()> {
-        Ok(())
-    }
-    fn alloc_sequence(&self) -> Result<SequenceState> {
-        Ok(SequenceState::host_only(0))
-    }
-    fn copy_logits_to_host(&self, _l: DevicePtr, _dst: &mut [u8]) -> Result<()> {
-        unreachable!("greedy fast path never reads logits back")
-    }
-    fn prefill(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
-        unreachable!("chunked prefill only")
-    }
-    fn decode(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
-        unreachable!("decode is driven by mod.rs, not by this harness")
-    }
-    fn decode_batch(
-        &self,
-        _t: &[u32],
-        _s: &mut [&mut SequenceState],
-        _st: u64,
-    ) -> Result<DevicePtr> {
-        unreachable!("decode is driven by mod.rs, not by this harness")
-    }
-    fn decode_draft(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
-        unreachable!("no speculation in this harness")
-    }
-    fn decode_verify(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<Vec<u32>> {
-        unreachable!("no speculation in this harness")
-    }
-    fn decode_verify_graphed(
-        &self,
-        _t: &[u32; 2],
-        _s: &mut SequenceState,
-        _st: u64,
-    ) -> Result<[u32; 2]> {
-        unreachable!("no speculation in this harness")
-    }
-    fn decode_verify_graphed_k3(
-        &self,
-        _t: &[u32; 3],
-        _s: &mut SequenceState,
-        _st: u64,
-    ) -> Result<[u32; 3]> {
-        unreachable!("no speculation in this harness")
-    }
-    fn decode_verify_graphed_k4(
-        &self,
-        _t: &[u32; 4],
-        _s: &mut SequenceState,
-        _st: u64,
-    ) -> Result<[u32; 4]> {
-        unreachable!("no speculation in this harness")
-    }
-    fn argmax_batch(&self, _l: DevicePtr, _n: usize, _st: u64) -> Result<Vec<u32>> {
-        unreachable!("batched decode is not driven here")
-    }
-    fn checkpoint_ssm_states(&self, _s: &mut SequenceState) -> Result<()> {
-        unreachable!("no speculation in this harness")
-    }
-    fn rollback_ssm_states(&self, _s: &mut SequenceState, _n: usize) -> Result<()> {
-        unreachable!("no speculation in this harness")
-    }
-    fn compact_sequence(&self, _s: &mut SequenceState, _new_slot: usize) -> Result<()> {
-        unreachable!("no compaction in this harness")
-    }
-    fn save_hidden_for_mtp(&self, _token_idx: usize, _st: u64) -> Result<()> {
-        unreachable!("no speculation in this harness")
-    }
-    fn run_mtp_propose(
-        &self,
-        _t: u32,
-        _p: usize,
-        _s: &mut SequenceState,
-        _st: u64,
-    ) -> Result<Option<u32>> {
-        unreachable!("no speculation in this harness")
-    }
-    fn run_mtp_propose_multi(
-        &self,
-        _t: u32,
-        _p: usize,
-        _n: usize,
-        _s: &mut SequenceState,
-        _st: u64,
-        _mask: Option<&[i32]>,
-    ) -> Result<Vec<u32>> {
-        unreachable!("no speculation in this harness")
-    }
-    fn trim_proposer_state(&self, _s: &mut SequenceState, _n: usize, _st: u64) -> Result<()> {
-        unreachable!("no speculation in this harness")
-    }
-    fn generate_speculative(
-        &self,
-        _p: &[u32],
-        _params: &spark_runtime::sampler::SamplingParams,
-        _n: usize,
-    ) -> Result<spark_model::engine::GenerateResult> {
-        unreachable!("no speculation in this harness")
-    }
-}
 
 /// What one run of the tick loop observed.
 struct Run {
@@ -208,7 +55,7 @@ struct Run {
 /// is applied before the continue phase, the order `mod.rs` uses
 /// (`start_new_requests` then `continue_in_progress_prefills`).
 fn drive(seed_depth: usize, ticks: usize) -> Run {
-    let model = PrefillStubModel;
+    let model = PrefillStubModel::default();
     let policy = FifoPolicy;
     let sched = SchedCtx::for_test();
 
@@ -339,7 +186,7 @@ fn the_tick_loop_makes_progress_every_tick() {
 /// rest of the queue in arrival order.
 #[test]
 fn promoting_the_head_preserves_the_order_of_the_remainder() {
-    let model = PrefillStubModel;
+    let model = PrefillStubModel::default();
     let mut keep = Vec::new();
     let mut prefilling: Vec<PrefillInProgress> = (1..=4)
         .map(|id| {
@@ -378,7 +225,7 @@ fn promoting_the_head_preserves_the_order_of_the_remainder() {
 /// keeping the indices valid, not licence to reorder.
 #[test]
 fn promoting_several_at_once_preserves_the_order_of_the_remainder() {
-    let model = PrefillStubModel;
+    let model = PrefillStubModel::default();
     let mut keep = Vec::new();
     let mut prefilling: Vec<PrefillInProgress> = (1..=5)
         .map(|id| {

--- a/crates/spark-server/src/scheduler/test_support_prefill.rs
+++ b/crates/spark-server/src/scheduler/test_support_prefill.rs
@@ -20,6 +20,14 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// promotion pushes onto `active` rather than finishing.
 pub(super) const FIRST: u32 = 7;
 
+/// A NON-NULL sentinel logits pointer. It is never dereferenced — the greedy
+/// fast path (temperature 0, no suppressed ids) answers from
+/// `argmax_on_device`, which this stub scripts. It must not be `NULL` because
+/// the batched paths treat NULL-on-a-last-chunk as "the model returned no
+/// logits" and fail the stream, which is a real contract worth keeping: a stub
+/// returning NULL would make every batched test look like a dropped request.
+const LOGITS: DevicePtr = DevicePtr(0x1000);
+
 /// How the stub answers `prefill_batch_chunk` for a batch of 2+ streams.
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BatchedBehaviour {
@@ -113,7 +121,7 @@ impl Model for PrefillStubModel {
         seq.tokens
             .extend_from_slice(&tokens[chunk_start..chunk_start + chunk_len]);
         seq.seq_len = seq.tokens.len();
-        Ok(DevicePtr::NULL)
+        Ok(LOGITS)
     }
     fn argmax_on_device(&self, _logits_ptr: DevicePtr, _stream: u64) -> Result<u32> {
         Ok(FIRST)

--- a/crates/spark-server/src/scheduler/test_support_prefill.rs
+++ b/crates/spark-server/src/scheduler/test_support_prefill.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared prefill-path `Model` stub for the scheduler tests.
+//!
+//! Lifted out of `prefill_fifo_tests.rs` when a second test file needed the
+//! same ~150-line `Model` impl. Copying it would have satisfied the file-size
+//! cap and broken SSOT: two stubs drifting apart is how a harness starts
+//! testing something the engine does not do.
+//!
+//! `test_support.rs` is the home for scheduler fixtures generally; this stub
+//! lives beside it rather than inside it only because that file is already at
+//! the 500-LoC cap.
+
+use anyhow::Result;
+use spark_model::traits::{BatchedPrefillDeclined, Model, PrefillSlice, SequenceState};
+use spark_runtime::gpu::DevicePtr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// The sampled first token. Not an EOS in the fixtures that use it, so
+/// promotion pushes onto `active` rather than finishing.
+pub(super) const FIRST: u32 = 7;
+
+/// How the stub answers `prefill_batch_chunk` for a batch of 2+ streams.
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BatchedBehaviour {
+    /// Run the trait's default per-stream loop (what a model with no batched
+    /// path of its own does).
+    #[default]
+    PerStream,
+    /// Refuse with a `BatchedPrefillDeclined` — the model looked at the wave
+    /// and said no BEFORE touching a stream. The scheduler must re-run the
+    /// wave one stream at a time and complete every request.
+    Decline,
+    /// Refuse with a plain error — the batch was admitted and something failed
+    /// with state already committed. The scheduler must NOT retry, and every
+    /// affected request must still receive an error rather than a closed
+    /// channel.
+    HardError,
+}
+
+/// Minimal `Model`: every prefill chunk succeeds and the greedy sampler
+/// (temperature 0.0, no suppressed ids) answers from `argmax_on_device`.
+/// Everything else is unreachable on the prefill paths this harness drives.
+///
+/// `batched` scripts the N>=2 batched-prefill answer so the scheduler's
+/// decline/failure handling can be driven without a GPU; `single_calls`
+/// counts the N==1 dispatches, which is how a test proves the per-stream
+/// fallback actually ran rather than the wave silently succeeding.
+#[derive(Default)]
+pub(super) struct PrefillStubModel {
+    pub(super) batched: BatchedBehaviour,
+    pub(super) single_calls: AtomicUsize,
+    pub(super) batched_calls: AtomicUsize,
+}
+
+impl PrefillStubModel {
+    pub(super) fn with_batched(batched: BatchedBehaviour) -> Self {
+        Self {
+            batched,
+            ..Default::default()
+        }
+    }
+}
+
+impl Model for PrefillStubModel {
+    /// The only override this harness needs: mirror the real dispatcher's
+    /// contract that an N==1 call is the single-stream path, and script the
+    /// N>=2 answer.
+    fn prefill_batch_chunk(
+        &self,
+        streams: &mut [PrefillSlice<'_>],
+        stream: u64,
+    ) -> Result<Vec<DevicePtr>> {
+        if streams.len() <= 1 {
+            self.single_calls.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.batched_calls.fetch_add(1, Ordering::Relaxed);
+            match self.batched {
+                BatchedBehaviour::PerStream => {}
+                BatchedBehaviour::Decline => {
+                    return Err(anyhow::Error::new(BatchedPrefillDeclined::new(
+                        "scripted decline (test)",
+                    )));
+                }
+                BatchedBehaviour::HardError => {
+                    anyhow::bail!("scripted hard batched-prefill failure (test)");
+                }
+            }
+        }
+        let mut out = Vec::with_capacity(streams.len());
+        for slice in streams.iter_mut() {
+            out.push(self.prefill_chunk(
+                slice.prompt_tokens,
+                slice.seq,
+                slice.chunk_start,
+                slice.chunk_len,
+                slice.is_last_chunk,
+                stream,
+            )?);
+        }
+        Ok(out)
+    }
+    fn prefill_chunk(
+        &self,
+        tokens: &[u32],
+        seq: &mut SequenceState,
+        chunk_start: usize,
+        chunk_len: usize,
+        _is_last: bool,
+        _stream: u64,
+    ) -> Result<DevicePtr> {
+        // Mirror the real contract: the chunk's tokens land in the sequence.
+        seq.tokens
+            .extend_from_slice(&tokens[chunk_start..chunk_start + chunk_len]);
+        seq.seq_len = seq.tokens.len();
+        Ok(DevicePtr::NULL)
+    }
+    fn argmax_on_device(&self, _logits_ptr: DevicePtr, _stream: u64) -> Result<u32> {
+        Ok(FIRST)
+    }
+    fn vocab_size(&self) -> usize {
+        32
+    }
+    fn free_sequence(&self, _seq: &mut SequenceState) -> Result<()> {
+        Ok(())
+    }
+    fn cache_sequence(&self, _seq: &SequenceState) {}
+    fn detach_slot_for_reuse(&self, _seq: &mut SequenceState) {}
+    fn has_proposer(&self) -> bool {
+        false
+    }
+    fn has_self_speculative(&self) -> bool {
+        false
+    }
+    fn logits_buffer_ptr(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn hidden_after_norm(&self) -> DevicePtr {
+        DevicePtr::NULL
+    }
+    fn bind_gpu_to_thread(&self) -> Result<()> {
+        Ok(())
+    }
+    fn alloc_sequence(&self) -> Result<SequenceState> {
+        Ok(SequenceState::host_only(0))
+    }
+    fn copy_logits_to_host(&self, _l: DevicePtr, _dst: &mut [u8]) -> Result<()> {
+        unreachable!("greedy fast path never reads logits back")
+    }
+    fn prefill(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("chunked prefill only")
+    }
+    fn decode(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("decode is driven by mod.rs, not by this harness")
+    }
+    fn decode_batch(
+        &self,
+        _t: &[u32],
+        _s: &mut [&mut SequenceState],
+        _st: u64,
+    ) -> Result<DevicePtr> {
+        unreachable!("decode is driven by mod.rs, not by this harness")
+    }
+    fn decode_draft(&self, _t: u32, _s: &mut SequenceState, _st: u64) -> Result<DevicePtr> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify(&self, _t: &[u32], _s: &mut SequenceState, _st: u64) -> Result<Vec<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed(
+        &self,
+        _t: &[u32; 2],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 2]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed_k3(
+        &self,
+        _t: &[u32; 3],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 3]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn decode_verify_graphed_k4(
+        &self,
+        _t: &[u32; 4],
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<[u32; 4]> {
+        unreachable!("no speculation in this harness")
+    }
+    fn argmax_batch(&self, _l: DevicePtr, _n: usize, _st: u64) -> Result<Vec<u32>> {
+        unreachable!("batched decode is not driven here")
+    }
+    fn checkpoint_ssm_states(&self, _s: &mut SequenceState) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn rollback_ssm_states(&self, _s: &mut SequenceState, _n: usize) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn compact_sequence(&self, _s: &mut SequenceState, _new_slot: usize) -> Result<()> {
+        unreachable!("no compaction in this harness")
+    }
+    fn save_hidden_for_mtp(&self, _token_idx: usize, _st: u64) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn run_mtp_propose(
+        &self,
+        _t: u32,
+        _p: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+    ) -> Result<Option<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn run_mtp_propose_multi(
+        &self,
+        _t: u32,
+        _p: usize,
+        _n: usize,
+        _s: &mut SequenceState,
+        _st: u64,
+        _mask: Option<&[i32]>,
+    ) -> Result<Vec<u32>> {
+        unreachable!("no speculation in this harness")
+    }
+    fn trim_proposer_state(&self, _s: &mut SequenceState, _n: usize, _st: u64) -> Result<()> {
+        unreachable!("no speculation in this harness")
+    }
+    fn generate_speculative(
+        &self,
+        _p: &[u32],
+        _params: &spark_runtime::sampler::SamplingParams,
+        _n: usize,
+    ) -> Result<spark_model::engine::GenerateResult> {
+        unreachable!("no speculation in this harness")
+    }
+}


### PR DESCRIPTION
> Same-repo restack of #1002 (was `TheTom:pr/prefill-varlen-batching`). Commits unchanged. Opened on `Avarok-Cybersecurity/atlas` so Graphite/GH can stack.

## Summary

**A 16-way burst of fresh prompts was prefilled strictly one prompt at a time, and the flag that was supposed to fix it returned sixteen empty HTTP 200s instead.** Both halves are one cause: four call sites decide whether chunk-zero streams may co-admit into a batched prefill, and one of them read a different boolean than the other three.

This PR makes that predicate a single function, re-runs a wave the model declines *before touching any stream* per-stream instead of dropping it, and gives every failed prefill an error frame instead of a silently closed SSE channel. The batching lever itself stays **opt-in and default OFF** (`--prefill-varlen-batch`, legacy `ATLAS_PREFILL_VARLEN=1`) until the H100 A/B is on the table.

Fixes #1000. Refs #927.

## What was wrong

Round 11 on 1×H100, `Qwen/Qwen3.8-27B-FP8`, two back-to-back 16-way bursts of 1193-token prompts, `--max-prefill-tokens 8192` (`prefill_budget=8192, max_batch_tokens=8196`), temp 0.

**Cell A — the default path.** nsys over the window counted `rms_norm_residual` launches per forward: **64 prefill forwards for 32 requests, strictly `1168, 25, 1168, 25, …`**, every one of them a single prompt.

| forward `GrdX` | count | busy ms | ms/forward | µs/token |
|---|---|---|---|---|
| 1168 (prompt head) | 32 | 7064.4 | 220.76 | 189.0 |
| 25 (prompt tail) | 32 | 936.2 | 29.26 | **1170.2** |

A 16-row decode step on the same box costs 1234.5 µs/token — **the 25-token tail chunk is per-token indistinguishable from decode**, and it is 11.7% of prefill GPU time for 2.1% of the tokens. Window: PREFILL 8.0 s (39.8%), DECODE 10.1 s (50.2%), IDLE 2.0 s (10.0%). C=16 TTFT p50 2.28 s / p99 4.22 s. **The budget was never binding**: 2048 and 24576 both moved the aggregate ±0.4%.

The scheduler was not the serialiser. `continue_in_progress_prefills` already hands all sixteen streams to `Model::prefill_batch_chunk` in one call. `kernel_batched_eligible` then rejects any batch with `chunk_start == 0` unless `allow_chunk_zero`, and a burst of fresh prompts is all chunk 0 — so it fell through to the per-stream loop: sixteen forwards at M=1193 instead of one at M≈7000, every projection GEMM at a sixth of the arithmetic intensity available.

**Cell E — the documented fix, enabled.** `ATLAS_PREFILL_VARLEN=1` at C=16:

```
ERROR ...run_batched_prefill: Batched prefill error (wave of 6 streams, 6
prefilling): prefill_inner: batched mode requires seq_len_start > 0 (paged
path); got seq_len_start=0. Caller must fall back to per-stream for this chunk.
```

**Sixteen HTTP 200s carrying zero tokens, no `finish_reason`, no usage frame, `err=0` at the client — 3/3 reps**, plus a recheck rep that dropped 3 of 16. Silent truncation, indistinguishable from a correct empty answer.

## Root cause

**1. Four readers, one boolean, three agreements.** `check_kernel_batched_eligible` (admission), the paged-upload force in `batch_kernel.rs` and `prefill_attention_paged_attn_batched` all read `codispatch || varlen`. The fourth — `Qwen3AttentionLayer::prefill_inner` — read `codispatch` **alone**. So under `--prefill-varlen-batch` admission said yes and the attention layer said no at layer 0, with Phase A already done: KV blocks allocated, prefix reservations taken, hidden staged for every member of the wave.

**2. The fallback the error asked for did not exist.** The bail text says "Caller must fall back to per-stream for this chunk." The caller pushed `(i, None)` for every member, and `promote_completed_prefills` freed each sequence while **dropping its `ResponseSink`**. The SSE body had already been committed with a 200 when the handler subscribed, so closing the channel produced a stream ending after the role delta. A blocking request fared no better: the dropped `oneshot` surfaces as the misleading "Inference cancelled".

## What the fix does

**One predicate, `ops::prefill_batched_chunk_zero_allowed()`.** All four sites call it; nobody re-derives the disjunction. `eligible::first_chunk_batched_enabled` is deleted rather than left as a second definition.

**`BatchedPrefillDeclined`, a refusal raised before any stream was mutated.** New marker error in `spark_model::traits`, detected with `downcast_ref` through the `anyhow` chain. The distinction is load-bearing: once a batched forward has entered Phase A it owns KV blocks and prefix reservations for every member, so re-running those streams would double-allocate — the caller must fail them *with a response*. A refusal raised earlier leaves the streams exactly as the scheduler handed them over, so the caller can and must re-run the whole wave per-stream. `batch.rs`'s arena-capacity check — which runs before a single stream is touched and used to take the whole wave down for one oversized member — is now a decline.

**Per-stream fallback, `phase_continue_prefills/prefill_fallback.rs`.** A declined wave is re-run one stream at a time (at `n == 1` the model's dispatcher delegates to the same single-stream path the non-batched scheduler runs), so a member that still fails fails alone. The advance/sample bookkeeping both paths share moved into the same module.

**Every failed prefill now answers.** `phase_promote_prefills` calls `lifecycle::send_error_to_sink` on the hard-error path — the same helper `prefill_request` already uses for a failure between taking the sink and building an `ActiveSeq`. This is that same window, one phase later.

**Tail pre-split, `Model::prefill_tail_cut`.** `prefill_chunk_dispatch` splits a prompt's FINAL chunk once at `((total-1)/bs)*bs - bs` (1168 for a 1193-token prompt at `bs=16`) to land an SSM tail checkpoint a later turn's block-floored prefix match can use. It is unconditional on hybrid-SSM models with the prefix cache active and must stay so — a shape that differs cold vs warm flips a temperature-0 argmax, since BF16 accumulation is not associative. The batched path does not split, so handing it a whole prompt as one `is_last` chunk would give a co-admitted stream a **different forward shape than the same prompt takes per-stream**. The model now reports where it would cut and the scheduler pre-splits there under VARLEN: geometry stays identical per sequence, and the tails **batch** — sixteen tails of one burst share `chunk_start = 1168`, so the planner puts all of them in ONE forward instead of sixteen standalone 25-token passes. The arithmetic is a single free function, `prefill_b::tail_split_cut`, called by both the splitter and the reporter.

**Admission arithmetic, for the record.** `wave_cap = min(--max-prefill-tokens, max_batch_tokens) = 8192`. Sixteen whole 1193-token prompts pack 6 per wave (6×1193 = 7158; a seventh is 8351) → **3 dispatches, not 16**. Pre-split 1168-token heads pack 7 (7×1168 = 8176). Both pinned in `prefill_waves::tests`.

**The boot route line prints the resolved decision**, not the raw argument: `prefill_chunk_zero_batch=` joins `prefill_varlen_batch=` on the `kernel flags:` line, so a log says which way the four-site predicate actually resolved.

## Tests

**`crates/spark-model/src/layers/ops/chunk_zero_ssot_tests.rs` (3)** — a source-scanning test over the tree, so a fifth reader cannot quietly re-derive the disjunction:

- `every_chunk_zero_reader_calls_the_one_predicate`
- `no_chunk_zero_reader_rederives_the_disjunction`
- `the_predicate_is_defined_once`

**`.../prefill_b/batch_kernel_chunk_zero_tests.rs` (2)** — the admission half, at the #927 shape (sibling file because `batch_kernel_tests.rs` was at the 500-LoC cap):

- `admits_the_h100_c16_chunk_zero_wave` — six fresh 1193-token prompts admitted; the six 25-token tails sharing `chunk_start == 1168` admitted as one wave; and the control, that with the predicate OFF the same wave is refused **at admission, before any stream is touched**
- `varlen_admits_ragged_chunk_zero_lengths`

**`crates/spark-server/src/scheduler/prefill_fallback_tests.rs` (3)** — end-to-end through the scheduler tick against a stub model:

- `a_declined_wave_is_re_run_per_stream_and_every_request_completes`
- `a_hard_batched_failure_still_answers_every_request` — the anti-#1000 assertion: an error frame, never a closed channel
- `the_control_the_batched_path_completes_everyone_when_it_works`

**`.../phase_continue_prefills/prefill_waves.rs` tests (+2)** — the burst geometry, pinned as numbers:

- `the_h100_c16_burst_packs_six_prompts_per_prefill_step` — 16 whole prompts → 3 waves of 6/6/4; 1168-token heads → 7 per step; sixteen 25-token tails → **one** wave
- `flag_off_still_admits_every_prompt_in_one_call` — the control, that the planner does not start splitting with the lever off

**`.../trait_impl/prefill_b.rs::tail_split_cut_tests` (4)** — `1193 @ bs=16 → 1168` (tail 25), a prompt sitting on a boundary, short prompts saturating to zero, and `bs == 0` not being a division.

**`crates/spark-server/src/scheduler/test_support_prefill.rs`** — the stub model and harness the fallback tests need, extracted out of `prefill_fifo_tests.rs` (which shrinks by 161 lines and keeps its five cases unchanged) so both suites share one stub.

**`crates/spark-model/examples/native_prefill_varlen_batch_microtest.rs`** — GPU receipt, `required-features = ["cuda", "gpu-examples"]`, exit 1 on failure. Three gated contracts on four ragged chunk-zero sequences: (1) **BITS** — the batched kernel's output equals the single-stream kernel's byte for byte (both arms run the same `prefill_paged_compute.cuh` body at BR=32 with the same operand order, so anything but `unequal = 0` is a bug; the test stays under `chunk_len = 256` so neither arm takes the BR=64 twin); (2) **KV** — the K/V pool is byte-identical before and after both arms, per-sequence digest, because the chunk-0 batched path READS the pages a fresh sequence just wrote; (3) **EXTENT** — guard bands untouched, and stream `b`'s output region written only by stream `b`, checked by perturbing one stream's Q and asserting only its rows move. It is built by this PR's gate but **has not been run on an H100**; see below.

## Test plan

All on Spark 1 (GB10), `ATLAS_SKIP_BUILD=1`, `--jobs 8`, in an isolated worktree against this branch.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p spark-model --all-targets --features cuda -- -D warnings` — **0 warnings**, `Finished \`dev\` profile [unoptimized] target(s) in 13.41s`
- [x] `cargo clippy -p spark-server --all-targets --features cuda,nccl -- -D warnings` — **0 warnings**, `Finished \`dev\` profile [unoptimized] target(s) in 25.30s`
- [x] `cargo test -p spark-model --features cuda --lib` — **897 passed, 0 failed, 11 ignored**
- [x] `cargo test -p spark-server --bins --features cuda,nccl` — **2460 passed, 0 failed, 12 ignored** (first run; the grammar cold-compile timing test did not flake)
- [x] `cargo build -p spark-model --examples --features cuda,gpu-examples` — clean, the microtest binary links
- [x] The CI file-size cap check (`.github/workflows/file-size-cap.yml`, run locally against this tree) — `✓ All .rs files in crates/ are ≤500 LoC (or in the allow-list)`. Nothing was added to the allow-list; the largest new file is the 400-LoC example.

Each of this PR's fourteen new unit tests was confirmed present in the run, by name, not just in the aggregate count.

## What this PR does NOT claim

- **No H100 A/B has been run.** The lever stays opt-in and default OFF. Everything above about throughput is *admission arithmetic* — how many prompts fit in a wave — plus the round-11 receipt for the behaviour being fixed. Nobody has measured the batched path's tok/s or TTFT against the default path on an H100 in this state.
- The measurement cells still owed, before the default can move: (a) C=16 burst, lever OFF, the round-11 cell-A control re-taken on this branch; (b) C=16 burst, lever ON — tok/s, TTFT p50/p99, and the nsys forward histogram, which should read 3 head waves + 1 tail wave rather than 64 single-prompt forwards; (c) the same pair with `ATLAS_NO_TAIL_SPLIT=1`, which is the A/B for the pre-split by itself; (d) a temperature-0 answer-equality check between lever ON and OFF, since the whole reason the tail split is pre-applied is that a differing forward shape flips an argmax; (e) the GPU microtest above, run on the H100.
- **The 25-token tails are not eliminated**, only batched. Removing the tail split entirely is `ATLAS_NO_TAIL_SPLIT=1` and costs the warm-turn checkpoint; that trade is not decided here.
- Nothing here touches the MLA path. `prefill_inner_hc` keeps its hard `seq_len_start > 0` failure, because `check_kernel_batched_eligible` rejects MLA configs wholesale via `config_is_mla` before any stream is touched — it is unreachable from the batched dispatcher, and a comment now says so rather than leaving it looking like a missed site.

`PREFILL-BATCHING-ATTRIBUTION.md` carries the full phase-1 attribution: the nsys anchors, why chunk 0 needed nothing structural, and why a tail cannot batch with another prompt's head.

## CLA

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
